### PR TITLE
feat(frontend): 초안 생성 후 진행 상태 확인을 보장

### DIFF
--- a/.agent/specs/711.md
+++ b/.agent/specs/711.md
@@ -1,0 +1,122 @@
+# Frontend E2E Spec: 초안 생성 후 파이프라인 진행 상태 확인
+
+## Goal
+
+운영자가 Domain Pack 초안 생성을 시작한 뒤 pipeline review 화면에서 현재 job의 진행 단계, 상태, 후속 행동 가능 여부를 확인할 수 있음을 Critical E2E로 보장한다.
+
+## Issue Summary
+
+GitHub Issue #711은 상담 로그 업로드 후 Domain Pack 초안 생성이 접수된 상태에서 운영자가 검토 또는 pipeline job 화면에 진입했을 때, 현재 pipeline job이 어느 단계까지 진행됐는지 화면 기준으로 판단할 수 있어야 한다는 요구사항이다. 진행 중, 완료, 실패 상태는 서로 구분되어야 하며, 현재 workspace에 연결된 pipeline job만 조회되어야 하고, 완료 전에는 승인/적용 같은 후속 행동이 잘못 활성화되지 않아야 한다.
+
+현재 코드 기준 `frontend/e2e/upload-domain-pack-generation.spec.ts`는 업로드 완료 후 명시적 초안 생성 요청과 review 화면 진입을 검증한다. `frontend/e2e/workspace-core.spec.ts`는 review 화면에서 RUNNING 상태가 완료/실패로 전이될 때의 상태 새로고침을 검증한다. 이번 작업은 업로드에서 시작된 신규 pipeline job이 아직 활성 review checkpoint에 도달하지 않은 진행 중 상태일 때도 review 화면의 진행 단계와 후속 행동 guard가 명확하게 보이는지를 Critical E2E로 고정한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["운영자가 상담 로그 ZIP 업로드"] --> B["업로드 완료 및 dataset id 확인"]
+    B --> C["Domain Pack 초안 생성 시작"]
+    C --> D["생성 요청이 pipeline job으로 접수됨"]
+    D --> E["검토 화면으로 이동"]
+    E --> F["현재 workspace/job review checkpoint 조회"]
+    F --> G{"활성 review checkpoint 존재?"}
+    G -->|"No, 진행 중"| H["RUNNING 단계와 새로고침 action 표시"]
+    H --> I["승인/적용 후속 action 미노출"]
+    G -->|"Yes"| J["도메인 확정 또는 사람 피드백 task 표시"]
+```
+
+## Design Diff
+
+| 영역 | As-is | To-be | 변경 내용 |
+| ---- | ----- | ----- | -------- |
+| Upload-to-review E2E | 초안 생성 요청 후 바로 도메인 확정 checkpoint가 있는 job 진입을 검증 | 초안 생성 요청 후 아직 checkpoint가 없는 RUNNING job에서도 review 화면의 진행 상태와 action guard를 검증 | Issue #711 진행 중 상태를 사용자 흐름 기준으로 추가 고정 |
+| Pipeline review 진행 중 상태 | 활성 checkpoint가 없으면 상태 새로고침과 도메인팩 관리 이동을 함께 제공 | 완료 전에는 도메인팩 관리 이동 대신 상태 새로고침만 제공하고 승인/적용은 완료 후 진행됨을 표시 | 완료 전 후속 행동 오인을 줄임 |
+| API mock | 생성 trigger가 고정된 `WAITING_DOMAIN_CONFIRMATION` job을 반환 | 테스트 옵션으로 생성 직후 `RUNNING` job fixture를 반환할 수 있음 | 실제 polling 전 단계의 진행 상태를 안정적으로 재현 |
+| Critical grouping | 관련 E2E가 일반 mocked E2E에 포함됨 | 신규 진행 상태 시나리오를 `@critical`로 식별 | 핵심 운영 회귀를 좁게 실행 가능 |
+
+## Component Tree
+
+```text
+frontend/e2e/upload-domain-pack-generation.spec.ts
+└─ Upload completed Domain Pack draft generation
+   └─ Running generation progress Critical scenario
+
+frontend/e2e/support/app-mocks.ts
+└─ installAppApiMocks
+   └─ upload/review fixtures
+
+frontend/src/pages/pipeline-review/ui/PipelineReviewPage.tsx
+└─ PipelineReviewPage
+   ├─ status context panel
+   └─ PipelineReviewCheckpointCard
+
+frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.tsx
+└─ StateActionCard
+   ├─ progress copy
+   └─ refresh action
+```
+
+## API Integration
+
+테스트는 기존 Playwright route mock과 `seen` API 호출 추적 배열을 사용한다. 새 backend endpoint, OpenAPI generated file, DTO 변경은 없다.
+
+| Method | Path | 목적 |
+| ------ | ---- | ---- |
+| `POST` | `/api/v1/workspaces/1/datasets/uploads:init` | ZIP 업로드 준비 |
+| `PUT` | `/e2e-upload/raw-log.zip` | presigned upload 대상 mock |
+| `POST` | `/api/v1/workspaces/1/datasets/uploads/77:complete` | 업로드 완료 및 `datasetId` 확보 |
+| `GET` | `/api/v1/workspaces/1/datasets/77/pipeline-jobs/latest?jobType=INGESTION` | 자동 ingestion job 없음 상태 구성 |
+| `POST` | `/api/v1/workspaces/1/datasets/77/pipeline-jobs/domain-pack-generation` | Domain Pack 초안 생성 요청 접수 |
+| `GET` | `/api/v1/workspaces/1/pipeline-jobs/905/review-checkpoint` | 생성 직후 RUNNING 상태인 pipeline job 조회 |
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+| ---- | --------- | ---- |
+| `.agent/specs/711.md` | new | Issue #711 요구사항과 검증 기준 기록 |
+| `frontend/e2e/support/app-mocks.ts` | modify | 초안 생성 trigger가 RUNNING job을 반환하는 fixture 옵션 추가 |
+| `frontend/e2e/upload-domain-pack-generation.spec.ts` | modify | 업로드 후 초안 생성 진행 상태와 후속 action guard Critical E2E 추가 |
+| `frontend/src/pages/pipeline-review/ui/PipelineReviewPage.tsx` | modify | 진행/완료/실패/review checkpoint별 초안 승인 가능 여부 문구 분리 |
+| `frontend/src/pages/pipeline-review/ui/PipelineReviewPage.test.tsx` | modify | pipeline status별 context panel 문구 검증 보강 |
+| `frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.tsx` | modify | 완료 전 no-checkpoint 상태에서 도메인팩 관리 CTA 미노출 |
+| `frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.test.tsx` | modify | RUNNING 상태의 action guard 검증 업데이트 |
+
+## State Management
+
+- Server state는 기존 TanStack Query `["pipeline-review-checkpoint", workspaceId, pipelineJobId]` 흐름을 유지한다.
+- `PipelineReviewPage`와 `PipelineReviewCheckpointCard`는 현재 route의 `workspaceId`와 `pipelineJobId`만 사용한다.
+- 진행 중이면서 활성 review checkpoint가 없는 상태에서는 `상태 새로고침`으로 같은 workspace/job을 재조회할 수 있어야 한다.
+- `SUCCEEDED` 상태에서만 도메인팩 관리 화면으로 이어지는 후속 CTA를 제공한다.
+- `FAILED` 상태는 업로드 재시도와 현재 job 새로고침을 제공하고 성공 CTA를 표시하지 않는다.
+- `DOMAIN_CONFIRMATION` 또는 `HUMAN_FEEDBACK` 상태는 해당 checkpoint task action만 제공하고 최종 승인/적용은 완료 후 Domain Pack 화면에서 진행됨을 안내한다.
+
+## Acceptance Criteria
+
+- 유효한 ZIP 업로드 완료 후 운영자가 `도메인팩 초안 생성 시작`을 누르면 생성 요청 접수와 `job 905 · RUNNING` 상태가 보인다.
+- `검토 화면으로 이동` CTA는 `/workspaces/1/pipeline-jobs/905/review`로 이동한다.
+- review 화면의 맥락 영역은 현재 단계가 `RUNNING`이고 반영 방식이 `활성 체크포인트 없음`임을 표시한다.
+- review 화면은 활성 checkpoint가 없을 때 `활성 리뷰 체크포인트가 없습니다.`와 `상태 새로고침` action을 표시한다.
+- 완료 전 RUNNING 상태에서는 `도메인팩 관리로 이동`, 승인, 적용, 배포 같은 후속 행동이 표시되지 않는다.
+- E2E mock은 `GET /workspaces/1/pipeline-jobs/905/review-checkpoint`처럼 현재 workspace와 pipeline job route에 맞는 endpoint만 검증한다.
+- 신규 시나리오는 Playwright `@critical` grep으로 식별 가능하다.
+
+## Non-goals
+
+- backend API contract, OpenAPI generated file, database schema는 변경하지 않는다.
+- 실제 Airflow 실행, ML artifact 생성, review task 생성 로직은 이 E2E에서 검증하지 않는다.
+- 완료/실패 전이 검증은 기존 `frontend/e2e/workspace-core.spec.ts` 시나리오를 유지하며 중복 확장하지 않는다.
+- Domain Pack 승인 화면의 적용/배포 workflow 자체를 변경하지 않는다.
+- live E2E나 운영 backend 데이터 의존 테스트를 추가하지 않는다.
+
+## Validation
+
+| 검증 | 목적 |
+| ---- | ---- |
+| `pnpm --dir frontend exec playwright test e2e/upload-domain-pack-generation.spec.ts --grep @critical` | Issue #711 Critical E2E만 좁게 검증 |
+| `pnpm --dir frontend e2e -- upload-domain-pack-generation.spec.ts` | upload-to-review mocked E2E 전체 회귀 검증 |
+| `pnpm --dir frontend test -- PipelineReviewPage PipelineReviewCheckpointCard --run` | pipeline review context/action guard 단위 검증 |
+| `pnpm --dir frontend exec eslint e2e/upload-domain-pack-generation.spec.ts e2e/support/app-mocks.ts src/pages/pipeline-review/ui/PipelineReviewPage.tsx src/features/pipeline-review/ui/PipelineReviewCheckpointCard.tsx` | 변경된 frontend 파일 lint 확인 |
+
+## Open Questions
+
+- 없음.

--- a/frontend/e2e/support/app-mocks.ts
+++ b/frontend/e2e/support/app-mocks.ts
@@ -9,6 +9,7 @@ const WORKFLOW_ID = 401;
 const INTENT_ID = 501;
 const DATASET_ID = 77;
 const PIPELINE_JOB_ID = 900;
+const RUNNING_GENERATION_PIPELINE_JOB_ID = 905;
 const SIMULATION_SESSION_ID = 8801;
 const SIMULATION_GOLDEN_CASE_ID = 9951;
 const SIMULATION_REPLAY_SESSION_ID = 9952;
@@ -39,6 +40,7 @@ export interface AppApiMockOptions {
   readonly uploadLatestPipelineJob?: "default" | "none";
   readonly domainPackGenerationFailureAttempts?: number;
   readonly dashboardKnowledgePackHealth?: "default" | "error";
+  readonly generatedPipelineJob?: "domain-confirmation" | "running";
 }
 
 interface PipelineReviewMockState {
@@ -1475,11 +1477,12 @@ async function fulfillUploadAndReview(
       return true;
     }
 
+    const generatedJob =
+      options.generatedPipelineJob === "running"
+        ? { pipelineJobId: RUNNING_GENERATION_PIPELINE_JOB_ID, status: "RUNNING" }
+        : { pipelineJobId: PIPELINE_JOB_ID, status: "WAITING_DOMAIN_CONFIRMATION" };
     await fulfillJson(route, {
-      data: {
-        pipelineJobId: PIPELINE_JOB_ID,
-        status: "WAITING_DOMAIN_CONFIRMATION",
-      },
+      data: generatedJob,
       status: 200,
     });
     return true;
@@ -1543,6 +1546,16 @@ async function fulfillUploadAndReview(
           },
         },
       ],
+    });
+    return true;
+  }
+
+  if (method === "GET" && path === "/workspaces/1/pipeline-jobs/905/review-checkpoint") {
+    await fulfillJson(route, {
+      pipelineJobId: RUNNING_GENERATION_PIPELINE_JOB_ID,
+      pipelineStatus: "RUNNING",
+      reviewKind: null,
+      tasks: [],
     });
     return true;
   }

--- a/frontend/e2e/upload-domain-pack-generation.spec.ts
+++ b/frontend/e2e/upload-domain-pack-generation.spec.ts
@@ -146,5 +146,68 @@ test.describe("Upload completed Domain Pack draft generation", () => {
         ),
       ).toHaveLength(1);
     });
+
+    test.describe(
+      "When the requested generation job is still running",
+      { tag: "@critical" },
+      () => {
+        test("Then the review screen shows progress and keeps approval actions unavailable", async ({
+          page,
+        }) => {
+          await installUploadGenerationMocks(page, {
+            generatedPipelineJob: "running",
+          });
+          const generationButton = await completeUpload(page);
+
+          await generationButton.click();
+
+          await expect(
+            page.getByText("생성 요청 완료", { exact: true }),
+          ).toBeVisible();
+          await expect(page.getByText(/job 905 · RUNNING/)).toBeVisible();
+
+          await page
+            .getByRole("button", { name: "검토 화면으로 이동" })
+            .click();
+
+          await expect(page).toHaveURL(
+            /\/workspaces\/1\/pipeline-jobs\/905\/review/,
+          );
+          const context = page.getByLabel("파이프라인 리뷰 맥락");
+          await expect(context).toContainText("RUNNING");
+          await expect(context).toContainText("활성 체크포인트 없음");
+          await expect(context).toContainText(
+            "완료 후 Domain Pack 화면에서 진행",
+          );
+          await expect(
+            page.getByText("활성 리뷰 체크포인트가 없습니다."),
+          ).toBeVisible();
+          await expect(
+            page.getByRole("button", { name: "상태 새로고침" }),
+          ).toBeVisible();
+          await expect(
+            page.getByRole("link", { name: "도메인팩 관리로 이동" }),
+          ).toHaveCount(0);
+          await expect(
+            page.getByRole("button", { name: /승인|적용|배포/ }),
+          ).toHaveCount(0);
+          expect(seen).toContain("POST /workspaces/1/datasets/uploads:init");
+          expect(seen).toContain(
+            "POST /workspaces/1/datasets/77/pipeline-jobs/domain-pack-generation",
+          );
+          expect(seen).toContain(
+            "GET /workspaces/1/pipeline-jobs/905/review-checkpoint",
+          );
+          expect(seen).not.toContain(
+            "GET /workspaces/1/pipeline-jobs/900/review-checkpoint",
+          );
+          expect(
+            seen.some((entry) =>
+              entry.startsWith("GET /workspaces/2/pipeline-jobs/905"),
+            ),
+          ).toBe(false);
+        });
+      },
+    );
   });
 });

--- a/frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.test.tsx
+++ b/frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.test.tsx
@@ -387,7 +387,32 @@ describe("PipelineReviewCheckpointCard", () => {
     expect(refetch).toHaveBeenCalledTimes(1);
   });
 
-  it("shows refresh and list navigation for no active checkpoint waiting states", () => {
+  it("shows cancelled state with upload retry and job refresh actions", () => {
+    const refetch = vi.fn();
+    mockedUseCheckpoint.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      isFetching: false,
+      refetch,
+      data: { pipelineJobId: 7, pipelineStatus: "CANCELLED", reviewKind: null, tasks: [] },
+    } as never);
+
+    renderCard();
+
+    expect(screen.getByText("파이프라인이 취소되었습니다.")).toBeInTheDocument();
+    expect(
+      screen.getByText("업로드를 다시 시작하거나 취소된 job 상태를 다시 조회할 수 있습니다."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "업로드 다시 시작" })).toHaveAttribute(
+      "href",
+      "/workspaces/1/upload",
+    );
+    expect(screen.queryByRole("link", { name: "도메인팩 관리로 이동" })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "현재 job 새로고침" }));
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows only refresh for no active checkpoint waiting states", () => {
     const refetch = vi.fn();
     mockedUseCheckpoint.mockReturnValue({
       isLoading: false,
@@ -400,13 +425,32 @@ describe("PipelineReviewCheckpointCard", () => {
     renderCard();
 
     expect(screen.getByText("활성 리뷰 체크포인트가 없습니다.")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "도메인팩 관리로 이동" })).toHaveAttribute(
-      "href",
-      "/workspaces/1/domain-packs",
-    );
+    expect(
+      screen.getByText(
+        "파이프라인이 검토 입력을 기다리는 상태가 되면 이 화면에 작업이 표시됩니다. 완료 전 승인/적용은 시작하지 않습니다.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "도메인팩 관리로 이동" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /승인|적용|배포/ })).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "상태 새로고침" }));
     expect(refetch).toHaveBeenCalledTimes(1);
   });
+
+  it("disables refresh while no active checkpoint state is fetching", () => {
+    mockedUseCheckpoint.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      isFetching: true,
+      refetch: vi.fn(),
+      data: { pipelineJobId: 7, pipelineStatus: "RUNNING", reviewKind: null, tasks: [] },
+    } as never);
+
+    renderCard();
+
+    expect(screen.getByRole("button", { name: "상태 새로고침" })).toBeDisabled();
+    expect(screen.queryByRole("link", { name: "도메인팩 관리로 이동" })).not.toBeInTheDocument();
+  });
+
 });
 
 function createHumanFeedbackCheckpoint(taskIds: number[]) {

--- a/frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.tsx
+++ b/frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState, type ReactNode } from "react";
-import { ArrowRightIcon, ListChecksIcon, RefreshCwIcon, UploadIcon } from "lucide-react";
+import { ListChecksIcon, RefreshCwIcon, UploadIcon } from "lucide-react";
 import { Link } from "react-router-dom";
 import {
   type ReviewCaseContext,
@@ -159,7 +159,7 @@ export function PipelineReviewCheckpointCard({ workspaceId, pipelineJobId }: Pro
               상태 새로고침
             </button>
           </>
-        ) : query.data?.pipelineStatus === "FAILED" ? (
+        ) : query.data?.pipelineStatus === "FAILED" || query.data?.pipelineStatus === "CANCELLED" ? (
           <>
             <Link to={`/workspaces/${workspaceId}/upload`} className={styles.stateActionPrimary}>
               <UploadIcon aria-hidden="true" />
@@ -176,21 +176,15 @@ export function PipelineReviewCheckpointCard({ workspaceId, pipelineJobId }: Pro
             </button>
           </>
         ) : (
-          <>
-            <button
-              type="button"
-              className={styles.stateActionPrimary}
-              disabled={query.isFetching}
-              onClick={() => void query.refetch()}
-            >
-              <RefreshCwIcon aria-hidden="true" />
-              상태 새로고침
-            </button>
-            <Link to={domainPackListPath(workspaceId)} className={styles.stateActionSecondary}>
-              <ArrowRightIcon aria-hidden="true" />
-              {CTA_GO_DOMAIN_PACK}
-            </Link>
-          </>
+          <button
+            type="button"
+            className={styles.stateActionPrimary}
+            disabled={query.isFetching}
+            onClick={() => void query.refetch()}
+          >
+            <RefreshCwIcon aria-hidden="true" />
+            상태 새로고침
+          </button>
         )}
       </StateActionCard>
     );
@@ -535,6 +529,9 @@ function checkpointStateTitle(pipelineStatus?: string): string {
   if (pipelineStatus === "FAILED") {
     return "파이프라인이 실패했습니다.";
   }
+  if (pipelineStatus === "CANCELLED") {
+    return "파이프라인이 취소되었습니다.";
+  }
   return "활성 리뷰 체크포인트가 없습니다.";
 }
 
@@ -545,5 +542,8 @@ function checkpointStateDescription(pipelineStatus?: string): string {
   if (pipelineStatus === "FAILED") {
     return "업로드를 다시 시작하거나 현재 job 상태를 다시 조회할 수 있습니다.";
   }
-  return "파이프라인이 검토 입력을 기다리는 상태가 되면 이 화면에 작업이 표시됩니다.";
+  if (pipelineStatus === "CANCELLED") {
+    return "업로드를 다시 시작하거나 취소된 job 상태를 다시 조회할 수 있습니다.";
+  }
+  return "파이프라인이 검토 입력을 기다리는 상태가 되면 이 화면에 작업이 표시됩니다. 완료 전 승인/적용은 시작하지 않습니다.";
 }

--- a/frontend/src/pages/pipeline-review/ui/PipelineReviewPage.test.tsx
+++ b/frontend/src/pages/pipeline-review/ui/PipelineReviewPage.test.tsx
@@ -60,20 +60,46 @@ describe("PipelineReviewPage", () => {
 
     expect(screen.getByText("초안 생성 전에 파이프라인 입력을 확정합니다.")).toBeInTheDocument();
     expect(screen.getByText("사람 피드백 대기")).toBeInTheDocument();
+    expect(screen.getByText("체크포인트 완료 후 진행")).toBeInTheDocument();
     expect(screen.getByTestId("checkpoint-card")).toHaveTextContent("1:7");
     expect(mockedUseCheckpoint).toHaveBeenCalledWith(1, 7, { autoRefresh: true });
     await waitFor(() => expect(screen.getByTestId("crumbs")).toHaveTextContent("Pipeline review"));
   });
 
   it.each([
-    ["WAITING_DOMAIN_CONFIRMATION", "DOMAIN_CONFIRMATION", "도메인 확정 대기", "결정 후 replay"],
-    ["SUCCEEDED", null, "파이프라인 완료", "활성 체크포인트 없음"],
-    ["FAILED", null, "파이프라인 실패", "활성 체크포인트 없음"],
-    ["RUNNING", null, "RUNNING", "활성 체크포인트 없음"],
-    [undefined, null, "확인 중", "활성 체크포인트 없음"],
+    [
+      "WAITING_DOMAIN_CONFIRMATION",
+      "DOMAIN_CONFIRMATION",
+      "도메인 확정 대기",
+      "결정 후 replay",
+      "체크포인트 완료 후 진행",
+    ],
+    [
+      "SUCCEEDED",
+      null,
+      "파이프라인 완료",
+      "활성 체크포인트 없음",
+      "Domain Pack 승인 화면에서 진행",
+    ],
+    ["FAILED", null, "파이프라인 실패", "활성 체크포인트 없음", "실패 상태에서는 승인 불가"],
+    ["CANCELLED", null, "파이프라인 취소", "활성 체크포인트 없음", "취소 상태에서는 승인 불가"],
+    [
+      "RUNNING",
+      null,
+      "RUNNING",
+      "활성 체크포인트 없음",
+      "완료 후 Domain Pack 화면에서 진행",
+    ],
+    [
+      undefined,
+      null,
+      "확인 중",
+      "활성 체크포인트 없음",
+      "완료 후 Domain Pack 화면에서 진행",
+    ],
   ])(
     "maps checkpoint status %s and review kind %s",
-    (pipelineStatus, reviewKind, expectedStatus, expectedMode) => {
+    (pipelineStatus, reviewKind, expectedStatus, expectedMode, expectedApproval) => {
       mockedUseCheckpoint.mockReturnValue({
         data: {
           pipelineJobId: 7,
@@ -87,6 +113,7 @@ describe("PipelineReviewPage", () => {
 
       expect(screen.getByText(expectedStatus)).toBeInTheDocument();
       expect(screen.getByText(expectedMode)).toBeInTheDocument();
+      expect(screen.getByText(expectedApproval)).toBeInTheDocument();
     },
   );
 

--- a/frontend/src/pages/pipeline-review/ui/PipelineReviewPage.tsx
+++ b/frontend/src/pages/pipeline-review/ui/PipelineReviewPage.tsx
@@ -53,7 +53,12 @@ export function PipelineReviewPage() {
         </div>
         <div className={styles.contextItem}>
           <span className={styles.contextLabel}>초안 승인</span>
-          <strong>Domain Pack 승인 화면에서 진행</strong>
+          <strong>
+            {approvalAvailabilityLabel(
+              checkpointQuery.data?.pipelineStatus,
+              checkpointQuery.data?.reviewKind,
+            )}
+          </strong>
         </div>
       </section>
 
@@ -82,6 +87,9 @@ function statusLabel(
   if (pipelineStatus === "FAILED") {
     return "파이프라인 실패";
   }
+  if (pipelineStatus === "CANCELLED") {
+    return "파이프라인 취소";
+  }
   if (pipelineStatus) {
     return pipelineStatus;
   }
@@ -93,4 +101,23 @@ function modeLabel(reviewKind?: string | null, isError = false): string {
     return "현재 job 상태 확인 불가";
   }
   return reviewKind ? "결정 후 replay" : "활성 체크포인트 없음";
+}
+
+function approvalAvailabilityLabel(
+  pipelineStatus?: string,
+  reviewKind?: string | null,
+): string {
+  if (reviewKind) {
+    return "체크포인트 완료 후 진행";
+  }
+  if (pipelineStatus === "SUCCEEDED") {
+    return "Domain Pack 승인 화면에서 진행";
+  }
+  if (pipelineStatus === "FAILED") {
+    return "실패 상태에서는 승인 불가";
+  }
+  if (pipelineStatus === "CANCELLED") {
+    return "취소 상태에서는 승인 불가";
+  }
+  return "완료 후 Domain Pack 화면에서 진행";
 }


### PR DESCRIPTION
Closes #711

## 변경 사항

- 이슈 711 요구사항과 acceptance criteria를 `.agent/specs/711.md`에 정리했습니다.
- 초안 생성 후 pipeline review 화면의 맥락 영역에서 진행 단계, 반영 방식, 초안 승인 가능 여부를 상태별로 구분해 표시합니다.
- 활성 checkpoint가 없는 RUNNING 상태에서는 `상태 새로고침`만 제공하고, 완료 전 `도메인팩 관리로 이동`/승인/적용/배포 후속 행동이 노출되지 않도록 했습니다.
- FAILED와 CANCELLED terminal 상태는 성공 CTA 없이 업로드 재시도와 현재 job 새로고침으로 분리했습니다.
- upload E2E mock에 생성 직후 RUNNING job fixture를 추가하고, 업로드→초안 생성→review 화면 진입 경로에서 현재 workspace/job `905`만 조회되는지 `@critical` E2E로 검증합니다.

## 검증

- `pnpm --dir frontend test -- PipelineReviewPage PipelineReviewCheckpointCard --run` (2 files, 26 tests; API/FSD audits passed)
- `pnpm --dir frontend exec eslint e2e/upload-domain-pack-generation.spec.ts e2e/support/app-mocks.ts src/pages/pipeline-review/ui/PipelineReviewPage.tsx src/pages/pipeline-review/ui/PipelineReviewPage.test.tsx src/features/pipeline-review/ui/PipelineReviewCheckpointCard.tsx src/features/pipeline-review/ui/PipelineReviewCheckpointCard.test.tsx`
- `pnpm --dir frontend exec playwright test e2e/upload-domain-pack-generation.spec.ts --config=playwright.codex-711.config.ts` (3 passed, 로컬 port 3000이 다른 Next dev server에서 사용 중이라 동일 설정의 임시 3171 preview config로 실행 후 제거)
- `git diff --check`

## 참고

- 구현 전 `LogUploadForm`, `PipelineReviewPage`, `PipelineReviewCheckpointCard`, `pipelineReviewApi`, 기존 upload/workspace E2E, `app-mocks.ts`, `frontend/DESIGN.md`, frontend FSD/test rules를 확인했습니다.
- spec review 2회 수행: issue fidelity와 Ostone repository compliance 관점에서 확인했고, 파일명/브랜치/affected paths와 검증 기준을 최종 diff에 맞췄습니다.
- self-review 3회 수행: Round 1에서 stale job `900` checkpoint가 같이 조회되지 않는 assertion을 보강했고 targeted Critical E2E를 재수행했습니다. Round 2에서 terminal status contract를 확인해 CANCELLED 상태도 승인 불가/재시도 경로로 정리했습니다. Round 3에서 temporary preview config 제거, validation claim, staged diff 범위, formatting을 확인했습니다.
- 최신 main rebase 후 self-review 3회를 다시 수행했습니다. 이 과정에서 main의 job `904` refresh fixture와 충돌하지 않도록 이번 Critical E2E의 RUNNING fixture를 job `905`로 분리했고, focused unit/lint/upload E2E를 재수행했습니다.
- 기본 Playwright config의 `localhost:3000`은 이 로컬 환경에서 다른 프로젝트 Next dev server가 점유하고 있어 stock command가 잘못된 서버를 재사용하는 문제가 있었습니다. 동일한 config 내용을 `localhost:3171`로 복제한 임시 config에서 upload E2E를 실행했고, 임시 config는 최종 diff에서 제거했습니다.
- pre-commit hook의 `pnpm run lint:frontend`는 API/FSD audit 통과 후 이번 변경과 무관한 기존 frontend ESLint baseline 47건으로 실패합니다. 변경 파일 대상 ESLint, focused unit/E2E, diff whitespace check는 통과했습니다.
- hook 실패는 repository-wide lint baseline 때문이라 변경 파일 대상 검증을 근거로 hook을 우회해 커밋했습니다.