### PR TITLE
fix(frontend): 업로드 쿨다운 만료 후 새 업로드를 보장

### DIFF
--- a/.agent/specs/708.md
+++ b/.agent/specs/708.md
@@ -1,0 +1,122 @@
+# Frontend Spec: 업로드 쿨다운 만료 후 새로고침 없는 재시작
+
+## Goal
+
+쿨다운 또는 entitlement 경계가 지난 업로드 화면이 브라우저 새로고침 없이 최신 업로드 가능 상태를 다시 조회하고 ZIP 업로드를 시작할 수 있게 한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["운영자가 /workspaces/{workspaceId}/upload 진입"] --> B["workspace + subscription 조회"]
+    B --> C{"업로드 가능?"}
+    C -->|No| D["업로드 영역 disabled + 제한 안내"]
+    D --> E["subscription.currentPeriodEnd 도달"]
+    E --> F["workspace/subscription 자동 재조회"]
+    F --> G{"업로드 가능 상태로 변경?"}
+    G -->|Yes| H["업로드 영역 enabled"]
+    H --> I["운영자가 ZIP 파일 선택"]
+    I --> J["presigned raw-file 업로드 시작"]
+    G -->|No| D
+    C -->|Yes| H
+```
+
+## Design Diff
+
+| 영역                 | As-is                                                                     | To-be                                                      | 변경 내용                                                                |
+| -------------------- | ------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------ |
+| Entitlement 갱신     | upload page mount/focus/reconnect 중심으로 조회                           | subscription period boundary에 맞춰 자동 재조회            | 쿨다운이 끝났는데 탭을 그대로 둔 운영자도 새로고침 없이 상태 전환을 본다 |
+| Upload disabled 상태 | `freeOnboardingStatus=CONSUMED`이고 active subscription이 없으면 disabled | 자동 재조회 결과 active subscription이면 disabled 해제     | 이전 제한 안내가 남아 업로드를 계속 막지 않는다                          |
+| E2E 회귀             | 업로드 성공 경로 중심                                                     | blocked → boundary refresh → ZIP upload 성공 시나리오 추가 | 이슈 Given/When/Then을 mocked E2E로 고정한다                             |
+
+## Component Tree
+
+```text
+WorkspaceUploadPage
+├─ useGetWorkspace(workspaceId)
+├─ useSubscription(workspaceId)
+├─ entitlement boundary refetch timer
+└─ LogUploadForm
+   └─ FileUploader
+```
+
+## API Integration
+
+| Method | Path                                                                     | Description                                         |
+| ------ | ------------------------------------------------------------------------ | --------------------------------------------------- |
+| GET    | `/api/v1/workspaces/{workspaceId}`                                       | `freeOnboardingStatus`를 포함한 workspace 상태 조회 |
+| GET    | `/api/v1/workspaces/{workspaceId}/subscription`                          | subscription status와 `currentPeriodEnd` 조회       |
+| POST   | `/api/v1/workspaces/{workspaceId}/datasets/uploads:init`                 | ZIP raw-file presigned 업로드 세션 생성             |
+| PUT    | presigned upload URL                                                     | ZIP 파일 전송                                       |
+| POST   | `/api/v1/workspaces/{workspaceId}/datasets/uploads/{datasetId}:complete` | 업로드 완료 처리                                    |
+
+확인 사항:
+
+- `frontend/src/pages/upload/ui/WorkspaceUploadPage.tsx`는 `useGetWorkspace`, `useSubscription`, `LogUploadForm`을 조합한다.
+- `frontend/src/entities/billing/api/useSubscription.ts`는 `SubscriptionResponse.currentPeriodEnd`를 그대로 반환한다.
+- 전용 `cooldownUntil` API 필드는 현재 확인되지 않았다. 이번 범위는 기존 subscription period boundary를 쿨다운/entitlement 재조회 시점으로 사용한다.
+
+## Data Flow
+
+```text
+WorkspaceUploadPage
+  -> workspace query: freeOnboardingStatus
+  -> subscription query: status, currentPeriodEnd
+  -> boundary timer: currentPeriodEnd + short buffer
+  -> workspaceQuery.refetch() + subscriptionQuery.refetch()
+  -> LogUploadForm props update
+  -> FileUploader disabled state update
+```
+
+## 수정 대상 파일
+
+| 파일                                                        | 변경 유형 | 설명                                                        |
+| ----------------------------------------------------------- | --------- | ----------------------------------------------------------- |
+| `frontend/src/pages/upload/ui/WorkspaceUploadPage.tsx`      | modify    | subscription boundary timer로 workspace/subscription 재조회 |
+| `frontend/src/pages/upload/ui/WorkspaceUploadPage.test.tsx` | modify    | period boundary 도달 시 refetch 호출 검증                   |
+| `frontend/e2e/upload-domain-pack-generation.spec.ts`        | modify    | blocked 상태에서 boundary 후 ZIP 업로드 가능 E2E 추가       |
+| `.agent/specs/708.md`                                       | new       | 이슈 스펙                                                   |
+
+## State Management
+
+- 서버 상태는 기존 TanStack Query hooks를 유지한다.
+- 새 client state는 추가하지 않는다.
+- `currentPeriodEnd`가 유효하고 미래 시각이면 `setTimeout`으로 1회 재조회한다.
+- scheduled refetch 중에는 기존 query fetching 상태를 entitlement 확인 중 상태에 포함한다.
+- 브라우저 timer overflow를 피하기 위해 매우 먼 미래 시각은 안전한 최대 timeout 범위로 clamp한다.
+- `currentPeriodEnd`가 없거나 invalid/past이면 별도 timer를 만들지 않는다.
+
+## Tests
+
+### Test Strategy
+
+| 구분            | 방법                                                           | 도구                           |
+| --------------- | -------------------------------------------------------------- | ------------------------------ |
+| 컴포넌트 테스트 | fake timer로 boundary refetch 호출 검증                        | Vitest + React Testing Library |
+| E2E 테스트      | mocked workspace/subscription 상태를 blocked에서 active로 전환 | Playwright                     |
+
+### Test Scenarios
+
+| #   | 시나리오           | 사전 조건                                                               | 조작                                     | 기대 결과                                                      |
+| --- | ------------------ | ----------------------------------------------------------------------- | ---------------------------------------- | -------------------------------------------------------------- |
+| 1   | Boundary refetch   | consumed onboarding + inactive subscription + future `currentPeriodEnd` | timer boundary 도달                      | workspace/subscription `refetch()` 호출                        |
+| 2   | Refreshless upload | blocked upload screen                                                   | clock fast-forward 후 ZIP 선택/처리 시작 | 새로고침 없이 upload area enabled, init/PUT/complete 요청 발생 |
+
+## Acceptance Criteria
+
+- 쿨다운 경계 이후 upload page는 workspace와 subscription 상태를 자동 재조회한다.
+- 재조회 결과 active subscription이면 `LogUploadForm`이 enabled 상태로 갱신된다.
+- 이전 제한 안내나 disabled file input이 새 ZIP 업로드를 계속 막지 않는다.
+- E2E는 clock 제어 또는 상태 재조회 fixture로 쿨다운 만료를 안정적으로 재현한다.
+- 변경은 frontend FSD 방향을 위반하지 않는다.
+
+## Non-goals
+
+- 별도 `cooldownUntil` API 필드 추가.
+- backend quota/window 계산 정책 변경.
+- presigned raw-file upload endpoint의 quota guard 추가.
+- billing 화면의 quota 사용량 UI 변경.
+
+## Open Questions
+
+- 제품 정책상 "쿨다운"의 최종 권위 필드가 `currentPeriodEnd`가 아니라 별도 API 필드로 추가될 경우, 이번 timer 기준은 해당 필드로 교체해야 한다.

--- a/frontend/e2e/upload-domain-pack-generation.spec.ts
+++ b/frontend/e2e/upload-domain-pack-generation.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test, type Page, type Route } from "@playwright/test";
 
 import { installAuth } from "./support/generated-api-auth";
 import {
@@ -9,6 +9,67 @@ import { installMockStomp } from "./support/mock-stomp";
 
 const generationRequest =
   "POST /workspaces/1/datasets/77/pipeline-jobs/domain-pack-generation";
+const workspaceRequest = "GET /workspaces/1";
+const subscriptionRequest = "GET /workspaces/1/subscription";
+
+async function fulfillJson(route: Route, body: unknown) {
+  await route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+async function installUploadCooldownMocks(
+  page: Page,
+  seen: string[],
+  periodEnd: string,
+) {
+  let cooldownExpired = false;
+
+  await page.route("**/api/v1/workspaces/1", async (route) => {
+    seen.push(workspaceRequest);
+    await fulfillJson(route, {
+      id: 1,
+      workspaceKey: "qa-workspace",
+      name: "QA Workspace",
+      description: "E2E workspace",
+      status: "ACTIVE",
+      myRole: "OWNER",
+      freeOnboardingStatus: "CONSUMED",
+      createdAt: "2026-05-01T00:00:00+09:00",
+      updatedAt: "2026-06-04T09:00:00+09:00",
+    });
+  });
+
+  await page.route("**/api/v1/workspaces/1/subscription", async (route) => {
+    seen.push(subscriptionRequest);
+    await fulfillJson(route, {
+      data: {
+        id: 11,
+        workspaceId: 1,
+        planKey: "PRO",
+        status: cooldownExpired ? "ACTIVE" : "INCOMPLETE",
+        currentPeriodStart: "2026-06-01T00:00:00+09:00",
+        currentPeriodEnd: cooldownExpired
+          ? "2026-07-01T00:00:00+09:00"
+          : periodEnd,
+        cancelAtPeriodEnd: false,
+        customerKey: "customer-qa-workspace",
+        memberLimit: 20,
+        datasetUploadLimit: 100,
+        pipelineRunLimit: 50,
+      },
+      status: 200,
+    });
+  });
+
+  return {
+    expireCooldown: () => {
+      cooldownExpired = true;
+    },
+  };
+}
 
 test.describe("Upload completed Domain Pack draft generation", () => {
   let seen: string[];
@@ -145,6 +206,49 @@ test.describe("Upload completed Domain Pack draft generation", () => {
             entry === "POST /workspaces/1/datasets/uploads/77:complete",
         ),
       ).toHaveLength(1);
+    });
+  });
+
+  test.describe("Given a paid workspace upload cooldown has a known period boundary", () => {
+    test("When the cooldown expires, Then the operator can upload a ZIP without refreshing the page", async ({
+      page,
+    }) => {
+      await installUploadGenerationMocks(page);
+      const now = new Date();
+      await page.clock.install({ time: now });
+      const cooldown = await installUploadCooldownMocks(
+        page,
+        seen,
+        new Date(now.getTime() + 1_000).toISOString(),
+      );
+
+      await page.goto("/workspaces/1/upload");
+
+      await expect(page.getByText("무료 온보딩 사용 완료")).toBeVisible();
+      await expect(page.locator('input[type="file"]')).toBeDisabled();
+
+      cooldown.expireCooldown();
+      await page.clock.fastForward(1500);
+
+      await expect(page.getByText(/활성 구독이 적용되어/)).toBeVisible();
+      await expect(page.locator('input[type="file"]')).toBeEnabled();
+
+      await page.locator('input[type="file"]').setInputFiles({
+        name: "refund-log.zip",
+        mimeType: "application/zip",
+        buffer: Buffer.from("PK\u0003\u0004-e2e"),
+      });
+      await page.getByRole("button", { name: "처리 시작" }).click();
+
+      await expect(page.getByText("업로드 완료").first()).toBeVisible();
+      await expect(page.getByText("refund-log.zip")).toBeVisible();
+      await expect(page.getByText("dataset 77")).toBeVisible();
+      expect(
+        seen.filter((entry) => entry === subscriptionRequest).length,
+      ).toBeGreaterThanOrEqual(2);
+      expect(seen).toContain("POST /workspaces/1/datasets/uploads:init");
+      expect(seen).toContain("PUT /e2e-upload/raw-log.zip");
+      expect(seen).toContain("POST /workspaces/1/datasets/uploads/77:complete");
     });
   });
 });

--- a/frontend/src/pages/upload/ui/WorkspaceUploadPage.test.tsx
+++ b/frontend/src/pages/upload/ui/WorkspaceUploadPage.test.tsx
@@ -1,43 +1,57 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WorkspaceUploadPage } from "./WorkspaceUploadPage";
 
 const mockUseGetWorkspace = vi.fn();
 const mockUseSubscription = vi.fn();
+const mockWorkspaceRefetch = vi.fn();
+const mockSubscriptionRefetch = vi.fn();
 
 vi.mock("../../../features/log-upload/ui/LogUploadForm", () => ({
   LogUploadForm: ({
     workspaceId,
     freeOnboardingStatus,
     hasActiveSubscription,
+    isEntitlementLoading,
   }: {
     workspaceId?: number;
     freeOnboardingStatus?: string;
     hasActiveSubscription?: boolean;
+    isEntitlementLoading?: boolean;
   }) => (
     <div data-testid="upload-form">
       workspace:{workspaceId} onboarding:{freeOnboardingStatus} active:
-      {String(hasActiveSubscription)}
+      {String(hasActiveSubscription)} loading:{String(isEntitlementLoading)}
     </div>
   ),
 }));
 
-vi.mock("@/shared/api/generated/endpoints/workspace-controller/workspace-controller", () => ({
-  useGetWorkspace: (...args: unknown[]) => mockUseGetWorkspace(...args),
-}));
+vi.mock(
+  "@/shared/api/generated/endpoints/workspace-controller/workspace-controller",
+  () => ({
+    useGetWorkspace: (...args: unknown[]) => mockUseGetWorkspace(...args),
+  }),
+);
 
 vi.mock("@/entities/billing", () => ({
   useSubscription: (...args: unknown[]) => mockUseSubscription(...args),
-  isSubscriptionEngaged: (status: string | undefined) => status === "ACTIVE" || status === "PAST_DUE",
+  isSubscriptionEngaged: (status: string | undefined) =>
+    status === "ACTIVE" || status === "PAST_DUE",
 }));
 
 function renderRoute(initialEntry: string) {
   return render(
     <MemoryRouter initialEntries={[initialEntry]}>
       <Routes>
-        <Route path="/workspaces/:workspaceId/upload" element={<WorkspaceUploadPage />} />
-        <Route path="/workspaces/:workspaceId/pipeline-jobs/:pipelineJobId/review" element={<div>리뷰 화면</div>} />
+        <Route
+          path="/workspaces/:workspaceId/upload"
+          element={<WorkspaceUploadPage />}
+        />
+        <Route
+          path="/workspaces/:workspaceId/pipeline-jobs/:pipelineJobId/review"
+          element={<div>리뷰 화면</div>}
+        />
       </Routes>
     </MemoryRouter>,
   );
@@ -45,11 +59,23 @@ function renderRoute(initialEntry: string) {
 
 describe("WorkspaceUploadPage", () => {
   beforeEach(() => {
+    vi.useRealTimers();
+    mockWorkspaceRefetch.mockReset();
+    mockSubscriptionRefetch.mockReset();
     mockUseGetWorkspace.mockReturnValue({
       data: { data: { id: 1, freeOnboardingStatus: "AVAILABLE" } },
       isLoading: false,
+      refetch: mockWorkspaceRefetch,
     });
-    mockUseSubscription.mockReturnValue({ data: null, isLoading: false });
+    mockUseSubscription.mockReturnValue({
+      data: null,
+      isLoading: false,
+      refetch: mockSubscriptionRefetch,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("redirects job upload links to the pipeline review screen", () => {
@@ -62,7 +88,7 @@ describe("WorkspaceUploadPage", () => {
     renderRoute("/workspaces/1/upload");
 
     expect(screen.getByTestId("upload-form")).toHaveTextContent(
-      "workspace:1 onboarding:AVAILABLE active:false",
+      "workspace:1 onboarding:AVAILABLE active:false loading:false",
     );
   });
 
@@ -70,13 +96,54 @@ describe("WorkspaceUploadPage", () => {
     mockUseGetWorkspace.mockReturnValue({
       data: { data: { id: 1, freeOnboardingStatus: "CONSUMED" } },
       isLoading: false,
+      refetch: mockWorkspaceRefetch,
     });
-    mockUseSubscription.mockReturnValue({ data: { status: "ACTIVE" }, isLoading: false });
+    mockUseSubscription.mockReturnValue({
+      data: { status: "ACTIVE" },
+      isLoading: false,
+      refetch: mockSubscriptionRefetch,
+    });
 
     renderRoute("/workspaces/1/upload");
 
     expect(screen.getByTestId("upload-form")).toHaveTextContent(
-      "workspace:1 onboarding:CONSUMED active:true",
+      "workspace:1 onboarding:CONSUMED active:true loading:false",
     );
+  });
+
+  it("refreshes upload entitlement when the subscription period boundary passes", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-07T00:00:00.000Z"));
+    mockUseGetWorkspace.mockReturnValue({
+      data: { data: { id: 1, freeOnboardingStatus: "CONSUMED" } },
+      isLoading: false,
+      refetch: mockWorkspaceRefetch,
+    });
+    mockUseSubscription.mockReturnValue({
+      data: {
+        status: "INCOMPLETE",
+        currentPeriodEnd: "2026-06-07T00:00:01.000Z",
+      },
+      isLoading: false,
+      refetch: mockSubscriptionRefetch,
+    });
+
+    renderRoute("/workspaces/1/upload");
+
+    expect(screen.getByTestId("upload-form")).toHaveTextContent(
+      "workspace:1 onboarding:CONSUMED active:false loading:false",
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(1499);
+    });
+    expect(mockWorkspaceRefetch).not.toHaveBeenCalled();
+    expect(mockSubscriptionRefetch).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(mockWorkspaceRefetch).toHaveBeenCalledTimes(1);
+    expect(mockSubscriptionRefetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/pages/upload/ui/WorkspaceUploadPage.tsx
+++ b/frontend/src/pages/upload/ui/WorkspaceUploadPage.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { Navigate, useParams, useSearchParams } from "react-router-dom";
 import { isSubscriptionEngaged, useSubscription } from "@/entities/billing";
 import {
@@ -12,6 +13,29 @@ interface WorkspaceWithFreeOnboarding {
   freeOnboardingStatus?: FreeOnboardingStatus;
 }
 
+const ENTITLEMENT_REFETCH_BUFFER_MS = 500;
+const MAX_TIMEOUT_MS = 2_147_483_647;
+
+function getEntitlementRefetchDelay(
+  periodEnd: string | undefined,
+): number | null {
+  if (!periodEnd) {
+    return null;
+  }
+
+  const periodEndMs = new Date(periodEnd).getTime();
+  if (!Number.isFinite(periodEndMs)) {
+    return null;
+  }
+
+  const delay = periodEndMs - Date.now() + ENTITLEMENT_REFETCH_BUFFER_MS;
+  if (delay <= 0) {
+    return null;
+  }
+
+  return Math.min(delay, MAX_TIMEOUT_MS);
+}
+
 export function WorkspaceUploadPage() {
   const { workspaceId } = useParams();
   const [searchParams] = useSearchParams();
@@ -22,14 +46,52 @@ export function WorkspaceUploadPage() {
   });
   const subscriptionQuery = useSubscription(parsedWorkspaceId);
 
-  if (parsedWorkspaceId !== null && pipelineJobId !== null) {
-    return <Navigate to={`/workspaces/${parsedWorkspaceId}/pipeline-jobs/${pipelineJobId}/review`} replace />;
-  }
-
   const workspace =
-    (selectApiData(workspaceQuery.data) as WorkspaceWithFreeOnboarding | undefined) ?? null;
+    (selectApiData(workspaceQuery.data) as
+      | WorkspaceWithFreeOnboarding
+      | undefined) ?? null;
   const subscription = subscriptionQuery.data ?? null;
   const hasActiveSubscription = isSubscriptionEngaged(subscription?.status);
+  const refetchWorkspace = workspaceQuery.refetch;
+  const refetchSubscription = subscriptionQuery.refetch;
+  const isEntitlementLoading = Boolean(
+    workspaceQuery.isLoading ||
+    workspaceQuery.isFetching ||
+    subscriptionQuery.isLoading ||
+    subscriptionQuery.isFetching,
+  );
+
+  useEffect(() => {
+    if (parsedWorkspaceId === null) {
+      return undefined;
+    }
+
+    const delay = getEntitlementRefetchDelay(subscription?.currentPeriodEnd);
+    if (delay === null) {
+      return undefined;
+    }
+
+    const timerId = window.setTimeout(() => {
+      void refetchWorkspace();
+      void refetchSubscription();
+    }, delay);
+
+    return () => window.clearTimeout(timerId);
+  }, [
+    parsedWorkspaceId,
+    refetchSubscription,
+    refetchWorkspace,
+    subscription?.currentPeriodEnd,
+  ]);
+
+  if (parsedWorkspaceId !== null && pipelineJobId !== null) {
+    return (
+      <Navigate
+        to={`/workspaces/${parsedWorkspaceId}/pipeline-jobs/${pipelineJobId}/review`}
+        replace
+      />
+    );
+  }
 
   return (
     <div style={{ padding: "var(--s-6) var(--s-8) var(--s-10)" }}>
@@ -37,7 +99,7 @@ export function WorkspaceUploadPage() {
         workspaceId={parsedWorkspaceId ?? undefined}
         freeOnboardingStatus={workspace?.freeOnboardingStatus ?? "AVAILABLE"}
         hasActiveSubscription={hasActiveSubscription}
-        isEntitlementLoading={workspaceQuery.isLoading || subscriptionQuery.isLoading}
+        isEntitlementLoading={isEntitlementLoading}
       />
     </div>
   );


### PR DESCRIPTION
Closes #708

## 변경 사항

- 이슈 708 요구사항과 acceptance criteria를 `.agent/specs/708.md`에 정리했습니다.
- upload 화면이 `subscription.currentPeriodEnd` 경계에 맞춰 workspace/subscription 상태를 자동 재조회하도록 했습니다.
- scheduled refetch 중에는 entitlement 확인 중 상태를 유지하고, 재조회 결과 active subscription이면 이전 업로드 제한 상태가 풀리도록 했습니다.
- consumed onboarding + inactive subscription 상태에서 쿨다운 경계 후 ZIP 업로드 init/PUT/complete가 새로고침 없이 진행되는 mocked E2E를 추가했습니다.

## 검증

- `pnpm --dir frontend test -- src/pages/upload/ui/WorkspaceUploadPage.test.tsx --run` (1 file, 4 tests; API/FSD audits passed)
- `pnpm --dir frontend exec eslint src/pages/upload/ui/WorkspaceUploadPage.tsx src/pages/upload/ui/WorkspaceUploadPage.test.tsx e2e/upload-domain-pack-generation.spec.ts`
- `pnpm --dir frontend exec playwright test upload-domain-pack-generation.spec.ts --project=chromium --config=playwright.codex-708.config.ts` (3 passed, 로컬 port 3000이 다른 Next dev server에서 사용 중이라 동일 설정의 임시 3178 preview config로 실행 후 제거)
- `pnpm --dir frontend lint` (API/FSD audits passed 후 이번 변경과 무관한 기존 frontend ESLint baseline 47건으로 실패)
- `git diff --check`
- `git diff --cached --check`
- `git show --check --stat --oneline HEAD`

## 참고

- 구현 전 `WorkspaceUploadPage`, `LogUploadForm`, `useSubscription`, query client 설정, 기존 upload E2E, `app-mocks.ts`, `frontend/DESIGN.md`, frontend FSD/test rules를 확인했습니다.
- spec review 2회 수행: issue fidelity와 Ostone repository compliance 관점에서 확인했고, 파일명/브랜치/affected paths와 검증 기준을 최종 diff에 맞췄습니다.
- self-review 3회 수행: Round 1에서 scheduled refetch 중 entitlement loading 상태를 보강했고, Round 2에서 timer/refetch/E2E mock boundary를 확인했으며, Round 3에서 temporary preview config 제거, validation claim, staged diff 범위, formatting을 확인했습니다.
- 최신 `main` rebase 중 같은 upload E2E spec의 신규 초안 생성 실패 복구 시나리오와 충돌이 있어 해당 시나리오를 유지한 채 쿨다운 시나리오를 병합했고, upload spec 3건을 다시 검증했습니다.
- 기본 Playwright config의 `localhost:3000`은 이 로컬 환경에서 다른 프로젝트 dev server가 점유하고 있어 stock command가 잘못된 서버를 재사용하는 문제가 있었습니다. 동일한 mocked E2E 설정을 `localhost:3178` 임시 config로 실행했고, 임시 config는 최종 diff에서 제거했습니다.
- hook 실패는 repository-wide lint baseline 때문이라 변경 파일 대상 검증을 근거로 hook을 우회해 커밋했습니다.