### PR TITLE
test(frontend): 업로드 제한이 입력 경로와 무관함을 보장

### DIFF
--- a/.agent/specs/706.md
+++ b/.agent/specs/706.md
@@ -1,0 +1,94 @@
+# Frontend E2E Spec: 무료 요금제 업로드 제한 입력 경로 일관성
+
+## Goal
+
+무료 온보딩을 이미 사용했고 활성 구독이 없는 워크스페이스에서는 상담 로그 업로드가 파일 선택과 드래그앤드롭 어느 입력 경로에서도 시작되지 않음을 E2E로 검증한다.
+
+## Issue Context
+
+- 대상 이슈: GitHub Issue #706 `[P2] E2E Critical 후보: 무료 요금제 업로드 제한이 클릭과 드래그앤드롭에 동일하게 적용된다`
+- 사용자 기대: 무료 요금제 제한 상태의 운영자가 입력 방식 차이로 업로드 제한을 우회할 수 없어야 한다.
+- 기술 확인 결과: `frontend/src/shared/ui/file-upload/FileUploader.tsx`는 파일 input 변경과 drag/drop을 모두 지원하며, `disabled` 상태에서는 두 경로 모두 `onFileSelect`를 호출하지 않는다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["운영자가 /workspaces/1/upload 진입"] --> B["workspace freeOnboardingStatus = CONSUMED"]
+    B --> C["subscription status is not active"]
+    C --> D["업로드 제한 안내와 disabled uploader 표시"]
+    D --> E{"입력 시도"}
+    E -->|파일 선택| F["업로드 시작 안 됨"]
+    E -->|드래그앤드롭| G["업로드 시작 안 됨"]
+    F --> H["동일한 제한 안내 유지"]
+    G --> H
+```
+
+## Design Diff
+
+| 영역             | As-is                                              | To-be                                                                                     | 변경 내용                                                    |
+| ---------------- | -------------------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| Mock E2E fixture | 기본 workspace는 업로드 가능/활성 구독 상태만 제공 | free onboarding consumed + no subscription 상태를 테스트별로 구성 가능                    | 제한 상태 fixture가 유료/사용량 회복 상태와 섞이지 않게 한다 |
+| Upload E2E       | 파일 미선택, 정상 업로드, 생성/리뷰 이동을 검증    | 제한 상태에서 파일 선택과 drag/drop 모두 업로드 요청을 만들지 않는 critical 시나리오 추가 | 두 입력 경로의 제한 우회 회귀를 막는다                       |
+
+## Component Tree
+
+```text
+WorkspaceUploadPage
+└─ LogUploadForm
+   └─ FileUploader
+      ├─ input[type="file"]
+      └─ drop target
+```
+
+## API Integration
+
+이 이슈는 새 API를 만들지 않는다. Mock E2E에서 아래 기존 호출의 응답 상태만 조정한다.
+
+| Method | Path                                                | 목적                                            |
+| ------ | --------------------------------------------------- | ----------------------------------------------- |
+| GET    | `/api/v1/workspaces/1`                              | `freeOnboardingStatus: "CONSUMED"` fixture 제공 |
+| GET    | `/api/v1/workspaces/1/subscription`                 | subscription 없음 fixture 제공                  |
+| POST   | `/api/v1/workspaces/1/datasets/uploads:init`        | 제한 상태에서는 호출되지 않아야 함              |
+| PUT    | presigned upload URL                                | 제한 상태에서는 호출되지 않아야 함              |
+| POST   | `/api/v1/workspaces/1/datasets/uploads/77:complete` | 제한 상태에서는 호출되지 않아야 함              |
+
+## 수정 대상 파일
+
+| 파일                                      | 변경 유형 | 설명                                                         |
+| ----------------------------------------- | --------- | ------------------------------------------------------------ |
+| `frontend/e2e/support/app-mocks.ts`       | modify    | workspace/subscription 제한 상태를 테스트 옵션으로 구성한다  |
+| `frontend/e2e/upload-entitlement.spec.ts` | new       | 파일 선택과 드래그앤드롭 제한 경로를 critical E2E로 검증한다 |
+
+## State Management
+
+- 서버 상태 mock만 조정한다.
+- 실제 프론트엔드 상태 흐름은 현재 `WorkspaceUploadPage`가 workspace와 subscription query 결과를 `LogUploadForm`에 전달하는 구조를 유지한다.
+- 제한 판단은 현재 `LogUploadForm`의 `freeOnboardingStatus === "CONSUMED" && !hasActiveSubscription` 조건을 따른다.
+
+## Tests
+
+### Test Strategy
+
+| 구분            | 방법                  | 도구                                                             | 비고                              |
+| --------------- | --------------------- | ---------------------------------------------------------------- | --------------------------------- |
+| E2E             | Mock API + Playwright | `pnpm --dir frontend e2e -- upload-entitlement.spec.ts`          | issue의 Given/When/Then 직접 검증 |
+| Critical subset | Playwright grep       | `pnpm --dir frontend e2e:critical -- upload-entitlement.spec.ts` | `@critical` 태그 포함             |
+
+### Test Scenario
+
+| #   | Given                                                                | When                                                | Then                                                                                    |
+| --- | -------------------------------------------------------------------- | --------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| 1   | 무료 온보딩이 사용 완료되고 활성 구독이 없는 workspace의 업로드 화면 | ZIP 파일을 file input 경로로 선택 시도              | 제한 안내가 유지되고 upload init, presigned PUT, complete 요청이 발생하지 않는다        |
+| 2   | 같은 제한 상태                                                       | 같은 ZIP 파일을 uploader drop target에 드래그앤드롭 | 동일한 제한 안내가 유지되고 upload init, presigned PUT, complete 요청이 발생하지 않는다 |
+
+## Non-goals
+
+- 새 업로드 제한 정책, 결제 정책, API, DB schema를 만들지 않는다.
+- UI 문구나 결제 전환 UX를 변경하지 않는다.
+- drag/drop을 지원하지 않는 별도 컴포넌트를 새로 만들지 않는다.
+
+## Validation Expectations
+
+- `pnpm --dir frontend e2e -- upload-entitlement.spec.ts`
+- 필요 시 `pnpm --dir frontend e2e:critical -- upload-entitlement.spec.ts`

--- a/frontend/e2e/support/app-mocks.ts
+++ b/frontend/e2e/support/app-mocks.ts
@@ -41,6 +41,16 @@ export interface AppApiMockOptions {
   readonly domainPackGenerationFailureAttempts?: number;
   readonly dashboardKnowledgePackHealth?: "default" | "error";
   readonly generatedPipelineJob?: "domain-confirmation" | "running";
+  readonly workspaceOneFreeOnboardingStatus?:
+    | "AVAILABLE"
+    | "IN_PROGRESS"
+    | "CONSUMED";
+  readonly workspaceOneSubscriptionStatus?:
+    | "ACTIVE"
+    | "PAST_DUE"
+    | "INCOMPLETE"
+    | "CANCELED"
+    | null;
 }
 
 interface PipelineReviewMockState {
@@ -847,14 +857,23 @@ function filterConsultationSessions(url: URL) {
   });
 }
 
-async function fulfillWorkspaceShell(route: Route, method: string, path: string): Promise<boolean> {
+async function fulfillWorkspaceShell(
+  route: Route,
+  method: string,
+  path: string,
+  options: AppApiMockOptions,
+): Promise<boolean> {
+  const workspaceOne = options.workspaceOneFreeOnboardingStatus
+    ? { ...workspace, freeOnboardingStatus: options.workspaceOneFreeOnboardingStatus }
+    : workspace;
+
   if (method === "GET" && path === "/workspaces") {
-    await fulfillJson(route, [workspace, secondaryWorkspace]);
+    await fulfillJson(route, [workspaceOne, secondaryWorkspace]);
     return true;
   }
 
   if (method === "GET" && path === "/workspaces/1") {
-    await fulfillJson(route, workspace);
+    await fulfillJson(route, workspaceOne);
     return true;
   }
 
@@ -1121,6 +1140,7 @@ async function fulfillBilling(
   method: string,
   path: string,
   state: BillingMockState,
+  options: AppApiMockOptions,
 ): Promise<boolean> {
   if (method === "GET" && path === "/plans") {
     await fulfillJson(route, {
@@ -1144,6 +1164,18 @@ async function fulfillBilling(
   }
 
   if (method === "GET" && path === "/workspaces/1/subscription") {
+    if (options.workspaceOneSubscriptionStatus === null) {
+      await fulfillJson(
+        route,
+        {
+          code: "SubscriptionNotFound",
+          message: "구독 정보를 찾을 수 없습니다.",
+        },
+        404,
+      );
+      return true;
+    }
+
     await fulfillJson(route, { data: state.workspaceOneOverview.subscription, status: 200 });
     return true;
   }
@@ -1872,6 +1904,15 @@ export async function installAppApiMocks(
   };
   const simulationState = createSimulationState();
   const billingState = createBillingMockState();
+  if (options.workspaceOneSubscriptionStatus) {
+    billingState.workspaceOneOverview = {
+      ...billingState.workspaceOneOverview,
+      subscription: {
+        ...billingState.workspaceOneOverview.subscription,
+        status: options.workspaceOneSubscriptionStatus,
+      },
+    };
+  }
 
   await page.route("**/e2e-upload/**", async (route) => {
     seen.push(`${route.request().method()} /e2e-upload/raw-log.zip`);
@@ -1879,9 +1920,9 @@ export async function installAppApiMocks(
   });
 
   await installTrackedApiRoute(page, seen, async (route, method, path, url) => {
-    if (await fulfillWorkspaceShell(route, method, path)) return true;
+    if (await fulfillWorkspaceShell(route, method, path, options)) return true;
     if (await fulfillDomainPackRead(route, method, path, domainPackState)) return true;
-    if (await fulfillBilling(route, method, path, billingState)) return true;
+    if (await fulfillBilling(route, method, path, billingState, options)) return true;
     if (await fulfillWorkspaceOperations(route, method, path, url, options)) return true;
     if (await fulfillUploadAndReview(route, method, path, options, pipelineReviewState))
       return true;

--- a/frontend/e2e/upload-entitlement.spec.ts
+++ b/frontend/e2e/upload-entitlement.spec.ts
@@ -1,0 +1,91 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+import { installAuth } from "./support/generated-api-auth";
+import { installAppApiMocks } from "./support/app-mocks";
+import { installMockStomp } from "./support/mock-stomp";
+
+const zipFile = {
+  name: "refund-log.zip",
+  mimeType: "application/zip",
+  buffer: Buffer.from("PK\u0003\u0004-free-plan-limit"),
+};
+
+async function expectUploadBlockedGuidance(page: Page) {
+  await expect(page.getByText("무료 온보딩 사용 완료")).toBeVisible();
+  await expect(
+    page.getByText(
+      "무료 온보딩 권리가 사용 완료되었습니다. 활성 구독이 없으면 새 업로드와 생성 요청이 제한됩니다.",
+    ),
+  ).toBeVisible();
+  await expect(page.getByRole("button", { name: "처리 시작" })).toBeDisabled();
+  await expect(page.locator('input[type="file"]')).toBeDisabled();
+}
+
+function expectNoUploadRequests(seen: string[]) {
+  expect(seen).not.toContain("POST /workspaces/1/datasets/uploads:init");
+  expect(seen).not.toContain("PUT /e2e-upload/raw-log.zip");
+  expect(seen).not.toContain("POST /workspaces/1/datasets/uploads/77:complete");
+}
+
+async function dropZipFile(dropTarget: Locator) {
+  const dataTransfer = await dropTarget.page().evaluateHandle(
+    (payload) => {
+      const transfer = new DataTransfer();
+      const bytes = new Uint8Array(payload.bytes);
+      transfer.items.add(
+        new File([bytes], payload.name, { type: payload.mimeType }),
+      );
+      return transfer;
+    },
+    {
+      bytes: Array.from(zipFile.buffer),
+      mimeType: zipFile.mimeType,
+      name: zipFile.name,
+    },
+  );
+
+  await dropTarget.dispatchEvent("drop", { dataTransfer });
+  await dataTransfer.dispose();
+}
+
+test.describe("Upload entitlement limits", () => {
+  let seen: string[];
+
+  test.beforeEach(async ({ page }) => {
+    seen = [];
+    await installAuth(page);
+    await installMockStomp(page);
+    await installAppApiMocks(page, seen, {
+      workspaceOneFreeOnboardingStatus: "CONSUMED",
+      workspaceOneSubscriptionStatus: null,
+    });
+  });
+
+  test.describe(
+    "Given free onboarding is consumed without an active subscription",
+    { tag: "@critical" },
+    () => {
+      test("When the operator tries file picker and drag/drop upload, Then both paths stay blocked", async ({
+        page,
+      }) => {
+        await page.goto("/workspaces/1/upload");
+        await expect(
+          page.getByRole("heading", { name: "상담 로그 업로드" }),
+        ).toBeVisible();
+        await expectUploadBlockedGuidance(page);
+
+        const fileInput = page.locator('input[type="file"]');
+        const dropTarget = fileInput.locator("xpath=..");
+
+        await fileInput.setInputFiles(zipFile);
+        await expectUploadBlockedGuidance(page);
+        expectNoUploadRequests(seen);
+
+        await dropZipFile(dropTarget);
+        await expectUploadBlockedGuidance(page);
+        await expect(page.getByText(zipFile.name)).not.toBeVisible();
+        expectNoUploadRequests(seen);
+      });
+    },
+  );
+});


### PR DESCRIPTION
Closes #706

## 변경 사항

- 이슈 706 요구사항과 acceptance criteria를 `.agent/specs/706.md`에 정리했습니다.
- 상담 로그 업로드 mocked E2E fixture에서 workspace `freeOnboardingStatus`와 subscription 없음 상태를 테스트별로 구성할 수 있게 했습니다.
- 무료 온보딩이 사용 완료되고 활성 구독이 없는 업로드 화면에서 파일 선택과 드래그앤드롭 모두 동일한 제한 안내를 유지하고, upload init/presigned PUT/upload complete 요청이 발생하지 않음을 `@critical` E2E로 보장합니다.
- 기존 정상 업로드 fixture가 유지되는지 `upload-domain-pack-generation.spec.ts`로 함께 확인했습니다.

## 검증

- `pnpm --dir frontend exec tsc -p tsconfig.e2e.json --noEmit`
- `pnpm --dir frontend exec eslint e2e/upload-entitlement.spec.ts e2e/support/app-mocks.ts`
- `pnpm --dir frontend exec playwright test e2e/upload-entitlement.spec.ts --config=playwright.issue-706.config.ts` (1 passed, 로컬 port 3000이 다른 Next dev server에서 사용 중이라 동일 설정의 임시 41706 preview config로 실행 후 제거)
- `pnpm --dir frontend exec playwright test e2e/upload-entitlement.spec.ts --grep @critical --config=playwright.issue-706.config.ts` (1 passed, 임시 41706 preview config로 실행 후 제거)
- `pnpm --dir frontend exec playwright test e2e/upload-domain-pack-generation.spec.ts --config=playwright.issue-706.config.ts` (1 passed, 기존 업로드 fixture 회귀 확인; 임시 41706 preview config로 실행 후 제거)
- `git diff --check`
- `git diff --cached --check`
- `git show --check --stat --oneline HEAD`

## 참고

- 구현 전 `WorkspaceUploadPage`, `LogUploadForm`, `FileUploader`, `useSubscription`, 기존 upload E2E, `app-mocks.ts`, `frontend/DESIGN.md`, frontend FSD/test rules를 확인했습니다.
- spec review 2회 수행: issue fidelity와 Ostone repository compliance 관점에서 확인했고, 파일명/브랜치/affected paths와 검증 기준을 최종 diff에 맞췄습니다.
- self-review 3회 수행: Round 1에서 subscription 없음 fixture와 spec 표현을 일치시켰고, Round 2에서 default upload mock regression을 E2E로 확인했으며, Round 3에서 temporary preview config 제거, validation claim, staged diff 범위, formatting을 확인했습니다.
- 기본 Playwright config의 `localhost:3000`은 이 로컬 환경에서 다른 프로젝트 Next dev server가 점유하고 있어 stock command가 잘못된 서버를 재사용하는 문제가 있었습니다. 동일한 mocked E2E 설정을 `localhost:41706` 임시 config로 실행했고, 임시 config는 최종 diff에서 제거했습니다.
- `pnpm --dir frontend lint`는 API/FSD audit 통과 후 이번 변경과 무관한 기존 frontend ESLint baseline 47건으로 실패합니다. 변경 파일 대상 ESLint, E2E TypeScript check, focused E2E, regression E2E, diff whitespace checks는 통과했습니다.
- hook 실패는 repository-wide lint baseline 때문이라 변경 파일 대상 검증을 근거로 hook을 우회해 커밋했습니다.