### PR TITLE
fix(frontend): 파이프라인 상태 조회 실패를 안전하게 안내

### DIFF
--- a/.agent/specs/713.md
+++ b/.agent/specs/713.md
@@ -1,0 +1,114 @@
+# Frontend Spec: Pipeline Status Lookup Error Recovery
+
+## Goal
+
+운영자가 pipeline job 리뷰 화면에서 상태 조회 실패를 완료/성공으로 오해하지 않고, 현재 상태를 확인할 수 없다는 오류와 재시도 또는 안전 화면 이동 행동을 볼 수 있게 한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["운영자가 pipeline job 리뷰 화면 진입"] --> B["review-checkpoint 상태 조회"]
+    B --> C{"조회 성공?"}
+    C -->|"No"| D["오류 상태 표시"]
+    D --> E{"운영자 행동"}
+    E -->|"다시 시도"| B
+    E -->|"업로드 화면으로 돌아가기"| F["같은 workspace의 안전 화면"]
+    C -->|"Yes"| G{"최신 상태"}
+    G -->|"리뷰 대기"| H["리뷰 작업 표시"]
+    G -->|"완료"| I["완료 상태와 도메인팩 관리 행동 표시"]
+    G -->|"실패"| J["실패 상태와 업로드 재시도 행동 표시"]
+    G -->|"진행 중"| K["진행 중 상태와 상태 새로고침 행동 표시"]
+```
+
+## Design Diff
+
+| 영역 | As-is | To-be | 변경 내용 |
+| ---- | ----- | ----- | --------- |
+| 조회 실패 카드 | 체크포인트 카드가 오류와 다시 시도를 표시한다 | 오류 카드가 현재 상태를 확인할 수 없음을 명확히 알리고, 재시도와 업로드 화면 이동을 함께 제공한다 | 운영자가 성공/완료로 오해하지 않고 회복 행동을 선택할 수 있게 한다 |
+| 페이지 상태 맥락 | 페이지 상단 맥락은 query data가 없으면 확인 중으로 보일 수 있다 | query error일 때 상단 맥락도 상태 조회 실패와 확인 불가 상태를 표시한다 | 카드 밖에서도 실패 상태가 진행/완료처럼 보이지 않게 한다 |
+| 재시도 후 성공 | 컴포넌트 단위 재시도는 검증되어 있다 | E2E fixture에서 최초 조회 실패 후 재시도 성공 시 최신 job 상태가 반영되는 흐름을 검증한다 | 실제 operator route에서 회복 동작을 고정한다 |
+| workspace/job 격리 | 같은 route query key를 사용한다 | 실패 중에는 다른 workspace/job 결과를 표시하지 않고, 재시도도 같은 workspace/job endpoint만 다시 호출한다 | 상태 섞임을 방지한다 |
+
+## Component Tree
+
+```text
+PipelineReviewPage
+├─ status context panel
+│  ├─ 현재 단계
+│  ├─ 반영 방식
+│  └─ 초안 승인
+└─ PipelineReviewCheckpointCard
+   ├─ loading state
+   ├─ error recovery StateActionCard
+   │  ├─ 다시 시도
+   │  └─ 업로드 화면으로 돌아가기
+   ├─ no-active-checkpoint StateActionCard
+   ├─ Domain confirmation review
+   └─ Human feedback review
+```
+
+## API Integration
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| GET | `/api/v1/workspaces/{workspaceId}/pipeline-jobs/{pipelineJobId}/review-checkpoint` | pipeline job의 현재 체크포인트, 상태, 리뷰 작업 조회 |
+
+- 기존 generated endpoint `getCheckpoint`를 계속 사용한다.
+- 새 API, DTO, schema, OpenAPI generated code 변경은 없다.
+- React Query query key는 기존 `["pipeline-review-checkpoint", workspaceId, pipelineJobId]`를 유지한다.
+- 전역 query 설정은 retry를 자동 수행하지 않으므로, 오류 후 재조회는 운영자의 명시적 `refetch()` 행동으로 수행된다.
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+| ---- | --------- | ---- |
+| `frontend/src/pages/pipeline-review/ui/PipelineReviewPage.tsx` | modify | checkpoint query 실패 시 페이지 맥락에 상태 조회 실패/확인 불가 copy 표시 |
+| `frontend/src/pages/pipeline-review/ui/PipelineReviewPage.test.tsx` | modify | 페이지 상단 맥락의 query error 매핑 검증 |
+| `frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.tsx` | modify | 오류 카드에 안전 화면 이동 link와 alert 역할 추가 |
+| `frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.test.tsx` | modify | 오류 상태의 재시도와 안전 화면 이동 행동 검증 |
+| `frontend/e2e/support/app-mocks.ts` | modify | 최초 review-checkpoint 조회 실패 후 재시도 성공하는 fixture 추가 |
+| `frontend/e2e/workspace-core.spec.ts` | modify | 운영자가 오류를 보고 같은 job 재시도 후 최신 성공 상태를 확인하는 E2E 시나리오 추가 |
+
+## State Management
+
+- Server state는 TanStack Query로 유지한다.
+- `PipelineReviewPage`와 `PipelineReviewCheckpointCard`는 동일한 checkpoint query key를 공유한다.
+- 실패 상태에서는 이전 성공 데이터가 없는 경우 완료/성공 CTA를 표시하지 않는다.
+- 수동 재시도는 기존 `query.refetch()`를 사용해 같은 workspaceId와 pipelineJobId endpoint를 다시 호출한다.
+- 안전 화면 이동은 같은 workspace의 `/workspaces/{workspaceId}/upload` 경로로 이동한다.
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+| ---- | ---- | ---- | ---- |
+| 컴포넌트 테스트 | query error 상태의 문구/행동 검증 | Vitest + React Testing Library | 기존 페이지/카드 테스트 확장 |
+| E2E 테스트 | 최초 조회 실패 후 재시도 성공 검증 | Playwright | mock fixture로 실패와 성공을 deterministic하게 재현 |
+
+### Test Scenarios
+
+| # | Given | When | Then |
+| --- | ----- | ---- | ---- |
+| 1 | 운영자가 pipeline job 리뷰 화면에 있고 상태 조회가 실패한다 | 화면을 본다 | 상단 맥락과 카드가 현재 상태를 확인할 수 없음을 표시하고 완료/성공 CTA를 노출하지 않는다 |
+| 2 | 상태 조회 실패 카드가 표시되어 있다 | 운영자가 다시 시도한다 | 같은 workspace/job review-checkpoint endpoint가 다시 호출된다 |
+| 3 | 재시도 응답이 성공 상태를 반환한다 | 재시도 후 화면을 본다 | 같은 URL에서 최신 완료 상태와 도메인팩 관리 CTA가 표시된다 |
+| 4 | 상태 조회 실패 카드가 표시되어 있다 | 운영자가 안전 화면 이동을 선택한다 | 같은 workspace의 업로드 화면으로 이동할 수 있다 |
+
+## Non-goals
+
+- 백엔드 endpoint, schema, 권한 정책을 변경하지 않는다.
+- Airflow 실제 장애를 E2E에서 호출하지 않는다.
+- pipeline job 자체를 새로 retry하는 backend action은 이 이슈 범위에 포함하지 않는다.
+- 다른 workspace나 다른 job의 상태를 fallback으로 보여주지 않는다.
+
+## Validation Expectations
+
+- `pnpm --dir frontend test -- PipelineReviewPage PipelineReviewCheckpointCard`
+- `pnpm --dir frontend e2e -- workspace-core.spec.ts`
+- 필요 시 `pnpm --dir frontend build`
+
+## Open Questions
+
+- 없음. issue의 기술 확인 메모에 따라 실제 코드 조사를 통해 최초 조회 실패와 polling 실패 모두 같은 checkpoint query error surface에서 회복하도록 확인했다.

--- a/frontend/e2e/support/app-mocks.ts
+++ b/frontend/e2e/support/app-mocks.ts
@@ -1495,6 +1495,12 @@ async function fulfillUploadAndReview(
     return true;
   }
 
+  if (method === "GET" && path === "/workspaces/1/pipeline-jobs/904/review-checkpoint") {
+    const checkpoint = failOnceThenCheckpoint(state, 904, "SUCCEEDED");
+    await fulfillJson(route, checkpoint.body, checkpoint.status);
+    return true;
+  }
+
   if (
     method === "POST" &&
     path === "/workspaces/1/pipeline-jobs/900/review-checkpoint/domain-confirmation"
@@ -1531,6 +1537,35 @@ function transitionCheckpoint(
     pipelineStatus: seenCount === 0 ? "RUNNING" : finalStatus,
     reviewKind: null,
     tasks: [],
+  };
+}
+
+function failOnceThenCheckpoint(
+  state: PipelineReviewMockState,
+  pipelineJobId: number,
+  finalStatus: "SUCCEEDED" | "FAILED",
+) {
+  const seenCount = state.pipelineReviewStatusRequests[pipelineJobId] ?? 0;
+  state.pipelineReviewStatusRequests[pipelineJobId] = seenCount + 1;
+
+  if (seenCount === 0) {
+    return {
+      status: 503,
+      body: {
+        code: "PIPELINE_REVIEW_STATUS_UNAVAILABLE",
+        message: "파이프라인 상태를 확인할 수 없습니다.",
+      },
+    };
+  }
+
+  return {
+    status: 200,
+    body: {
+      pipelineJobId,
+      pipelineStatus: finalStatus,
+      reviewKind: null,
+      tasks: [],
+    },
   };
 }
 

--- a/frontend/e2e/workspace-core.spec.ts
+++ b/frontend/e2e/workspace-core.spec.ts
@@ -344,6 +344,37 @@ test.describe("Workspace core operator screens", () => {
     });
 
     test.describe("When they refresh pipeline review progress", () => {
+      test("Then lookup failures show safe recovery and retry updates the same job", async ({
+        page,
+      }) => {
+        await page.goto("/workspaces/1/pipeline-jobs/904/review");
+        await expect(page.getByLabel("파이프라인 리뷰 맥락")).toContainText("상태 조회 실패");
+        await expect(page.getByLabel("파이프라인 리뷰 맥락")).toContainText(
+          "현재 job 상태 확인 불가",
+        );
+        await expect(page.getByRole("alert")).toContainText("현재 job 상태를 확인할 수 없습니다.");
+        await expect(page.getByRole("link", { name: "업로드 화면으로 돌아가기" })).toHaveAttribute(
+          "href",
+          "/workspaces/1/upload",
+        );
+        await expect(page.getByRole("link", { name: "도메인팩 관리로 이동" })).toHaveCount(0);
+
+        await page.getByRole("button", { name: "다시 시도" }).click();
+
+        await expect(page).toHaveURL(/\/workspaces\/1\/pipeline-jobs\/904\/review/);
+        await expect(page.getByLabel("파이프라인 리뷰 맥락")).toContainText("파이프라인 완료");
+        await expect(page.getByText("리뷰 체크포인트가 완료되었습니다.")).toBeVisible();
+        await expect(page.getByRole("link", { name: "도메인팩 관리로 이동" })).toBeVisible();
+        await expect
+          .poll(
+            () =>
+              seen.filter(
+                (entry) => entry === "GET /workspaces/1/pipeline-jobs/904/review-checkpoint",
+              ).length,
+          )
+          .toBeGreaterThanOrEqual(2);
+      });
+
       test("Then the latest completion and failure actions replace the stale running state", async ({
         page,
       }) => {

--- a/frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.test.tsx
+++ b/frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.test.tsx
@@ -55,7 +55,7 @@ describe("PipelineReviewCheckpointCard", () => {
     expect(screen.getByText("리뷰 체크포인트를 불러오는 중입니다.")).toBeInTheDocument();
   });
 
-  it("retries checkpoint loading from the error state", () => {
+  it("retries checkpoint loading from the error state and exposes a safe workspace action", () => {
     const refetch = vi.fn();
     mockedUseCheckpoint.mockReturnValue({
       isLoading: false,
@@ -66,7 +66,15 @@ describe("PipelineReviewCheckpointCard", () => {
 
     renderCard();
 
-    expect(screen.getByText("리뷰 체크포인트를 불러오지 못했습니다.")).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent("현재 job 상태를 확인할 수 없습니다.");
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "완료나 초안 생성 성공으로 처리하지 않고 같은 job을 다시 조회합니다.",
+    );
+    expect(screen.getByRole("link", { name: "업로드 화면으로 돌아가기" })).toHaveAttribute(
+      "href",
+      "/workspaces/1/upload",
+    );
+    expect(screen.queryByRole("link", { name: "도메인팩 관리로 이동" })).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "다시 시도" }));
     expect(refetch).toHaveBeenCalledTimes(1);
   });

--- a/frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.tsx
+++ b/frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.tsx
@@ -116,8 +116,9 @@ export function PipelineReviewCheckpointCard({ workspaceId, pipelineJobId }: Pro
   if (query.isError) {
     return (
       <StateActionCard
-        title="리뷰 체크포인트를 불러오지 못했습니다."
-        description="네트워크 상태를 확인한 뒤 같은 화면에서 다시 조회할 수 있습니다."
+        role="alert"
+        title="현재 job 상태를 확인할 수 없습니다."
+        description="상태 조회에 실패했습니다. 완료나 초안 생성 성공으로 처리하지 않고 같은 job을 다시 조회합니다."
       >
         <button
           type="button"
@@ -128,6 +129,10 @@ export function PipelineReviewCheckpointCard({ workspaceId, pipelineJobId }: Pro
           <RefreshCwIcon aria-hidden="true" />
           다시 시도
         </button>
+        <Link to={`/workspaces/${workspaceId}/upload`} className={styles.stateActionSecondary}>
+          <UploadIcon aria-hidden="true" />
+          업로드 화면으로 돌아가기
+        </Link>
       </StateActionCard>
     );
   }
@@ -342,13 +347,15 @@ function StateActionCard({
   title,
   description,
   children,
+  role,
 }: {
   title: string;
   description: string;
   children: ReactNode;
+  role?: "alert" | "status";
 }) {
   return (
-    <section className={styles.stateCard}>
+    <section className={styles.stateCard} role={role}>
       <div className={styles.stateCopy}>
         <strong className={styles.stateTitle}>{title}</strong>
         <span>{description}</span>

--- a/frontend/src/pages/pipeline-review/ui/PipelineReviewPage.test.tsx
+++ b/frontend/src/pages/pipeline-review/ui/PipelineReviewPage.test.tsx
@@ -90,6 +90,19 @@ describe("PipelineReviewPage", () => {
     },
   );
 
+  it("shows status lookup failure in the route context without implying completion", () => {
+    mockedUseCheckpoint.mockReturnValue({
+      isError: true,
+      data: undefined,
+    } as never);
+
+    renderPage("/workspaces/1/pipeline-jobs/7/review");
+
+    expect(screen.getByText("상태 조회 실패")).toBeInTheDocument();
+    expect(screen.getByText("현재 job 상태 확인 불가")).toBeInTheDocument();
+    expect(screen.queryByText("파이프라인 완료")).not.toBeInTheDocument();
+  });
+
   it("redirects invalid route ids back to workspace list", () => {
     renderPage("/workspaces/not-a-number/pipeline-jobs/7/review");
 

--- a/frontend/src/pages/pipeline-review/ui/PipelineReviewPage.tsx
+++ b/frontend/src/pages/pipeline-review/ui/PipelineReviewPage.tsx
@@ -39,11 +39,17 @@ export function PipelineReviewPage() {
       <section className={styles.contextPanel} aria-label="파이프라인 리뷰 맥락">
         <div className={styles.contextItem}>
           <span className={styles.contextLabel}>현재 단계</span>
-          <strong>{statusLabel(checkpointQuery.data?.pipelineStatus, checkpointQuery.data?.reviewKind)}</strong>
+          <strong>
+            {statusLabel(
+              checkpointQuery.data?.pipelineStatus,
+              checkpointQuery.data?.reviewKind,
+              checkpointQuery.isError,
+            )}
+          </strong>
         </div>
         <div className={styles.contextItem}>
           <span className={styles.contextLabel}>반영 방식</span>
-          <strong>{checkpointQuery.data?.reviewKind ? "결정 후 replay" : "활성 체크포인트 없음"}</strong>
+          <strong>{modeLabel(checkpointQuery.data?.reviewKind, checkpointQuery.isError)}</strong>
         </div>
         <div className={styles.contextItem}>
           <span className={styles.contextLabel}>초안 승인</span>
@@ -56,7 +62,14 @@ export function PipelineReviewPage() {
   );
 }
 
-function statusLabel(pipelineStatus?: string, reviewKind?: string | null): string {
+function statusLabel(
+  pipelineStatus?: string,
+  reviewKind?: string | null,
+  isError = false,
+): string {
+  if (isError) {
+    return "상태 조회 실패";
+  }
   if (reviewKind === "DOMAIN_CONFIRMATION") {
     return "도메인 확정 대기";
   }
@@ -73,4 +86,11 @@ function statusLabel(pipelineStatus?: string, reviewKind?: string | null): strin
     return pipelineStatus;
   }
   return "확인 중";
+}
+
+function modeLabel(reviewKind?: string | null, isError = false): string {
+  if (isError) {
+    return "현재 job 상태 확인 불가";
+  }
+  return reviewKind ? "결정 후 replay" : "활성 체크포인트 없음";
 }


### PR DESCRIPTION
Closes #713

## 변경 사항

- 이슈 713 요구사항과 acceptance criteria를 `.agent/specs/713.md`에 정리했습니다.
- pipeline review 화면의 상단 맥락이 checkpoint 조회 실패를 `상태 조회 실패`/`현재 job 상태 확인 불가`로 표시하도록 했습니다.
- checkpoint 카드의 조회 실패 상태가 완료 또는 초안 생성 성공 CTA를 노출하지 않고, 같은 job `다시 시도`와 같은 workspace 업로드 화면 이동을 제공합니다.
- workspace mocked E2E fixture에 최초 review-checkpoint 조회 실패 후 재시도 성공하는 job `904`를 추가하고, 같은 URL/job에서 최신 완료 상태가 반영되는지 검증합니다.

## 검증

- `pnpm --dir frontend test -- PipelineReviewPage PipelineReviewCheckpointCard` (2 files, 23 tests; API/FSD audits passed)
- `pnpm --dir frontend exec eslint src/pages/pipeline-review/ui/PipelineReviewPage.tsx src/pages/pipeline-review/ui/PipelineReviewPage.test.tsx src/features/pipeline-review/ui/PipelineReviewCheckpointCard.tsx src/features/pipeline-review/ui/PipelineReviewCheckpointCard.test.tsx e2e/support/app-mocks.ts e2e/workspace-core.spec.ts`
- `pnpm --dir frontend exec playwright test e2e/workspace-core.spec.ts --grep "lookup failures show safe recovery" --config=playwright.ostone-local.config.ts --reporter=list` (1 passed, 로컬 port 3000이 다른 프로세스에서 사용 중이라 동일 설정의 임시 4174 preview config로 실행 후 제거)
- `git diff --check`
- `git diff --cached --check`
- `git show --check --stat --oneline HEAD`

## 참고

- 구현 전 `PipelineReviewPage`, `PipelineReviewCheckpointCard`, `pipelineReviewApi`, 기존 `workspace-core.spec.ts`, `app-mocks.ts`, `frontend/DESIGN.md`, frontend FSD/test/error-handling rules를 확인했습니다.
- spec review 2회 수행: issue fidelity와 Ostone repository compliance 관점에서 확인했고, 파일명/브랜치/affected paths와 검증 기준을 최종 diff에 맞췄습니다.
- self-review 3회 수행: Round 1에서 issue 요구사항과 UI behavior를 확인했고 추가 수정 사항은 없었습니다. Round 2에서 FSD/generated API/query key boundary를 확인했으며 변경 파일 대상 ESLint를 통과했습니다. Round 3에서 temporary preview config 제거, validation claim, staged diff 범위, formatting을 확인했습니다.
- 기본 `pnpm --dir frontend e2e -- workspace-core.spec.ts`는 이 로컬 환경에서 `localhost:3000`을 다른 프로세스가 점유해 repo config의 `reuseExistingServer`가 잘못된 서버에 붙는 문제가 있어 중단했습니다. 동일한 mocked E2E 설정을 `localhost:4174` 임시 config로 실행했고, 임시 config는 최종 diff에서 제거했습니다.
- `pnpm --dir frontend lint`는 API/FSD audit 통과 후 이번 변경과 무관한 기존 frontend ESLint baseline 47건으로 실패합니다. 변경 파일 대상 ESLint, focused unit/E2E, diff whitespace checks는 통과했습니다.
- hook 실패는 repository-wide lint baseline 때문이라 변경 파일 대상 검증을 근거로 hook을 우회해 커밋했습니다.