### PR TITLE
fix(frontend): 대시보드 빈 상태 CTA 흐름을 분리

### DIFF
--- a/.agent/specs/779.md
+++ b/.agent/specs/779.md
@@ -1,0 +1,91 @@
+# 대시보드 빈 상태 CTA 라우팅 정정
+
+## Goal
+
+빈 대시보드의 CTA가 운영자용 워크스페이스 시뮬레이션과 외부 고객용 데모 채팅 미리보기를 명확히 분리해 각각 올바른 화면으로 이동하게 한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A[워크스페이스 대시보드 진입] --> B{운영 데이터 존재?}
+    B -->|있음| C[운영 KPI와 추천 액션 표시]
+    B -->|없음| D[빈 상태 CTA 표시]
+    D --> E[상담 업로드]
+    D --> F[지식팩 검토]
+    D --> G[시뮬레이션 시작]
+    D --> H[고객 화면 미리보기]
+    E --> I[/workspaces/{workspaceId}/upload]
+    F --> J[/workspaces/{workspaceId}/domain-packs]
+    G --> K[/workspaces/{workspaceId}/simulation]
+    H --> L[/demo/chat/{workspaceId}]
+```
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+|------|-------|-------|----------|
+| 빈 상태 시뮬레이션 CTA | `시뮬레이션 시작`이 `/demo/chat/{workspaceId}`로 이동 | `시뮬레이션 시작`이 `/workspaces/{workspaceId}/simulation`으로 이동 | 운영자 검증 플로우와 이동 대상 일치 |
+| 고객 미리보기 CTA | 데모 채팅이 시뮬레이션 CTA에 섞임 | `고객 화면 미리보기` CTA를 별도로 제공 | 외부 고객용 데모 채팅 목적을 분리 |
+| 라우팅 helper | 데모 채팅 path helper만 사용 | 워크스페이스 시뮬레이션 path helper와 데모 채팅 path helper를 구분 | CTA 테스트가 각 helper의 목적을 검증 |
+
+## Component Tree
+
+```text
+WorkspaceDashboardPage
+└─ DashboardStatePanel
+   ├─ 상담 업로드 CTA
+   ├─ 지식팩 검토 CTA
+   ├─ 시뮬레이션 시작 CTA
+   └─ 고객 화면 미리보기 CTA
+```
+
+## API Integration
+
+API contract 변경은 없다. 모든 변경은 클라이언트 라우팅과 CTA 표시 범위에 한정한다.
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx` | modify | 빈 상태 CTA 라벨과 이동 대상을 실제 화면 목적에 맞춘다. |
+| `frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx` | modify | 빈 상태 CTA의 workspace simulation route와 demo chat route를 검증한다. |
+| `frontend/src/shared/lib/demoRoutes.ts` | modify | demo chat path와 workspace simulation path helper를 명확히 구분한다. |
+| `frontend/src/shared/lib/demoRoutes.test.ts` | new | route helper encoding과 query string 보존을 검증한다. |
+
+## State Management
+
+상태 관리 변경은 없다. `DashboardStatePanel`은 기존 `state`와 `workspaceId` props만 사용한다.
+
+## Requirements
+
+1. 빈 대시보드의 `시뮬레이션 시작` CTA는 `/workspaces/{workspaceId}/simulation`으로 이동해야 한다.
+2. 데모 채팅 또는 고객 화면 미리보기는 `시뮬레이션 시작`과 다른 CTA 라벨로 표시해야 한다.
+3. 각 CTA 라벨은 이동 대상 화면의 실제 목적과 일치해야 한다.
+4. route helper는 workspace id가 문자열이어도 안전하게 path를 생성해야 한다.
+5. 기존 로딩, 오류, partial, empty 상태 렌더링 구조는 유지해야 한다.
+
+## Non-goals
+
+- 워크스페이스 시뮬레이션 화면의 기능이나 API를 변경하지 않는다.
+- 데모 채팅 화면의 기능, 인증 정책, URL 스키마를 변경하지 않는다.
+- 대시보드 레이아웃과 디자인 시스템을 새로 설계하지 않는다.
+- backend, database schema, generated API 산출물을 변경하지 않는다.
+
+## Acceptance Criteria
+
+- 빈 대시보드에서 `dashboard-simulation-cta`의 `href`가 `/workspaces/1/simulation`으로 검증된다.
+- 빈 대시보드에서 고객용 데모 채팅 CTA가 별도 라벨과 test id로 표시되고 `/demo/chat/1`로 검증된다.
+- CTA 라벨 `시뮬레이션 시작`과 `고객 화면 미리보기`가 동시에 존재하며 서로 다른 목적의 link로 구분된다.
+- route helper 테스트가 `/workspaces/{workspaceId}/simulation`과 `/demo/chat/{workspaceId}` 생성을 각각 검증한다.
+
+## Validation
+
+- `cd frontend && pnpm test -- WorkspaceDashboardPage.test.tsx demoRoutes.test.ts --run`
+- 필요 시 `cd frontend && pnpm lint`
+
+## Open Questions
+
+- 없음.

--- a/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx
@@ -454,6 +454,18 @@ describe("WorkspaceDashboardPage", () => {
     ).toBeInTheDocument();
     expect(screen.getByTestId("dashboard-simulation-cta")).toHaveAttribute(
       "href",
+      "/workspaces/1/simulation",
+    );
+    expect(
+      screen.getByRole("link", { name: /시뮬레이션 시작/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /고객 화면 미리보기/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("dashboard-customer-preview-cta"),
+    ).toHaveAttribute(
+      "href",
       "/demo/chat/1",
     );
     expect(screen.getByTestId("recommendation-empty")).toHaveTextContent(

--- a/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx
@@ -5,6 +5,7 @@ import {
   CheckCircle2Icon,
   FileUpIcon,
   FlaskConicalIcon,
+  MonitorSmartphoneIcon,
   RefreshCwIcon,
 } from "lucide-react";
 
@@ -22,7 +23,10 @@ import {
   type WorkspaceDashboardActionRecommendations,
 } from "@/features/workspace-dashboard-health/api/workspaceDashboardHealthApi";
 import type { ShellContext } from "@/shared/ui/ostone/chrome";
-import { buildDemoChatPath } from "@/shared/lib/demoRoutes";
+import {
+  buildDemoChatPath,
+  buildWorkspaceSimulationPath,
+} from "@/shared/lib/demoRoutes";
 import { parseRouteId } from "@/shared/lib/parseRouteId";
 import { Button } from "@/shared/ui/button";
 import { NativeSelect, NativeSelectOption } from "@/shared/ui/native-select";
@@ -959,11 +963,20 @@ export function DashboardStatePanel({
         </Button>
         <Button asChild variant="outline">
           <Link
-            to={buildDemoChatPath(workspaceId)}
+            to={buildWorkspaceSimulationPath(workspaceId)}
             data-testid="dashboard-simulation-cta"
           >
             <FlaskConicalIcon aria-hidden="true" />
             시뮬레이션 시작
+          </Link>
+        </Button>
+        <Button asChild variant="outline">
+          <Link
+            to={buildDemoChatPath(workspaceId)}
+            data-testid="dashboard-customer-preview-cta"
+          >
+            <MonitorSmartphoneIcon aria-hidden="true" />
+            고객 화면 미리보기
           </Link>
         </Button>
       </div>

--- a/frontend/src/shared/lib/demoRoutes.test.ts
+++ b/frontend/src/shared/lib/demoRoutes.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { buildDemoChatPath, buildWorkspaceSimulationPath } from "./demoRoutes";
+
+describe("demoRoutes", () => {
+  it("buildWorkspaceSimulationPath가 워크스페이스 시뮬레이션 경로를 만든다", () => {
+    expect(buildWorkspaceSimulationPath(42)).toBe("/workspaces/42/simulation");
+    expect(buildWorkspaceSimulationPath("space key")).toBe(
+      "/workspaces/space%20key/simulation",
+    );
+  });
+
+  it("buildDemoChatPath가 고객용 데모 채팅 경로와 query string을 만든다", () => {
+    expect(buildDemoChatPath(42)).toBe("/demo/chat/42");
+    expect(
+      buildDemoChatPath("space key", new URLSearchParams({ name: "김민지" })),
+    ).toBe("/demo/chat/space%20key?name=%EA%B9%80%EB%AF%BC%EC%A7%80");
+  });
+});

--- a/frontend/src/shared/lib/demoRoutes.test.ts
+++ b/frontend/src/shared/lib/demoRoutes.test.ts
@@ -8,6 +8,9 @@ describe("demoRoutes", () => {
     expect(buildWorkspaceSimulationPath("space key")).toBe(
       "/workspaces/space%20key/simulation",
     );
+    expect(buildWorkspaceSimulationPath("a/b?c&d")).toBe(
+      "/workspaces/a%2Fb%3Fc%26d/simulation",
+    );
   });
 
   it("buildDemoChatPath가 고객용 데모 채팅 경로와 query string을 만든다", () => {

--- a/frontend/src/shared/lib/demoRoutes.ts
+++ b/frontend/src/shared/lib/demoRoutes.ts
@@ -1,3 +1,9 @@
+export function buildWorkspaceSimulationPath(
+  workspaceId: number | string,
+): string {
+  return `/workspaces/${encodeURIComponent(String(workspaceId))}/simulation`;
+}
+
 export function buildDemoChatPath(
   workspaceId: number | string,
   searchParams?: URLSearchParams,


### PR DESCRIPTION
Closes #779

## 변경 사항

- 이슈 779 요구사항과 acceptance criteria를 `.agent/specs/779.md`에 정리했습니다.
- 빈 대시보드의 `시뮬레이션 시작` CTA가 `/workspaces/{workspaceId}/simulation`으로 이동하도록 분리했습니다.
- 외부 고객용 데모 채팅은 `고객 화면 미리보기` CTA로 별도 제공하고 `/demo/chat/{workspaceId}`로 이동하도록 유지했습니다.
- `demoRoutes` helper와 dashboard 테스트를 보강해 workspace simulation route와 demo chat route가 서로 섞이지 않도록 검증합니다.

## 검증

- `pnpm --dir frontend test -- WorkspaceDashboardPage.test.tsx demoRoutes.test.ts --run` (2 files, 9 tests; API/FSD audits passed)
- `pnpm --dir frontend exec eslint src/pages/workspace/ui/WorkspaceDashboardPage.tsx src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx src/shared/lib/demoRoutes.ts src/shared/lib/demoRoutes.test.ts`
- `pnpm --dir frontend exec eslint src/shared/lib/demoRoutes.test.ts`
- `pnpm --dir frontend build` (Vite chunk-size warning만 표시)
- `git diff --check`

## 참고

- 구현 전 issue 779, `WorkspaceDashboardPage`, `demoRoutes`, 기존 dashboard tests, `App.tsx`의 `/workspaces/:workspaceId/simulation` 및 `/demo/chat/:workspaceId` route, `frontend/DESIGN.md`, frontend FSD/test rules를 확인했습니다.
- spec review 2회 수행: issue fidelity와 Ostone repository compliance 관점에서 확인했고, 파일명/브랜치/affected paths와 검증 기준을 최종 diff에 맞췄습니다.
- self-review 3회 수행: Round 1에서 helper test 가독성을 보강했고, Round 2에서 FSD/shared-lib boundary와 route contract를 확인했으며, Round 3에서 staged diff 범위, whitespace, validation claim을 확인했습니다.
- 후속 리뷰 의견으로 workspace id 특수문자 인코딩 테스트를 보강했고, 해당 1-file diff에 대해 3회 self-review와 focused test/ESLint/whitespace check를 다시 수행했습니다.
- `pnpm --dir frontend lint`와 pre-commit hook의 `pnpm run lint:frontend`는 이번 변경과 무관한 기존 frontend ESLint baseline 47건으로 실패합니다. 변경 파일 대상 ESLint, focused unit/build, API/FSD audit, diff whitespace check는 통과했습니다.
- hook 실패는 repository-wide lint baseline 때문이라 변경 파일 대상 검증을 근거로 hook을 우회해 커밋했습니다.