### PR TITLE
fix(frontend): 지식팩 건강도 CTA가 생성 흐름으로 안내

### DIFF
--- a/.agent/specs/781.md
+++ b/.agent/specs/781.md
@@ -1,0 +1,88 @@
+# 지식팩 건강도 CTA 생성/검토 흐름 정합성
+
+## Goal
+
+Knowledge Health 패널의 다음 행동 CTA가 현재 지식팩 상태에 맞는 업로드, 검토, 생성 시작/재시도 화면으로 이동하도록 정리한다.
+
+## Problem
+
+`frontend/src/features/workspace-dashboard-health/model/buildWorkspaceDashboardHealthView.ts`는 생성이 필요한 상태의 CTA를 `/workspaces/{workspaceId}/domain-packs`로 보낸다. 이 경로는 도메인팩 목록 화면이며, 실제 생성 요청을 시작할 수 있는 화면이 아니다. 또한 업로드 기록이 없는 초기 상태에서도 업로드 CTA와 생성 CTA가 함께 노출되어 사용자가 생성 가능한 버튼으로 오해할 수 있다.
+
+## Scope
+
+- `frontend/src/features/workspace-dashboard-health/model/buildWorkspaceDashboardHealthView.ts`의 상태별 CTA 생성 규칙을 정리한다.
+- `frontend/src/features/workspace-dashboard-health/ui/KnowledgePackHealthPanel.tsx`는 기존 CTA view를 그대로 렌더링하되 라벨/목적지가 변경된 view를 표시한다.
+- `frontend/src/features/log-upload/ui/LogUploadForm.tsx`는 `datasetId` query가 있으면 기존 업로드 데이터셋으로 생성 요청을 시작할 수 있는 상태를 표시한다.
+- 상태별 CTA 회귀 테스트를 `frontend/src/features/workspace-dashboard-health/model/buildWorkspaceDashboardHealthView.test.ts`와 관련 UI 테스트에 추가 또는 갱신한다.
+
+## Non-goals
+
+- backend API, database schema, OpenAPI 생성 산출물을 변경하지 않는다.
+- 도메인팩 목록 화면에 새 생성 버튼이나 새 라우트를 추가하지 않는다.
+- 파일 업로드 정책, 구독/온보딩 권한 정책, pipeline review 화면의 동작을 변경하지 않는다.
+- Knowledge Health 패널의 레이아웃과 디자인 토큰을 새로 설계하지 않는다.
+
+## Affected Paths
+
+- `frontend/src/features/workspace-dashboard-health/model/buildWorkspaceDashboardHealthView.ts`
+- `frontend/src/features/workspace-dashboard-health/model/buildWorkspaceDashboardHealthView.test.ts`
+- `frontend/src/features/workspace-dashboard-health/ui/KnowledgePackHealthPanel.tsx`
+- `frontend/src/features/workspace-dashboard-health/ui/KnowledgePackHealthPanel.test.tsx`
+- `frontend/src/features/log-upload/ui/LogUploadForm.tsx`
+- `frontend/src/features/log-upload/ui/LogUploadForm.test.tsx`
+
+## Requirements
+
+1. 업로드 기록이 없으면 Knowledge Health 패널은 업로드 CTA만 제공해야 한다.
+2. 검토 대기 상태이고 `pipelineJobId`가 있으면 CTA는 pipeline review 화면으로 이동해야 한다.
+3. 마지막 생성이 실패했거나 새 업로드가 운영 지식팩에 반영되지 않았거나 업로드는 있으나 생성 기록이 없으면 CTA는 생성 요청을 시작할 수 있는 업로드 화면으로 이동해야 한다.
+4. 생성 시작/재시도 CTA는 대상 `datasetId`를 query로 전달해 사용자가 같은 업로드 데이터셋으로 생성 요청을 시작할 수 있어야 한다.
+5. 생성 시작/재시도에 사용할 `datasetId`를 확인할 수 없으면 생성 CTA를 만들지 않고 업로드 또는 검토 CTA만 표시해야 한다.
+6. CTA 라벨은 도착 흐름과 맞아야 하며 업로드, 검토, 생성 시작/생성 재시도를 혼용하지 않아야 한다.
+7. `LogUploadForm`은 `datasetId` query가 있으면 새 파일 선택 없이 생성 요청 패널을 표시하고 기존 `useTriggerDomainPackGeneration` mutation으로 같은 생성 요청을 수행해야 한다.
+8. `LogUploadForm`에서 다른 파일 업로드를 선택하면 query 기반 생성 대상 상태를 해제하고 일반 업로드 화면으로 돌아갈 수 있어야 한다.
+
+## Data/API Impact
+
+- production API contract 변경은 없다.
+- 생성 요청은 기존 generated hook `useTriggerDomainPackGeneration`을 계속 사용한다.
+- 추가 route는 만들지 않고 기존 `/workspaces/{workspaceId}/upload` route에 `datasetId` query를 사용한다.
+
+## Data Flow
+
+```text
+KnowledgePackHealthPanel
+  -> buildWorkspaceDashboardHealthView(workspaceId, health)
+  -> upload CTA: /workspaces/{workspaceId}/upload
+  -> review CTA: /workspaces/{workspaceId}/pipeline-jobs/{pipelineJobId}/review
+  -> generate CTA: /workspaces/{workspaceId}/upload?datasetId={datasetId}
+  -> LogUploadForm reads datasetId query
+  -> operator clicks domain pack generation start/retry
+  -> useTriggerDomainPackGeneration({ workspaceId, datasetId })
+```
+
+## Tests
+
+| 구분 | 방법 | 도구 |
+| --- | --- | --- |
+| 모델 회귀 | 업로드 없음, 검토 대기, 새 업로드, 생성 실패, 생성 기록 없음 상태별 CTA label/path 검증 | Vitest |
+| 컴포넌트 회귀 | Knowledge Health 패널 link label/href 검증 | Vitest, React Testing Library |
+| 폼 회귀 | `datasetId` query 진입 시 새 파일 없이 생성 버튼 표시 및 mutation payload 검증 | Vitest, React Testing Library |
+
+## Acceptance Criteria
+
+- 업로드 기록이 없는 초기 상태에서 `/domain-packs`로 향하는 생성 CTA가 노출되지 않는다.
+- 검토 대기 상태의 CTA는 `/workspaces/{workspaceId}/pipeline-jobs/{pipelineJobId}/review`로 이동한다.
+- 생성 시작 또는 재시도가 가능한 상태의 CTA는 `/workspaces/{workspaceId}/upload?datasetId={datasetId}`로 이동한다.
+- 생성 실패 상태는 생성 재시도 라벨을 사용하고, 새 업로드 또는 생성 기록 없음 상태는 생성 시작 라벨을 사용한다.
+- `LogUploadForm`은 `datasetId` query로 진입했을 때 업로드 완료 상태를 명확히 보여주고 생성 요청 버튼을 제공한다.
+- 상태별 CTA 생성 테스트가 추가 또는 갱신된다.
+
+## Validation
+
+- `pnpm --dir frontend test -- buildWorkspaceDashboardHealthView.test.ts KnowledgePackHealthPanel.test.tsx LogUploadForm.test.tsx --run`
+- `git diff --check`
+
+## Open Questions
+
+- 없음.

--- a/frontend/src/features/log-upload/ui/LogUploadForm.test.tsx
+++ b/frontend/src/features/log-upload/ui/LogUploadForm.test.tsx
@@ -407,6 +407,59 @@ describe("LogUploadForm", () => {
     expect(screen.queryByText("도메인팩 관리로 이동")).not.toBeInTheDocument();
   });
 
+  it("opens generation controls directly when a dataset id query is provided", () => {
+    render(
+      <MemoryRouter initialEntries={["/workspaces/1/upload?datasetId=42"]}>
+        <LogUploadForm workspaceId={1} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("생성 대상 상담 로그")).toBeInTheDocument();
+    expect(screen.getAllByText(/dataset 42/).length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByText("도메인팩 초안 생성 시작"));
+
+    expect(mockTriggerMutate).toHaveBeenCalledWith({
+      workspaceId: 1,
+      datasetId: 42,
+    });
+  });
+
+  it("blocks dataset query generation when the workspace cannot start generation", () => {
+    render(
+      <MemoryRouter initialEntries={["/workspaces/1/upload?datasetId=42"]}>
+        <LogUploadForm
+          workspaceId={1}
+          freeOnboardingStatus="CONSUMED"
+          hasActiveSubscription={false}
+        />
+      </MemoryRouter>,
+    );
+
+    const generationButton = screen.getByText("도메인팩 초안 생성 시작").closest("button");
+
+    expect(generationButton).toBeDisabled();
+
+    fireEvent.click(screen.getByText("도메인팩 초안 생성 시작"));
+
+    expect(mockTriggerMutate).not.toHaveBeenCalled();
+  });
+
+  it("clears query-backed generation state when uploading another file", () => {
+    render(
+      <MemoryRouter initialEntries={["/workspaces/1/upload?datasetId=42"]}>
+        <LogUploadForm workspaceId={1} />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByText("다른 파일 업로드"));
+
+    expect(mockNavigate).toHaveBeenCalledWith("/workspaces/1/upload", {
+      replace: true,
+    });
+    expect(screen.getByText("파일을 먼저 선택해 주세요.")).toBeInTheDocument();
+  });
+
   it("shows automatic ingestion pipeline status and opens status screen", () => {
     mockIngestionQuery = {
       data: {

--- a/frontend/src/features/log-upload/ui/LogUploadForm.test.tsx
+++ b/frontend/src/features/log-upload/ui/LogUploadForm.test.tsx
@@ -35,6 +35,10 @@ type StartParams = {
   onError: (message: string) => void;
 };
 type TriggerVariables = { workspaceId: number; datasetId: number };
+type TriggerCallbacks = {
+  onSuccess?: (response: unknown, variables: TriggerVariables) => void;
+  onError?: (error: unknown, variables: TriggerVariables) => void;
+};
 
 let startBehavior: "success" | "error" | "pending" = "success";
 let startError = "업로드 실패";
@@ -42,7 +46,11 @@ let lastStartParams: StartParams | null = null;
 let callTriggerOnSuccess:
   | ((response: unknown, variables: TriggerVariables) => void)
   | null = null;
-let callTriggerOnError: ((error: unknown) => void) | null = null;
+let callTriggerOnError:
+  | ((error: unknown, variables: TriggerVariables) => void)
+  | null = null;
+let lastTriggerVariables: TriggerVariables | null = null;
+let lastTriggerCallbacks: TriggerCallbacks | null = null;
 let mockTriggerIsPending = false;
 let mockIngestionQuery = {
   data: { pipelineJob: null },
@@ -89,17 +97,18 @@ vi.mock("../model/useLatestDatasetPipelineJob", () => ({
 vi.mock(
   "../../../shared/api/generated/endpoints/domain-pack-generation-trigger-controller/domain-pack-generation-trigger-controller",
   () => ({
-    useTriggerDomainPackGeneration: (config: {
-      mutation?: {
-        onSuccess?: (response: unknown, variables: TriggerVariables) => void;
-        onError?: (error: unknown) => void;
+    useTriggerDomainPackGeneration: () => {
+      callTriggerOnSuccess = (response: unknown, variables: TriggerVariables) => {
+        lastTriggerCallbacks?.onSuccess?.(response, variables);
       };
-    }) => {
-      callTriggerOnSuccess = config?.mutation?.onSuccess ?? null;
-      callTriggerOnError = config?.mutation?.onError ?? null;
+      callTriggerOnError = (error: unknown, variables: TriggerVariables) => {
+        lastTriggerCallbacks?.onError?.(error, variables);
+      };
       return {
-        mutate: (...args: unknown[]) => {
-          mockTriggerMutate(...args);
+        mutate: (variables: TriggerVariables, callbacks?: TriggerCallbacks) => {
+          lastTriggerVariables = variables;
+          lastTriggerCallbacks = callbacks ?? null;
+          mockTriggerMutate(variables);
         },
         isPending: mockTriggerIsPending,
         reset: mockTriggerReset,
@@ -166,6 +175,8 @@ describe("LogUploadForm", () => {
     lastStartParams = null;
     callTriggerOnSuccess = null;
     callTriggerOnError = null;
+    lastTriggerVariables = null;
+    lastTriggerCallbacks = null;
     mockTriggerIsPending = false;
     mockIngestionQuery = {
       data: { pipelineJob: null },
@@ -460,6 +471,32 @@ describe("LogUploadForm", () => {
     expect(screen.getByText("파일을 먼저 선택해 주세요.")).toBeInTheDocument();
   });
 
+  it("ignores a late generation response after the query-backed dataset is reset", () => {
+    render(
+      <MemoryRouter initialEntries={["/workspaces/1/upload?datasetId=42"]}>
+        <LogUploadForm workspaceId={1} />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByText("도메인팩 초안 생성 시작"));
+
+    expect(lastTriggerVariables).toEqual({ workspaceId: 1, datasetId: 42 });
+
+    fireEvent.click(screen.getByText("다른 파일 업로드"));
+
+    act(() => {
+      callTriggerOnSuccess?.(
+        { pipelineJobId: 11, status: "REQUESTED" },
+        { workspaceId: 1, datasetId: 42 },
+      );
+    });
+
+    expect(screen.queryByText("생성 요청 완료")).not.toBeInTheDocument();
+    expect(vi.mocked(toast.success)).not.toHaveBeenCalledWith(
+      "도메인팩 초안 생성 요청 완료",
+    );
+  });
+
   it("shows automatic ingestion pipeline status and opens status screen", () => {
     mockIngestionQuery = {
       data: {
@@ -619,7 +656,10 @@ describe("LogUploadForm", () => {
     fireEvent.click(screen.getByText("처리 시작"));
     fireEvent.click(screen.getByText("도메인팩 초안 생성 시작"));
     act(() => {
-      callTriggerOnError?.(new Error("Airflow 연결 실패"));
+      callTriggerOnError?.(new Error("Airflow 연결 실패"), {
+        workspaceId: 1,
+        datasetId: 42,
+      });
     });
 
     expect(screen.getByText("생성 요청 실패")).toBeInTheDocument();

--- a/frontend/src/features/log-upload/ui/LogUploadForm.tsx
+++ b/frontend/src/features/log-upload/ui/LogUploadForm.tsx
@@ -62,6 +62,11 @@ interface LogUploadFormProps {
   paidUploadCooldown?: PaidUploadCooldown;
 }
 
+interface GenerationRequestToken {
+  readonly id: number;
+  readonly datasetId: number;
+}
+
 const FREE_ONBOARDING_STATUS_META: Record<
   FreeOnboardingStatus,
   { label: string; copy: string }
@@ -135,6 +140,8 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({
     kind: "idle",
   });
   const generationRequestInFlightRef = useRef(false);
+  const generationRequestIdRef = useRef(0);
+  const activeGenerationRequestRef = useRef<GenerationRequestToken | null>(null);
 
   const queryGenerationDataset =
     generationDatasetId !== null && generationDatasetId !== ignoredGenerationDatasetId
@@ -154,32 +161,20 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({
     "INGESTION",
   );
 
-  const generationMutation = useTriggerDomainPackGeneration({
-    mutation: {
-      onSuccess: (response) => {
-        generationRequestInFlightRef.current = false;
-        setGenerationStatus({
-          kind: "success",
-          ...readGenerationResponse(response),
-        });
-        toast.success("도메인팩 초안 생성 요청 완료");
-      },
-      onError: (error) => {
-        generationRequestInFlightRef.current = false;
-        const message = getErrorMessage(
-          error,
-          "도메인팩 초안 생성 요청에 실패했습니다.",
-        );
-        setGenerationStatus({ kind: "error", message });
-        toast.error(message, {
-          action: {
-            label: "재시도",
-            onClick: () => handleStartGeneration(),
-          },
-        });
-      },
-    },
-  });
+  const generationMutation = useTriggerDomainPackGeneration();
+
+  const clearActiveGenerationRequest = () => {
+    activeGenerationRequestRef.current = null;
+    generationRequestInFlightRef.current = false;
+  };
+
+  const isActiveGenerationRequest = (request: GenerationRequestToken) => {
+    const activeRequest = activeGenerationRequestRef.current;
+    return (
+      activeRequest?.id === request.id &&
+      activeRequest.datasetId === request.datasetId
+    );
+  };
 
   const freeOnboardingMeta = FREE_ONBOARDING_STATUS_META[freeOnboardingStatus];
   const isPaidCooldownBlocked = Boolean(
@@ -218,7 +213,7 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({
     setStatus("idle");
     setUploadedDataset(null);
     setGenerationStatus({ kind: "idle" });
-    generationRequestInFlightRef.current = false;
+    clearActiveGenerationRequest();
     rawFileUpload.reset();
     generationMutation.reset();
   };
@@ -241,7 +236,7 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({
           fileName: fileToUpload.name,
         });
         setGenerationStatus({ kind: "idle" });
-        generationRequestInFlightRef.current = false;
+        clearActiveGenerationRequest();
         setStatus("success");
         toast.success("업로드 완료");
       },
@@ -249,7 +244,7 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({
         setStatus("idle");
         setUploadedDataset(null);
         setGenerationStatus({ kind: "idle" });
-        generationRequestInFlightRef.current = false;
+        clearActiveGenerationRequest();
         toast.error(message, {
           action: {
             label: "재시도",
@@ -263,6 +258,7 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({
   const handleCancelUpload = () => {
     rawFileUpload.cancel();
     setStatus("idle");
+    clearActiveGenerationRequest();
   };
 
   function handleStartGeneration() {
@@ -280,12 +276,50 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({
       return;
     }
 
+    const generationRequest = {
+      id: generationRequestIdRef.current + 1,
+      datasetId: activeUploadedDataset.datasetId,
+    };
+    generationRequestIdRef.current = generationRequest.id;
+    activeGenerationRequestRef.current = generationRequest;
     generationRequestInFlightRef.current = true;
     setGenerationStatus({ kind: "triggering" });
-    generationMutation.mutate({
-      workspaceId,
-      datasetId: activeUploadedDataset.datasetId,
-    });
+    generationMutation.mutate(
+      {
+        workspaceId,
+        datasetId: activeUploadedDataset.datasetId,
+      },
+      {
+        onSuccess: (response) => {
+          if (!isActiveGenerationRequest(generationRequest)) {
+            return;
+          }
+          clearActiveGenerationRequest();
+          setGenerationStatus({
+            kind: "success",
+            ...readGenerationResponse(response),
+          });
+          toast.success("도메인팩 초안 생성 요청 완료");
+        },
+        onError: (error) => {
+          if (!isActiveGenerationRequest(generationRequest)) {
+            return;
+          }
+          clearActiveGenerationRequest();
+          const message = getErrorMessage(
+            error,
+            "도메인팩 초안 생성 요청에 실패했습니다.",
+          );
+          setGenerationStatus({ kind: "error", message });
+          toast.error(message, {
+            action: {
+              label: "재시도",
+              onClick: () => handleStartGeneration(),
+            },
+          });
+        },
+      },
+    );
   }
 
   const handleReset = () => {
@@ -295,7 +329,7 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({
     setUploadedDataset(null);
     setStatus("idle");
     setGenerationStatus({ kind: "idle" });
-    generationRequestInFlightRef.current = false;
+    clearActiveGenerationRequest();
     setIgnoredGenerationDatasetId(generationDatasetId);
     if (generationDatasetId !== null && workspaceId != null) {
       navigate(`/workspaces/${workspaceId}/upload`, { replace: true });

--- a/frontend/src/features/log-upload/ui/LogUploadForm.tsx
+++ b/frontend/src/features/log-upload/ui/LogUploadForm.tsx
@@ -1,6 +1,6 @@
 import React, { useId, useRef, useState } from "react";
 import { toast } from "sonner";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 
 import { FileUploader } from "../../../shared/ui/file-upload/FileUploader";
 import { Button } from "../../../shared/ui/button/Button";
@@ -18,6 +18,7 @@ import {
   RAW_LOG_UPLOAD_MAX_SIZE_LABEL,
   validateRawLogUploadFile,
 } from "../../../shared/lib/rawLogUploadPolicy";
+import { parseRouteId } from "../../../shared/lib/parseRouteId";
 import { useRawFileUpload } from "../model/useRawFileUpload";
 import { useLatestDatasetPipelineJob } from "../model/useLatestDatasetPipelineJob";
 
@@ -120,20 +121,36 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({
   paidUploadCooldown,
 }) => {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const generationDatasetId = parseRouteId(searchParams.get("datasetId") ?? undefined);
   const fileRequiredMessageId = useId();
   const [file, setFile] = useState<File | null>(null);
   const [status, setStatus] = useState<UploadStatus>("idle");
   const [uploadedDataset, setUploadedDataset] =
     useState<UploadedDataset | null>(null);
+  const [ignoredGenerationDatasetId, setIgnoredGenerationDatasetId] = useState<
+    number | null
+  >(null);
   const [generationStatus, setGenerationStatus] = useState<GenerationStatus>({
     kind: "idle",
   });
   const generationRequestInFlightRef = useRef(false);
 
+  const queryGenerationDataset =
+    generationDatasetId !== null && generationDatasetId !== ignoredGenerationDatasetId
+      ? {
+          datasetId: generationDatasetId,
+          fileName: `dataset ${generationDatasetId}`,
+        }
+      : null;
+  const activeUploadedDataset = uploadedDataset ?? queryGenerationDataset;
+  const displayStatus: UploadStatus =
+    status === "idle" && queryGenerationDataset ? "success" : status;
+
   const rawFileUpload = useRawFileUpload();
   const ingestionJobQuery = useLatestDatasetPipelineJob(
     workspaceId,
-    uploadedDataset?.datasetId,
+    activeUploadedDataset?.datasetId,
     "INGESTION",
   );
 
@@ -197,6 +214,7 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({
       return;
     }
     setFile(selectedFile);
+    setIgnoredGenerationDatasetId(generationDatasetId);
     setStatus("idle");
     setUploadedDataset(null);
     setGenerationStatus({ kind: "idle" });
@@ -248,7 +266,13 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({
   };
 
   function handleStartGeneration() {
-    if (!workspaceId || !uploadedDataset?.datasetId) {
+    if (isUploaderDisabled) {
+      toast.error(
+        isEntitlementLoading ? "업로드 가능 여부를 확인 중입니다." : blockedMessage,
+      );
+      return;
+    }
+    if (!workspaceId || !activeUploadedDataset?.datasetId) {
       toast.error("생성 요청에 필요한 데이터셋 정보를 확인할 수 없습니다.");
       return;
     }
@@ -260,7 +284,7 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({
     setGenerationStatus({ kind: "triggering" });
     generationMutation.mutate({
       workspaceId,
-      datasetId: uploadedDataset.datasetId,
+      datasetId: activeUploadedDataset.datasetId,
     });
   }
 
@@ -272,6 +296,10 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({
     setStatus("idle");
     setGenerationStatus({ kind: "idle" });
     generationRequestInFlightRef.current = false;
+    setIgnoredGenerationDatasetId(generationDatasetId);
+    if (generationDatasetId !== null && workspaceId != null) {
+      navigate(`/workspaces/${workspaceId}/upload`, { replace: true });
+    }
   };
 
   const domainPacksPath = workspaceId
@@ -288,14 +316,15 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({
     workspaceId != null && ingestionJob != null
       ? `/workspaces/${workspaceId}/pipeline-jobs/${ingestionJob.pipelineJobId}/review`
       : null;
-  const canStartGeneration = Boolean(uploadedDataset?.datasetId);
+  const canStartGeneration = Boolean(activeUploadedDataset?.datasetId) && !isUploaderDisabled;
   const isGenerationPending =
     generationStatus.kind === "triggering" || generationMutation.isPending;
+  const isDashboardGenerationTarget =
+    queryGenerationDataset !== null && uploadedDataset === null;
   const shouldShowManualGenerationFallback =
     generationStatus.kind === "idle" &&
-    !ingestionJob &&
-    !ingestionJobQuery.isLoading &&
-    !ingestionJobQuery.isError;
+    (isDashboardGenerationTarget ||
+      (!ingestionJob && !ingestionJobQuery.isLoading && !ingestionJobQuery.isError));
   const handleIngestionRefresh = () => {
     ingestionJobQuery.refetch();
   };
@@ -351,7 +380,7 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({
         />
       </div>
 
-      {status === "idle" && (
+      {displayStatus === "idle" && (
         <div
           className={`${styles.filePreview} ${file ? "" : styles.emptyFilePreview}`}
         >
@@ -384,30 +413,34 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({
         </div>
       )}
 
-      {status === "success" && (
+      {displayStatus === "success" && (
         <div className={styles.afterUpload}>
           <div className={styles.uploadSummary}>
-            <span className={styles.statusLabel}>업로드 완료</span>
-            <strong>{uploadedDataset?.fileName ?? file?.name}</strong>
+            <span className={styles.statusLabel}>
+              {isDashboardGenerationTarget ? "생성 대상 상담 로그" : "업로드 완료"}
+            </span>
+            <strong>{activeUploadedDataset?.fileName ?? file?.name}</strong>
             <span>
-              {uploadedDataset?.datasetId
-                ? `dataset ${uploadedDataset.datasetId}`
+              {activeUploadedDataset?.datasetId
+                ? `dataset ${activeUploadedDataset.datasetId}`
                 : "데이터셋 ID 확인 필요"}
             </span>
           </div>
 
-          <PipelineJobStatusPanel
-            queryState={{
-              isLoading: ingestionJobQuery.isLoading,
-              isError: ingestionJobQuery.isError,
-              isFetching: ingestionJobQuery.isFetching,
-            }}
-            job={ingestionJob}
-            reviewPath={ingestionReviewPath}
-            onRefresh={handleIngestionRefresh}
-            onReset={handleReset}
-            onNavigate={navigate}
-          />
+          {!isDashboardGenerationTarget && (
+            <PipelineJobStatusPanel
+              queryState={{
+                isLoading: ingestionJobQuery.isLoading,
+                isError: ingestionJobQuery.isError,
+                isFetching: ingestionJobQuery.isFetching,
+              }}
+              job={ingestionJob}
+              reviewPath={ingestionReviewPath}
+              onRefresh={handleIngestionRefresh}
+              onReset={handleReset}
+              onNavigate={navigate}
+            />
+          )}
 
           {shouldShowManualGenerationFallback && (
             <div className={styles.generationPanel}>

--- a/frontend/src/features/workspace-dashboard-health/model/buildWorkspaceDashboardHealthView.test.ts
+++ b/frontend/src/features/workspace-dashboard-health/model/buildWorkspaceDashboardHealthView.test.ts
@@ -39,7 +39,7 @@ describe("buildWorkspaceDashboardHealthView", () => {
     expect(view.metrics.find((metric) => metric.label === "운영 지식팩")?.value).toBe("v4");
   });
 
-  it("새 로그, 검토 대기, 생성 실패를 경고와 CTA로 변환한다", () => {
+  it("검토 대기 중이면 pipeline review CTA만 제공한다", () => {
     const view = buildWorkspaceDashboardHealthView(1, {
       activeKnowledgePack: {
         packId: 11,
@@ -68,22 +68,121 @@ describe("buildWorkspaceDashboardHealthView", () => {
       pendingReviewCount: 2,
     });
 
-    expect(view.alerts.map((alert) => alert.title)).toEqual(
-      expect.arrayContaining([
-        "새 상담 로그가 운영 지식팩에 아직 반영되지 않았습니다.",
-        "검토 대기 항목 2개가 남아 있습니다.",
-        "최근 지식팩 생성이 실패했습니다.",
-      ]),
+    expect(view.alerts.map((alert) => alert.title)).toContain(
+      "검토 대기 항목 2개가 남아 있습니다.",
     );
-    expect(view.ctas).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          kind: "review",
-          to: "/workspaces/1/pipeline-jobs/77/review",
-        }),
-        expect.objectContaining({ kind: "generate", to: "/workspaces/1/domain-packs" }),
-      ]),
+    expect(view.ctas).toEqual([
+      {
+        kind: "review",
+        label: "검토 화면으로 이동",
+        to: "/workspaces/1/pipeline-jobs/77/review",
+      },
+    ]);
+  });
+
+  it("새 업로드가 있으면 해당 데이터셋으로 지식팩 생성 시작 CTA를 만든다", () => {
+    const view = buildWorkspaceDashboardHealthView(1, {
+      activeKnowledgePack: {
+        packId: 11,
+        packName: "CS Pack",
+        versionId: 12,
+        versionNo: 4,
+        publishedAt: "2026-06-01T10:00:00Z",
+        createdAt: "2026-06-01T09:00:00Z",
+      },
+      lastLogUpload: {
+        datasetId: 8,
+        datasetKey: "june-log",
+        datasetName: "6월 상담 로그",
+        datasetStatus: "READY",
+        uploadedAt: "2026-06-03T09:00:00Z",
+      },
+      lastKnowledgePackGeneration: {
+        pipelineJobId: 77,
+        datasetId: 7,
+        domainPackId: 11,
+        status: "SUCCEEDED",
+        requestedAt: "2026-06-01T09:10:00Z",
+        startedAt: "2026-06-01T09:11:00Z",
+        finishedAt: "2026-06-01T09:30:00Z",
+      },
+      pendingReviewCount: 0,
+    });
+
+    expect(view.alerts.map((alert) => alert.title)).toContain(
+      "새 상담 로그가 운영 지식팩에 아직 반영되지 않았습니다.",
     );
+    expect(view.ctas).toEqual([
+      {
+        kind: "generate",
+        label: "지식팩 생성 시작",
+        to: "/workspaces/1/upload?datasetId=8",
+      },
+    ]);
+  });
+
+  it("생성 실패 상태이면 실패한 생성 데이터셋으로 재시도 CTA를 만든다", () => {
+    const view = buildWorkspaceDashboardHealthView(1, {
+      activeKnowledgePack: {
+        packId: 11,
+        packName: "CS Pack",
+        versionId: 12,
+        versionNo: 4,
+        publishedAt: "2026-06-01T10:00:00Z",
+        createdAt: "2026-06-01T09:00:00Z",
+      },
+      lastLogUpload: {
+        datasetId: 8,
+        datasetKey: "june-log",
+        datasetName: "6월 상담 로그",
+        datasetStatus: "READY",
+        uploadedAt: "2026-06-03T09:00:00Z",
+      },
+      lastKnowledgePackGeneration: {
+        pipelineJobId: 77,
+        datasetId: 8,
+        domainPackId: 11,
+        status: "FAILED",
+        requestedAt: "2026-06-03T09:10:00Z",
+        startedAt: "2026-06-03T09:11:00Z",
+        finishedAt: "2026-06-03T09:30:00Z",
+      },
+      pendingReviewCount: 0,
+    });
+
+    expect(view.alerts.map((alert) => alert.title)).toContain(
+      "최근 지식팩 생성이 실패했습니다.",
+    );
+    expect(view.ctas).toEqual([
+      {
+        kind: "generate",
+        label: "지식팩 생성 재시도",
+        to: "/workspaces/1/upload?datasetId=8",
+      },
+    ]);
+  });
+
+  it("업로드는 있지만 생성 기록이 없으면 업로드 데이터셋으로 생성 시작 CTA를 만든다", () => {
+    const view = buildWorkspaceDashboardHealthView(2, {
+      activeKnowledgePack: null,
+      lastLogUpload: {
+        datasetId: 15,
+        datasetKey: "first-log",
+        datasetName: "첫 상담 로그",
+        datasetStatus: "READY",
+        uploadedAt: "2026-06-03T09:00:00Z",
+      },
+      lastKnowledgePackGeneration: null,
+      pendingReviewCount: 0,
+    });
+
+    expect(view.ctas).toEqual([
+      {
+        kind: "generate",
+        label: "지식팩 생성 시작",
+        to: "/workspaces/2/upload?datasetId=15",
+      },
+    ]);
   });
 
   it("업로드와 운영 지식팩이 없으면 초기 행동을 제안한다", () => {
@@ -99,8 +198,7 @@ describe("buildWorkspaceDashboardHealthView", () => {
       "상담 로그 업로드 기록이 없습니다.",
     ]);
     expect(view.ctas).toEqual([
-      { kind: "upload", label: "상담 업로드", to: "/workspaces/3/upload" },
-      { kind: "generate", label: "지식팩 생성", to: "/workspaces/3/domain-packs" },
+      { kind: "upload", label: "상담 로그 업로드", to: "/workspaces/3/upload" },
     ]);
   });
 });

--- a/frontend/src/features/workspace-dashboard-health/model/buildWorkspaceDashboardHealthView.ts
+++ b/frontend/src/features/workspace-dashboard-health/model/buildWorkspaceDashboardHealthView.ts
@@ -1,5 +1,10 @@
 import type { WorkspaceDashboardHealth } from "../api/workspaceDashboardHealthApi";
-import { CTA_GO_REVIEW, CTA_UPLOAD_LOGS } from "@/shared/lib/ctaLabels";
+import {
+  CTA_GO_REVIEW,
+  CTA_RETRY_GENERATION,
+  CTA_START_GENERATION,
+  CTA_UPLOAD_LOGS,
+} from "@/shared/lib/ctaLabels";
 
 export type HealthTone = "normal" | "warning" | "danger";
 export type HealthCtaKind = "upload" | "review" | "generate";
@@ -119,7 +124,7 @@ export function buildWorkspaceDashboardHealthView(
   } else if (canStartGeneration) {
     ctas.push({
       kind: "generate",
-      label: isGenerationFailed ? "지식팩 생성 재시도" : "지식팩 생성 시작",
+      label: isGenerationFailed ? CTA_RETRY_GENERATION : CTA_START_GENERATION,
       to: `/workspaces/${workspaceId}/upload?datasetId=${generationDatasetId}`,
     });
   }

--- a/frontend/src/features/workspace-dashboard-health/model/buildWorkspaceDashboardHealthView.ts
+++ b/frontend/src/features/workspace-dashboard-health/model/buildWorkspaceDashboardHealthView.ts
@@ -1,4 +1,5 @@
 import type { WorkspaceDashboardHealth } from "../api/workspaceDashboardHealthApi";
+import { CTA_GO_REVIEW, CTA_UPLOAD_LOGS } from "@/shared/lib/ctaLabels";
 
 export type HealthTone = "normal" | "warning" | "danger";
 export type HealthCtaKind = "upload" | "review" | "generate";
@@ -55,6 +56,15 @@ export function buildWorkspaceDashboardHealthView(
     activePack?.publishedAt && lastUpload?.uploadedAt
       ? new Date(lastUpload.uploadedAt).getTime() > new Date(activePack.publishedAt).getTime()
       : false;
+  const generationDatasetId = isGenerationFailed
+    ? (lastGeneration?.datasetId ?? lastUpload?.datasetId ?? null)
+    : (lastUpload?.datasetId ?? lastGeneration?.datasetId ?? null);
+  const canStartGeneration =
+    Boolean(lastUpload) &&
+    !isReviewWaiting &&
+    !isGenerationRunning &&
+    generationDatasetId != null &&
+    (!activePack || hasNewerUpload || isGenerationFailed || !lastGeneration);
 
   const alerts: HealthAlertView[] = [];
   if (!activePack) {
@@ -97,22 +107,20 @@ export function buildWorkspaceDashboardHealthView(
   if (!lastUpload) {
     ctas.push({
       kind: "upload",
-      label: "상담 업로드",
+      label: CTA_UPLOAD_LOGS,
       to: `/workspaces/${workspaceId}/upload`,
     });
-  }
-  if (isReviewWaiting && lastGeneration?.pipelineJobId) {
+  } else if (isReviewWaiting && lastGeneration?.pipelineJobId) {
     ctas.push({
       kind: "review",
-      label: "검토 화면으로 이동",
+      label: CTA_GO_REVIEW,
       to: `/workspaces/${workspaceId}/pipeline-jobs/${lastGeneration.pipelineJobId}/review`,
     });
-  }
-  if (!activePack || hasNewerUpload || isGenerationFailed || (lastUpload && !lastGeneration)) {
+  } else if (canStartGeneration) {
     ctas.push({
       kind: "generate",
-      label: "지식팩 생성",
-      to: `/workspaces/${workspaceId}/domain-packs`,
+      label: isGenerationFailed ? "지식팩 생성 재시도" : "지식팩 생성 시작",
+      to: `/workspaces/${workspaceId}/upload?datasetId=${generationDatasetId}`,
     });
   }
 

--- a/frontend/src/features/workspace-dashboard-health/ui/KnowledgePackHealthPanel.test.tsx
+++ b/frontend/src/features/workspace-dashboard-health/ui/KnowledgePackHealthPanel.test.tsx
@@ -66,6 +66,47 @@ describe("KnowledgePackHealthPanel", () => {
     );
   });
 
+  it("생성 가능한 상태에서는 업로드 화면의 데이터셋 생성 상태로 이동한다", () => {
+    mockedUseWorkspaceDashboardHealth.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        activeKnowledgePack: {
+          packId: 11,
+          packName: "CS Pack",
+          versionId: 12,
+          versionNo: 4,
+          publishedAt: "2026-06-01T10:00:00Z",
+          createdAt: "2026-06-01T09:00:00Z",
+        },
+        lastLogUpload: {
+          datasetId: 8,
+          datasetKey: "june-log",
+          datasetName: "6월 상담 로그",
+          datasetStatus: "READY",
+          uploadedAt: "2026-06-03T09:00:00Z",
+        },
+        lastKnowledgePackGeneration: {
+          pipelineJobId: 77,
+          datasetId: 7,
+          domainPackId: 11,
+          status: "SUCCEEDED",
+          requestedAt: "2026-06-01T09:10:00Z",
+          finishedAt: "2026-06-01T09:30:00Z",
+        },
+        pendingReviewCount: 0,
+      },
+    } as ReturnType<typeof useWorkspaceDashboardHealth>);
+
+    renderPanel();
+
+    expect(screen.getByRole("link", { name: /지식팩 생성 시작/ })).toHaveAttribute(
+      "href",
+      "/workspaces/1/upload?datasetId=8",
+    );
+    expect(screen.queryByRole("link", { name: /도메인팩 관리/ })).not.toBeInTheDocument();
+  });
+
   it("error 상태에서는 stale 운영 상태 대신 재시도 가능한 오류 상태만 표시한다", () => {
     const refetch = vi.fn();
     mockedUseWorkspaceDashboardHealth.mockReturnValue({

--- a/frontend/src/shared/lib/ctaLabels.ts
+++ b/frontend/src/shared/lib/ctaLabels.ts
@@ -15,6 +15,12 @@ export const CTA_GO_DOMAIN_PACK = "도메인팩 관리로 이동";
 /** 상담 로그 업로드 화면으로 이동 */
 export const CTA_UPLOAD_LOGS = "상담 로그 업로드";
 
+/** 업로드된 상담 로그로 도메인팩 생성을 시작 */
+export const CTA_START_GENERATION = "지식팩 생성 시작";
+
+/** 실패한 도메인팩 생성 요청을 재시도 */
+export const CTA_RETRY_GENERATION = "지식팩 생성 재시도";
+
 /** 현재 업로드 흐름을 초기화하고 다른 파일을 올린다 */
 export const CTA_UPLOAD_AGAIN = "다른 파일 업로드";
 


### PR DESCRIPTION
Closes #781

## 변경 사항

- 이슈 781 요구사항과 acceptance criteria를 `.agent/specs/781.md`에 정리했습니다.
- Knowledge Health 패널의 다음 행동 CTA를 업로드 없음, 검토 대기, 생성 시작, 생성 재시도 상태별로 하나의 명확한 흐름만 안내하도록 정리했습니다.
- 생성 시작/재시도 CTA가 도메인팩 목록이 아니라 `/workspaces/{workspaceId}/upload?datasetId={datasetId}`로 이동해 실제 생성 요청을 시작할 수 있게 했습니다.
- upload 화면이 `datasetId` query로 진입하면 새 파일 업로드 없이 해당 데이터셋의 도메인팩 초안 생성 요청 패널을 표시하고, 권한/쿨다운 차단 상태에서는 생성 요청도 비활성화합니다.
- 생성 요청 후 사용자가 다른 파일 업로드나 초기화로 세션을 바꾼 경우, 늦게 도착한 이전 생성 응답은 현재 화면 상태를 갱신하지 않도록 했습니다.

## 검증

- `pnpm --dir frontend test -- buildWorkspaceDashboardHealthView.test.ts KnowledgePackHealthPanel.test.tsx LogUploadForm.test.tsx --run` (3 files, 38 tests; API/FSD audits passed)
- `pnpm --dir frontend exec eslint src/shared/lib/ctaLabels.ts src/features/workspace-dashboard-health/model/buildWorkspaceDashboardHealthView.ts src/features/workspace-dashboard-health/model/buildWorkspaceDashboardHealthView.test.ts src/features/workspace-dashboard-health/ui/KnowledgePackHealthPanel.test.tsx src/features/log-upload/ui/LogUploadForm.tsx src/features/log-upload/ui/LogUploadForm.test.tsx`
- `pnpm --dir frontend build`
- `git diff --check`
- `git show --check --stat --oneline HEAD`

## 참고

- 구현 전 issue 781, `buildWorkspaceDashboardHealthView`, `KnowledgePackHealthPanel`, `LogUploadForm`, 기존 upload/status tests, `frontend/DESIGN.md`, frontend FSD/test/code-review rules를 확인했습니다.
- spec review 2회 수행: issue fidelity 관점에서 업로드/검토/생성/재시도 CTA 요구사항을 매핑했고, repository compliance 관점에서 파일명/브랜치/affected paths와 검증 기준을 최종 diff에 맞췄습니다.
- 최초 self-review 3회 수행: Round 1에서 dataset query 진입 시 권한/쿨다운 우회 가능성을 막았고, Round 2에서 effect 기반 query sync를 React hook lint에 맞는 derived state로 바꿨으며, Round 3에서 생성 기록 없음과 query reset 회귀 테스트를 보강했습니다.
- CodeRabbit 리뷰 후 follow-up self-review 3회 수행: Round 1에서 late generation response가 현재 세션을 덮어쓰는 문제를 request token으로 차단했고, Round 2에서 생성 CTA 라벨 상수화를 반영했으며, Round 3에서 stale response 회귀 테스트와 focused 검증을 재수행했습니다.
- `pnpm --dir frontend lint`는 API/FSD audit 통과 후 이번 변경과 무관한 기존 frontend ESLint baseline 47건으로 실패합니다. 변경 파일 대상 ESLint, focused unit/build, diff checks는 통과했습니다.
- pre-commit hook은 repository-wide lint baseline 때문에 우회했습니다.