### PR TITLE
fix(frontend): 대시보드 집계 필터 조건을 보장

### DIFF
--- a/.agent/specs/782.md
+++ b/.agent/specs/782.md
@@ -1,0 +1,123 @@
+# Frontend Spec: 대시보드 집계 필터 요청 반영
+
+## Goal
+
+대시보드에서 사용자가 조작할 수 있는 필터와 실제 집계 API 요청 조건을 일치시켜, 표시된 운영 조건과 metrics, recommendations, workflow rankings 데이터가 서로 어긋나지 않게 한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["워크스페이스 대시보드 진입"] --> B["기간 필터 선택"]
+    B --> C{"사용자 지정 기간?"}
+    C -->|No| D["선택 기간의 from/to 계산"]
+    C -->|Yes| E{"시작일과 종료일 입력 완료?"}
+    E -->|No| F["집계 요청 보류"]
+    E -->|Yes| D
+    D --> G["metrics 요청"]
+    D --> H["recommendations 요청"]
+    D --> I["workflow rankings 요청"]
+    G --> J["동일 조건의 대시보드 표시"]
+    H --> J
+    I --> J
+```
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+| --- | --- | --- | --- |
+| 기간 필터 | 기간 조건이 집계 요청에 전달됨 | 유지 | `from`, `to`를 세 집계 요청에 동일하게 전달한다. |
+| 운영 지식팩 버전 필터 | UI에 노출되지만 집계 API가 지원하지 않음 | 숨김 | 백엔드와 generated OpenAPI가 지원하지 않는 필터를 조작 가능한 UI에서 제거한다. |
+| Channel 필터 | UI에 노출되지만 집계 API가 지원하지 않음 | 숨김 | 백엔드와 generated OpenAPI가 지원하지 않는 필터를 조작 가능한 UI에서 제거한다. |
+| Workflow Status 필터 | UI에 노출되지만 집계 API가 지원하지 않음 | 숨김 | 백엔드와 generated OpenAPI가 지원하지 않는 필터를 조작 가능한 UI에서 제거한다. |
+| 테스트 | 일부 테스트가 unsupported 필터 선택 후에도 기간 요청만 검증함 | 지원 필터 기준 검증 | 보이는 필터가 실제 요청 URL에 반영되는지 검증한다. |
+
+## Component Tree
+
+```text
+WorkspaceDashboardPage
+├─ DashboardFilters
+│  ├─ 기간 segmented buttons
+│  └─ 사용자 지정 시작일/종료일 input
+├─ FilterSummary
+├─ ActionRecommendationsPanel
+├─ DashboardMetricsGrid
+├─ AutomationCoveragePanel
+├─ KnowledgePackHealthPanel
+└─ HotpathWorkflowRankingPanel
+```
+
+## API Integration
+
+### Endpoints
+
+| Method | Path | 지원 query | 비고 |
+| --- | --- | --- | --- |
+| GET | `/api/v1/workspaces/{workspaceId}/consultation/metrics` | `from`, `to` | generated `GetMetricsParams`도 `from`, `to`만 노출한다. |
+| GET | `/api/v1/workspaces/{workspaceId}/dashboard/action-recommendations` | `from`, `to` | generated `GetActionRecommendationsParams`도 `from`, `to`만 노출한다. |
+| GET | `/api/v1/workspaces/{workspaceId}/dashboard/workflow-rankings` | `from`, `to` | generated `GetWorkflowRankingsParams`도 `from`, `to`만 노출한다. |
+
+### Query Key / Request Pattern
+
+대시보드 페이지는 `buildMetricDateRange(filters)`로 계산한 동일 `from`, `to` 객체를 아래 호출에 전달한다.
+
+```typescript
+consultationApi.getMetrics(workspaceId, metricDateRange);
+fetchWorkspaceDashboardActionRecommendations(workspaceId, metricDateRange);
+consultationApi.getWorkflowRankings(workspaceId, metricDateRange);
+```
+
+## Data Flow
+
+```text
+DashboardFilters(period/custom dates)
+  -> buildMetricDateRange
+  -> metrics / action recommendations / workflow rankings
+  -> panels render same operating period
+```
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+| --- | --- | --- |
+| `frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx` | update | 지원되는 기간 필터만 노출하고 summary를 실제 요청 조건과 일치시킨다. |
+| `frontend/src/pages/workspace/ui/workspace-dashboard-page.module.css` | update | 필터 레이아웃이 기간 전용 UI에 맞게 안정적으로 보이도록 조정한다. |
+| `frontend/src/features/consultation/api/consultationApi.ts` | update | metrics, workflow rankings, bottleneck analysis read를 generated endpoint wrapper 경유로 유지한다. |
+| `frontend/src/features/workspace-dashboard-health/api/workspaceDashboardHealthApi.ts` | update | dashboard health, action recommendations read를 generated endpoint wrapper 경유로 유지한다. |
+| `frontend/scripts/manual-api-call-allowlist.json` | update | generated endpoint 전환으로 더 이상 필요하지 않은 dashboard manual API allowlist를 제거한다. |
+| `frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx` | update | 노출 필터와 세 집계 요청 파라미터를 검증한다. |
+| `frontend/src/features/consultation/api/consultationApi.test.ts` | existing verification | metrics, workflow rankings URL query 검증을 유지한다. |
+| `frontend/src/features/workspace-dashboard-health/api/workspaceDashboardHealthApi.test.ts` | existing verification | recommendations URL query 검증을 유지한다. |
+
+## State Management
+
+대시보드 필터 상태는 페이지 내부 `useState`로 유지한다. 서버 상태 캐시 구조는 새로 도입하지 않는다. 사용자 지정 기간에서 `from`, `to`가 모두 입력되지 않은 경우 기존처럼 집계 요청을 보류한다.
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+| --- | --- | --- | --- |
+| 단위/통합 테스트 | 대시보드 페이지 mock API 호출 검증 | Vitest + Testing Library | 기간 변경 시 세 집계 호출이 같은 params를 받는지 확인한다. |
+| API wrapper 테스트 | request URL query 검증 | Vitest | `from`, `to`가 실제 URL query로 직렬화되는지 확인한다. |
+| 정적 검사 | frontend lint/type/build 범위 | pnpm/vp | 변경 범위에 맞는 실행 가능한 명령을 선택한다. |
+
+### Acceptance Criteria
+
+- 지원되는 기간 필터는 `from`, `to` query parameter로 세 집계 요청에 전달된다.
+- 백엔드가 아직 지원하지 않는 운영 지식팩 버전, Channel, Workflow Status 필터는 조작 가능한 UI에서 노출하지 않는다.
+- 기간 변경 시 metrics, recommendations, workflow rankings가 동일 조건으로 갱신된다.
+- 테스트에서 필터별 요청 URL 또는 API 호출 params를 검증한다.
+
+## Non-goals
+
+- 백엔드에 운영 지식팩 버전, Channel, Workflow Status 집계 필터를 새로 추가하지 않는다.
+- generated OpenAPI 파일을 직접 수정하지 않는다.
+- 대시보드 집계 로직이나 응답 스키마를 변경하지 않는다.
+
+## Open Questions
+
+- 운영 지식팩 버전, Channel, Workflow Status를 실제 집계 조건으로 지원할 백엔드 API 확장은 별도 이슈에서 다룬다.

--- a/.agent/specs/782.md
+++ b/.agent/specs/782.md
@@ -105,7 +105,7 @@ DashboardFilters(period/custom dates)
 | 단위/통합 테스트 | 대시보드 페이지 mock API 호출 검증 | Vitest + Testing Library | 기간 변경 시 세 집계 호출이 같은 params를 받는지 확인한다. |
 | API wrapper 테스트 | request URL query 검증 | Vitest | `from`, `to`가 실제 URL query로 직렬화되는지 확인한다. |
 | E2E 테스트 | 대시보드 필터 조작 및 API request 관찰 | Playwright | 지원 기간 필터만 조작 가능하고 세 집계 URL이 같은 기간 조건으로 요청되는지 확인한다. |
-| 정적 검사 | frontend lint/type/build 범위 | pnpm/vp | 변경 범위에 맞는 실행 가능한 명령을 선택한다. |
+| 정적 검사 | frontend lint/type/build 범위 | `pnpm --dir frontend test`, `pnpm --dir frontend exec eslint`, `pnpm --dir frontend build` | 변경 범위에 맞는 실행 가능한 명령을 선택한다. |
 
 ### Acceptance Criteria
 

--- a/.agent/specs/782.md
+++ b/.agent/specs/782.md
@@ -88,6 +88,7 @@ DashboardFilters(period/custom dates)
 | `frontend/src/features/workspace-dashboard-health/api/workspaceDashboardHealthApi.ts` | update | dashboard health, action recommendations read를 generated endpoint wrapper 경유로 유지한다. |
 | `frontend/scripts/manual-api-call-allowlist.json` | update | generated endpoint 전환으로 더 이상 필요하지 않은 dashboard manual API allowlist를 제거한다. |
 | `frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx` | update | 노출 필터와 세 집계 요청 파라미터를 검증한다. |
+| `frontend/e2e/workspace-core.spec.ts` | update | 대시보드 E2E가 지원 기간 필터와 unsupported 필터 비노출을 검증하도록 맞춘다. |
 | `frontend/src/features/consultation/api/consultationApi.test.ts` | existing verification | metrics, workflow rankings URL query 검증을 유지한다. |
 | `frontend/src/features/workspace-dashboard-health/api/workspaceDashboardHealthApi.test.ts` | existing verification | recommendations URL query 검증을 유지한다. |
 
@@ -103,6 +104,7 @@ DashboardFilters(period/custom dates)
 | --- | --- | --- | --- |
 | 단위/통합 테스트 | 대시보드 페이지 mock API 호출 검증 | Vitest + Testing Library | 기간 변경 시 세 집계 호출이 같은 params를 받는지 확인한다. |
 | API wrapper 테스트 | request URL query 검증 | Vitest | `from`, `to`가 실제 URL query로 직렬화되는지 확인한다. |
+| E2E 테스트 | 대시보드 필터 조작 및 API request 관찰 | Playwright | 지원 기간 필터만 조작 가능하고 세 집계 URL이 같은 기간 조건으로 요청되는지 확인한다. |
 | 정적 검사 | frontend lint/type/build 범위 | pnpm/vp | 변경 범위에 맞는 실행 가능한 명령을 선택한다. |
 
 ### Acceptance Criteria

--- a/frontend/e2e/workspace-core.spec.ts
+++ b/frontend/e2e/workspace-core.spec.ts
@@ -135,7 +135,7 @@ test.describe("Workspace core operator screens", () => {
         expect(seen).toContain(`GET /workspaces/1/dashboard/workflow-rankings?${range}`);
       });
 
-      test("Then compact filter controls update summaries, date queries, and action navigation", async ({
+      test("Then compact supported filters update summaries, date queries, and action navigation", async ({
         page,
       }) => {
         await page.goto("/workspaces/1/dashboard");
@@ -148,23 +148,30 @@ test.describe("Workspace core operator screens", () => {
           )
           .toBe(true);
 
-        await page.getByLabel("운영 지식팩 버전 필터").selectOption("published");
-        await page.getByLabel("채널 필터").selectOption("email");
-        await page.getByLabel("워크플로우 상태 필터").selectOption("handoff");
+        await expect(page.getByLabel("운영 지식팩 버전 필터")).toHaveCount(0);
+        await expect(page.getByLabel("채널 필터")).toHaveCount(0);
+        await expect(page.getByLabel("워크플로우 상태 필터")).toHaveCount(0);
 
         const summary = page.getByLabel("대시보드 필터 요약");
-        await expect(summary).toContainText("운영 버전");
-        await expect(summary).toContainText("이메일");
-        await expect(summary).toContainText("상담원 연결");
+        await expect(summary).not.toContainText("운영 버전");
+        await expect(summary).not.toContainText("이메일");
+        await expect(summary).not.toContainText("상담원 연결");
 
         await page.getByRole("button", { name: "사용자 지정" }).click();
         await page.getByLabel("시작일").fill("2026-06-01");
         await page.getByLabel("종료일").fill("2026-06-03");
         await expect(summary).toContainText("2026-06-01 ~ 2026-06-03");
+        const customRange = "from=2026-06-01&to=2026-06-03";
+        await expect
+          .poll(() => seen.includes(`GET /workspaces/1/consultation/metrics?${customRange}`))
+          .toBe(true);
         await expect
           .poll(() =>
-            seen.includes("GET /workspaces/1/consultation/metrics?from=2026-06-01&to=2026-06-03"),
+            seen.includes(`GET /workspaces/1/dashboard/action-recommendations?${customRange}`),
           )
+          .toBe(true);
+        await expect
+          .poll(() => seen.includes(`GET /workspaces/1/dashboard/workflow-rankings?${customRange}`))
           .toBe(true);
 
         await page.getByRole("link", { name: /바로 보기/ }).click();

--- a/frontend/scripts/manual-api-call-allowlist.json
+++ b/frontend/scripts/manual-api-call-allowlist.json
@@ -57,16 +57,6 @@
       "wrapperPurpose": "toast/error mapping"
     },
     {
-      "file": "src/features/consultation/api/consultationApi.ts",
-      "importName": "customFetch",
-      "callee": "customFetch",
-      "endpoint": "identifier:url",
-      "occurrences": 3,
-      "reason": "Generated signatures do not expose the dashboard metric query parameters used by these reads.",
-      "scope": "Consultation metrics, workflow ranking, and bottleneck analysis computed URLs.",
-      "wrapperPurpose": "unwrap/select"
-    },
-    {
       "file": "src/features/consultation/api/llmToolWorkflowApi.ts",
       "importName": "customFetch",
       "callee": "customFetch",
@@ -210,24 +200,6 @@
       "reason": "OpenAPI generated endpoint is not available for simulation golden case replay creation.",
       "scope": "Simulation golden case replay endpoint.",
       "wrapperPurpose": "unwrap/select"
-    },
-    {
-      "file": "src/features/workspace-dashboard-health/api/workspaceDashboardHealthApi.ts",
-      "importName": "customFetch",
-      "callee": "customFetch",
-      "endpoint": "/api/v1/workspaces/${}/dashboard/knowledge-pack-health",
-      "reason": "OpenAPI is not generated for this dashboard read endpoint yet.",
-      "scope": "Workspace dashboard knowledge-pack health endpoint.",
-      "wrapperPurpose": "query key standardization"
-    },
-    {
-      "file": "src/features/workspace-dashboard-health/api/workspaceDashboardHealthApi.ts",
-      "importName": "customFetch",
-      "callee": "customFetch",
-      "endpoint": "/api/v1/workspaces/${}/dashboard/action-recommendations${}",
-      "reason": "OpenAPI is not generated for this dashboard read endpoint yet.",
-      "scope": "Workspace dashboard action recommendations endpoint.",
-      "wrapperPurpose": "query key standardization"
     }
   ]
 }

--- a/frontend/src/features/consultation/api/consultationApi.ts
+++ b/frontend/src/features/consultation/api/consultationApi.ts
@@ -13,7 +13,9 @@ import {
   releaseSession,
   updateResponseMode,
 } from "@/shared/api/generated/endpoints/counselor-session-controller/counselor-session-controller";
-import { customFetch } from "@/shared/api/mutator";
+import { getMetrics as getGeneratedMetrics } from "@/shared/api/generated/endpoints/consultation-metrics-controller/consultation-metrics-controller";
+import { getWorkflowRankings as getGeneratedWorkflowRankings } from "@/shared/api/generated/endpoints/workspace-workflow-ranking-controller/workspace-workflow-ranking-controller";
+import { getBottleneckAnalysis as getGeneratedBottleneckAnalysis } from "@/shared/api/generated/endpoints/workspace-workflow-bottleneck-analysis-controller/workspace-workflow-bottleneck-analysis-controller";
 import { requireApiData, selectApiData } from "@/shared/api";
 import type { GetSessionsParams } from "@/shared/api/generated/zod";
 import type {
@@ -25,8 +27,8 @@ import type {
 // 상담 endpoint는 가능한 한 generated controller에 위임한다:
 // queue(getQueue) / sessions(getSessions) / messages(getMessages) /
 // assign·release·response-mode(counselor-session) / draft-response(consultation).
-// 단, dashboard workflow rankings·bottleneck analysis와, from/to 기간 필터가 필요한 metrics는
-// generated 시그니처가 해당 파라미터를 노출하지 않아 customFetch 직접 호출을 유지한다.
+// dashboard 집계 read endpoint는 generated wrapper를 거쳐 호출하고,
+// feature wrapper는 기존 화면이 기대하는 응답 payload만 unwrap한다.
 
 export type ChatSession = ConsultationChatSession;
 export type ChatMessage = ConsultationChatMessage;
@@ -427,31 +429,22 @@ export const consultationApi = {
     workspaceId: number,
     params: ConsultationMetricsParams = {},
   ): Promise<ConsultationMetrics> => {
-    const searchParams = new URLSearchParams();
-    if (params.from) searchParams.set("from", params.from);
-    if (params.to) searchParams.set("to", params.to);
-    const query = searchParams.toString();
-    const url = `/api/v1/workspaces/${workspaceId}/consultation/metrics${query ? `?${query}` : ""}`;
-    const response = await customFetch<ConsultationMetrics | { data?: ConsultationMetrics }>(url, {
-      method: "GET",
-    });
-    return requireApiData<ConsultationMetrics>(response, "상담 지표 응답을 확인할 수 없습니다.");
+    const response = await getGeneratedMetrics(workspaceId, params);
+    return requireApiData<ConsultationMetrics>(
+      response as unknown as ConsultationMetrics | { data?: ConsultationMetrics },
+      "상담 지표 응답을 확인할 수 없습니다.",
+    );
   },
 
   getWorkflowRankings: async (
     workspaceId: number,
     params: ConsultationMetricsParams = {},
   ): Promise<WorkspaceWorkflowRankingResponse> => {
-    const searchParams = new URLSearchParams();
-    if (params.from) searchParams.set("from", params.from);
-    if (params.to) searchParams.set("to", params.to);
-    const query = searchParams.toString();
-    const url = `/api/v1/workspaces/${workspaceId}/dashboard/workflow-rankings${query ? `?${query}` : ""}`;
-    const response = await customFetch<
-      WorkspaceWorkflowRankingResponse | { data?: WorkspaceWorkflowRankingResponse }
-    >(url, { method: "GET" });
+    const response = await getGeneratedWorkflowRankings(workspaceId, params);
     return requireApiData<WorkspaceWorkflowRankingResponse>(
-      response,
+      response as unknown as
+        | WorkspaceWorkflowRankingResponse
+        | { data?: WorkspaceWorkflowRankingResponse },
       "워크플로우 랭킹 응답을 확인할 수 없습니다.",
     );
   },
@@ -461,16 +454,15 @@ export const consultationApi = {
     workflowDefinitionId: number,
     params: ConsultationMetricsParams = {},
   ): Promise<WorkspaceWorkflowBottleneckAnalysis> => {
-    const searchParams = new URLSearchParams();
-    if (params.from) searchParams.set("from", params.from);
-    if (params.to) searchParams.set("to", params.to);
-    const query = searchParams.toString();
-    const url = `/api/v1/workspaces/${workspaceId}/dashboard/workflows/${workflowDefinitionId}/bottleneck-analysis${query ? `?${query}` : ""}`;
-    const response = await customFetch<
-      WorkspaceWorkflowBottleneckAnalysis | { data?: WorkspaceWorkflowBottleneckAnalysis }
-    >(url, { method: "GET" });
+    const response = await getGeneratedBottleneckAnalysis(
+      workspaceId,
+      workflowDefinitionId,
+      params,
+    );
     return requireApiData<WorkspaceWorkflowBottleneckAnalysis>(
-      response,
+      response as unknown as
+        | WorkspaceWorkflowBottleneckAnalysis
+        | { data?: WorkspaceWorkflowBottleneckAnalysis },
       "워크플로우 병목 분석 응답을 확인할 수 없습니다.",
     );
   },

--- a/frontend/src/features/workspace-dashboard-health/api/workspaceDashboardHealthApi.ts
+++ b/frontend/src/features/workspace-dashboard-health/api/workspaceDashboardHealthApi.ts
@@ -1,8 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 
-import { customFetch } from "@/shared/api/mutator";
-
-// OpenAPI is not generated for this dashboard read endpoint yet.
+import {
+  getActionRecommendations as getGeneratedActionRecommendations,
+  getKnowledgePackHealth as getGeneratedKnowledgePackHealth,
+} from "@/shared/api/generated/endpoints/workspace-dashboard-controller/workspace-dashboard-controller";
+import { requireApiData } from "@/shared/api";
 
 export interface WorkspaceDashboardKnowledgePack {
   packId: number;
@@ -77,26 +79,33 @@ export const workspaceDashboardActionRecommendationKeys = {
 export function useWorkspaceDashboardHealth(workspaceId: number) {
   return useQuery({
     queryKey: workspaceDashboardHealthKeys.detail(workspaceId),
-    queryFn: ({ signal }) =>
-      customFetch<WorkspaceDashboardHealth>(
-        `/api/v1/workspaces/${workspaceId}/dashboard/knowledge-pack-health`,
-        { method: "GET", signal },
-      ),
+    queryFn: async ({ signal }) => {
+      const response = await getGeneratedKnowledgePackHealth(workspaceId, {
+        signal,
+      });
+      return requireApiData<WorkspaceDashboardHealth>(
+        response as unknown as
+          | WorkspaceDashboardHealth
+          | { data?: WorkspaceDashboardHealth },
+        "워크스페이스 대시보드 건강도 응답을 확인할 수 없습니다.",
+      );
+    },
   });
 }
 
-export function fetchWorkspaceDashboardActionRecommendations(
+export async function fetchWorkspaceDashboardActionRecommendations(
   workspaceId: number,
   params: WorkspaceDashboardActionRecommendationParams = {},
   signal?: AbortSignal,
 ) {
-  const searchParams = new URLSearchParams();
-  if (params.from) searchParams.set("from", params.from);
-  if (params.to) searchParams.set("to", params.to);
-  const query = searchParams.toString();
-  return customFetch<WorkspaceDashboardActionRecommendations>(
-    `/api/v1/workspaces/${workspaceId}/dashboard/action-recommendations${query ? `?${query}` : ""}`,
-    { method: "GET", signal },
+  const response = await getGeneratedActionRecommendations(workspaceId, params, {
+    signal,
+  });
+  return requireApiData<WorkspaceDashboardActionRecommendations>(
+    response as unknown as
+      | WorkspaceDashboardActionRecommendations
+      | { data?: WorkspaceDashboardActionRecommendations },
+    "워크스페이스 대시보드 추천 액션 응답을 확인할 수 없습니다.",
   );
 }
 

--- a/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx
@@ -257,7 +257,7 @@ describe("WorkspaceDashboardPage", () => {
     expect(mockedFetchActionRecommendations).not.toHaveBeenCalled();
   });
 
-  it("공통 필터와 상담 처리 KPI, 추천 액션, 운영 지식팩 건강도, 핫패스 랭킹을 표시한다", async () => {
+  it("기간 필터와 상담 처리 KPI, 추천 액션, 운영 지식팩 건강도, 핫패스 랭킹을 표시한다", async () => {
     renderPage();
 
     expect(
@@ -272,9 +272,13 @@ describe("WorkspaceDashboardPage", () => {
       screen.queryByText(/필터와 배치 구조를 먼저 고정합니다/),
     ).not.toBeInTheDocument();
     expect(screen.getByLabelText("기간 필터")).toBeInTheDocument();
-    expect(screen.getByLabelText("운영 지식팩 버전 필터")).toHaveValue("all");
-    expect(screen.getByLabelText("채널 필터")).toHaveValue("all");
-    expect(screen.getByLabelText("워크플로우 상태 필터")).toHaveValue("all");
+    expect(
+      screen.queryByLabelText("운영 지식팩 버전 필터"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("채널 필터")).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("워크플로우 상태 필터"),
+    ).not.toBeInTheDocument();
     expect(screen.getByText("총 상담")).toBeInTheDocument();
     expect(await screen.findByText("120")).toBeInTheDocument();
     expect(screen.getByText("1분 15초")).toBeInTheDocument();
@@ -342,7 +346,7 @@ describe("WorkspaceDashboardPage", () => {
     );
   });
 
-  it("기간과 공통 필터 변경을 요약 상태와 API 요청에 반영한다", async () => {
+  it("기간 변경을 요약 상태와 API 요청에 반영한다", async () => {
     renderPage();
 
     fireEvent.click(screen.getByRole("button", { name: "사용자 지정" }));
@@ -352,21 +356,12 @@ describe("WorkspaceDashboardPage", () => {
     fireEvent.change(screen.getByLabelText("종료일"), {
       target: { value: "2026-06-03" },
     });
-    fireEvent.change(screen.getByLabelText("운영 지식팩 버전 필터"), {
-      target: { value: "published" },
-    });
-    fireEvent.change(screen.getByLabelText("채널 필터"), {
-      target: { value: "email" },
-    });
-    fireEvent.change(screen.getByLabelText("워크플로우 상태 필터"), {
-      target: { value: "handoff" },
-    });
 
     const summary = screen.getByLabelText("대시보드 필터 요약");
     expect(summary).toHaveTextContent("2026-06-01 ~ 2026-06-03");
-    expect(summary).toHaveTextContent("운영 버전");
-    expect(summary).toHaveTextContent("이메일");
-    expect(summary).toHaveTextContent("상담원 연결");
+    expect(summary).not.toHaveTextContent("운영 지식팩");
+    expect(summary).not.toHaveTextContent("채널");
+    expect(summary).not.toHaveTextContent("워크플로우");
     await waitFor(() =>
       expect(mockedGetMetrics).toHaveBeenLastCalledWith(1, {
         from: "2026-06-01",

--- a/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx
@@ -25,7 +25,6 @@ import type { ShellContext } from "@/shared/ui/ostone/chrome";
 import { buildDemoChatPath } from "@/shared/lib/demoRoutes";
 import { parseRouteId } from "@/shared/lib/parseRouteId";
 import { Button } from "@/shared/ui/button";
-import { NativeSelect, NativeSelectOption } from "@/shared/ui/native-select";
 import { LoadingSpinner } from "@/shared/ui/ostone/atoms/LoadingSpinner";
 import { ErrorState } from "@/shared/ui/ostone/atoms/ErrorState";
 
@@ -39,9 +38,6 @@ interface DashboardFilters {
   period: DashboardPeriod;
   customFrom: string;
   customTo: string;
-  domainPackVersion: string;
-  channel: string;
-  workflowStatus: string;
 }
 
 interface FilterOption<T extends string = string> {
@@ -69,34 +65,10 @@ const PERIOD_OPTIONS: Array<FilterOption<DashboardPeriod>> = [
   { value: "custom", label: "사용자 지정" },
 ];
 
-const DOMAIN_PACK_VERSION_OPTIONS: FilterOption[] = [
-  { value: "all", label: "전체 버전" },
-  { value: "published", label: "운영 버전" },
-  { value: "draft", label: "검토 중 버전" },
-];
-
-const CHANNEL_OPTIONS: FilterOption[] = [
-  { value: "all", label: "전체 채널" },
-  { value: "web-chat", label: "웹채팅" },
-  { value: "email", label: "이메일" },
-  { value: "phone", label: "전화" },
-];
-
-const WORKFLOW_STATUS_OPTIONS: FilterOption[] = [
-  { value: "all", label: "전체 상태" },
-  { value: "running", label: "진행 중" },
-  { value: "completed", label: "완료" },
-  { value: "handoff", label: "상담원 연결" },
-  { value: "failed", label: "실패" },
-];
-
 const INITIAL_FILTERS: DashboardFilters = {
   period: "7d",
   customFrom: "",
   customTo: "",
-  domainPackVersion: "all",
-  channel: "all",
-  workflowStatus: "all",
 };
 
 function toDateInputValue(date: Date): string {
@@ -144,18 +116,7 @@ function buildPeriodSummary(filters: DashboardFilters): string {
 }
 
 function FilterSummary({ filters }: { filters: DashboardFilters }) {
-  const summaryItems = [
-    ["기간", buildPeriodSummary(filters)],
-    [
-      "운영 지식팩",
-      getOptionLabel(DOMAIN_PACK_VERSION_OPTIONS, filters.domainPackVersion),
-    ],
-    ["채널", getOptionLabel(CHANNEL_OPTIONS, filters.channel)],
-    [
-      "워크플로우",
-      getOptionLabel(WORKFLOW_STATUS_OPTIONS, filters.workflowStatus),
-    ],
-  ];
+  const summaryItems = [["기간", buildPeriodSummary(filters)]];
 
   return (
     <dl className={styles.filterSummary} aria-label="대시보드 필터 요약">
@@ -786,8 +747,7 @@ function DashboardFilters({
             공통 필터
           </h2>
           <p className={styles.sectionDescription}>
-            대시보드 섹션이 같은 기간과 운영 조건을 기준으로 집계되도록
-            설정합니다.
+            대시보드 섹션이 같은 기간을 기준으로 집계되도록 설정합니다.
           </p>
         </div>
       </div>
@@ -831,58 +791,6 @@ function DashboardFilters({
           </label>
         </div>
       ) : null}
-
-      <div className={styles.selectGrid}>
-        <label className={styles.field}>
-          <span>운영 지식팩 버전</span>
-          <NativeSelect
-            value={filters.domainPackVersion}
-            onChange={(event) =>
-              updateFilter("domainPackVersion", event.target.value)
-            }
-            aria-label="운영 지식팩 버전 필터"
-            size="sm"
-          >
-            {DOMAIN_PACK_VERSION_OPTIONS.map((option) => (
-              <NativeSelectOption key={option.value} value={option.value}>
-                {option.label}
-              </NativeSelectOption>
-            ))}
-          </NativeSelect>
-        </label>
-        <label className={styles.field}>
-          <span>Channel</span>
-          <NativeSelect
-            value={filters.channel}
-            onChange={(event) => updateFilter("channel", event.target.value)}
-            aria-label="채널 필터"
-            size="sm"
-          >
-            {CHANNEL_OPTIONS.map((option) => (
-              <NativeSelectOption key={option.value} value={option.value}>
-                {option.label}
-              </NativeSelectOption>
-            ))}
-          </NativeSelect>
-        </label>
-        <label className={styles.field}>
-          <span>Workflow Status</span>
-          <NativeSelect
-            value={filters.workflowStatus}
-            onChange={(event) =>
-              updateFilter("workflowStatus", event.target.value)
-            }
-            aria-label="워크플로우 상태 필터"
-            size="sm"
-          >
-            {WORKFLOW_STATUS_OPTIONS.map((option) => (
-              <NativeSelectOption key={option.value} value={option.value}>
-                {option.label}
-              </NativeSelectOption>
-            ))}
-          </NativeSelect>
-        </label>
-      </div>
     </section>
   );
 }

--- a/frontend/src/pages/workspace/ui/workspace-dashboard-page.module.css
+++ b/frontend/src/pages/workspace/ui/workspace-dashboard-page.module.css
@@ -116,13 +116,9 @@
 
 .customDateGrid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(160px, 1fr));
-  gap: var(--s-2);
-}
-
-.customDateGrid {
   grid-column: 1 / -1;
   grid-template-columns: repeat(2, minmax(160px, 240px));
+  gap: var(--s-2);
 }
 
 .field {

--- a/frontend/src/pages/workspace/ui/workspace-dashboard-page.module.css
+++ b/frontend/src/pages/workspace/ui/workspace-dashboard-page.module.css
@@ -44,10 +44,7 @@
 
 .filterBar {
   display: grid;
-  grid-template-columns: minmax(220px, 0.8fr) minmax(280px, 1fr) minmax(
-      420px,
-      1.45fr
-    );
+  grid-template-columns: minmax(220px, 0.8fr) minmax(280px, 1fr);
   align-items: end;
   gap: var(--s-3);
   padding: var(--s-4);
@@ -117,14 +114,14 @@
   color: var(--paper);
 }
 
-.customDateGrid,
-.selectGrid {
+.customDateGrid {
   display: grid;
   grid-template-columns: repeat(3, minmax(160px, 1fr));
   gap: var(--s-2);
 }
 
 .customDateGrid {
+  grid-column: 1 / -1;
   grid-template-columns: repeat(2, minmax(160px, 240px));
 }
 
@@ -159,7 +156,7 @@
 
 .filterSummary {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: var(--s-2);
 }
 
@@ -800,10 +797,6 @@
 
   .coverageHeader {
     flex-direction: column;
-  }
-
-  .selectGrid {
-    grid-template-columns: 1fr;
   }
 
   .ctaGrid {


### PR DESCRIPTION
Closes #782

## 변경 사항

- 이슈 782 요구사항과 acceptance criteria를 `.agent/specs/782.md`에 정리했습니다.
- 대시보드 공통 필터에서 현재 집계 API가 지원하지 않는 운영 지식팩 버전, Channel, Workflow Status 선택 UI를 제거했습니다.
- 기간 필터와 사용자 지정 시작/종료일만 조작 가능한 필터로 유지하고, metrics, recommendations, workflow rankings가 같은 `from`/`to` 조건으로 갱신되도록 테스트를 정리했습니다.
- dashboard aggregate read wrapper가 generated endpoint를 사용하도록 전환하고, 더 이상 필요하지 않은 manual API allowlist 항목을 제거했습니다.
- 대시보드 E2E를 현재 지원 필터 정책에 맞춰 갱신하고, 세 집계 request URL이 같은 사용자 지정 기간 조건을 받는지 검증했습니다.
- 리뷰 지적에 따라 spec의 정적 검사 명령 표기를 실제 커맨드로 바꾸고, `.customDateGrid` 중복 CSS 선언을 정리했습니다.

## 검증

- `pnpm --dir frontend test -- WorkspaceDashboardPage.test.tsx consultationApi.test.ts workspaceDashboardHealthApi.test.ts` (3 files, 38 tests; API/FSD audits passed)
- `pnpm --dir frontend exec eslint src/pages/workspace/ui/WorkspaceDashboardPage.tsx src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx src/features/consultation/api/consultationApi.ts src/features/consultation/api/consultationApi.test.ts src/features/workspace-dashboard-health/api/workspaceDashboardHealthApi.ts src/features/workspace-dashboard-health/api/workspaceDashboardHealthApi.test.ts`
- `pnpm --dir frontend exec eslint e2e/workspace-core.spec.ts`
- `pnpm --dir frontend exec playwright test e2e/workspace-core.spec.ts --grep "compact supported filters" --config .playwright-4173.config.ts` (local 3000 port occupied, equivalent temporary config on 4173)
- `pnpm --dir frontend exec playwright test e2e/workspace-core.spec.ts --config .playwright-4173.config.ts` (16 passed; local 3000 port occupied, equivalent temporary config on 4173)
- `pnpm --dir frontend build` (Vite chunk-size warning만 표시)
- `git diff --check`

## 참고

- 구현 전 issue 782, `WorkspaceDashboardPage`, dashboard API wrappers/tests, generated aggregate endpoint signatures, backend controller query params, `frontend/DESIGN.md`, frontend FSD/test rules를 확인했습니다.
- spec review 2회 수행: issue fidelity 관점에서 지원 필터와 미지원 필터 처리를 매핑했고, repository compliance 관점에서 파일명/브랜치/affected paths와 검증 기준을 최종 diff에 맞췄습니다.
- self-review 3회 수행: Round 1에서 acceptance criteria와 visible filter surface를 확인했고, Round 2에서 generated endpoint 사용, FSD boundary, manual API allowlist 정합성을 확인했으며, Round 3에서 staged diff 범위, whitespace, build/typecheck, validation claim을 확인했습니다.
- E2E CI 실패 대응 후 self-review 3회 추가 수행: Round 1에서 실패 원인과 acceptance criteria 매핑을 확인했고, Round 2에서 기존 E2E request 관찰 패턴과 spec 정합성을 확인했으며, Round 3에서 focused/file-wide E2E, ESLint, diff check 결과를 확인했습니다.
- 리뷰 대응 후 self-review 3회 추가 수행: Round 1에서 리뷰 지적 해소 여부를 확인했고, Round 2에서 실제 CSS 적용 의미가 유지되는지 확인했으며, Round 3에서 unit/API tests, 대상 ESLint, build, E2E, diff check 결과를 확인했습니다.
- `pnpm --dir frontend lint`는 API/FSD audit 통과 후 이번 변경과 무관한 기존 frontend ESLint baseline 47건으로 실패합니다. 변경 파일 대상 ESLint, focused tests, build, diff checks는 통과했습니다.
- pre-commit hook은 repository-wide lint baseline 때문에 우회했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 대시보드 필터: 기간 선택(오늘/7일/30일/사용자 지정)으로 단순화
  * 미지원 필터(운영 지식팩 버전, 채널, 워크플로우 상태) 제거
  * 필터 영역 레이아웃 개선 (2열 구성으로 조정)

* **문서**
  * 대시보드 필터 기능 요구사항 스펙 문서 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->