### PR TITLE
fix(frontend): 사용자 화면 미리보기 워크스페이스 맥락을 보장

### DIFF
--- a/.agent/specs/780.md
+++ b/.agent/specs/780.md
@@ -1,0 +1,95 @@
+# Frontend Spec: 사용자 화면 미리보기 워크스페이스 컨텍스트 유지
+
+## Goal
+
+워크스페이스 내부 사이드바의 사용자 화면 미리보기 링크가 전역 데모 선택 화면이 아니라 현재 워크스페이스 기준 사용자 채팅 화면으로 이동하게 한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["운영자가 /workspaces/:workspaceId 내부 화면에 있음"] --> B["사이드바 사용자 화면 미리보기 선택"]
+    B --> C{"workspaceId를 확인할 수 있음?"}
+    C -->|Yes| D["/chat/:workspaceId 새 탭으로 이동"]
+    C -->|No| E["공개 데모 선택 화면 /demo로 이동"]
+    D --> F["현재 워크스페이스의 고객 경험 미리보기"]
+    E --> G["외부 공개 데모 진입점"]
+```
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+| --- | --- | --- | --- |
+| 사이드바 미리보기 CTA | 항상 `/demo`로 이동 | `/workspaces/:workspaceId` 내부에서는 `/chat/:workspaceId`로 이동 | 운영자가 작업 중인 워크스페이스 맥락을 유지 |
+| 전역 데모 선택 화면 | 내부 워크스페이스 CTA에서도 사용 | 공개 데모 진입점 또는 workspaceId 부재 시 fallback으로만 사용 | 내부 운영 플로우와 공개 데모 플로우 분리 |
+| 새 탭 안내 | 일반 외부 링크 아이콘 설명 | 현재 워크스페이스 미리보기 또는 공개 데모 fallback 새 탭 동작을 설명 | 링크 목적과 새 탭 동작을 더 명확히 표시 |
+
+## Component Tree
+
+```text
+Sidebar
+├─ TOP_NAV_ITEMS
+│  └─ 사용자 화면 미리보기
+└─ SidebarLink
+   ├─ Icon
+   ├─ label
+   └─ new-tab indicator
+```
+
+## API Integration
+
+API 호출이나 generated client 변경은 없다. 이 변경은 프론트엔드 라우팅 링크 생성만 다룬다.
+
+## Data Flow
+
+```text
+OstoneShell
+└─ resolvedBasePath: /workspaces/:workspaceId
+   └─ Sidebar
+      └─ preview route helper
+         ├─ workspaceId 있음: buildUserChatPath(workspaceId)
+         └─ workspaceId 없음: /demo
+```
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+| --- | --- | --- |
+| `frontend/src/shared/ui/ostone/chrome/Sidebar.tsx` | modify | 미리보기 CTA의 workspaceId 기반 href와 새 탭 안내 라벨 변경 |
+| `frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx` | modify | 사이드바 링크가 현재 workspace 기준 경로를 사용하는지 검증 |
+| `frontend/src/shared/lib/demoRoutes.ts` | modify | 공개 데모 선택 경로 fallback을 명시적으로 공유 |
+| `frontend/src/shared/lib/userChatRoutes.ts` | modify | workspace basePath에서 사용자 채팅 경로를 계산하는 helper 제공 |
+
+## State Management
+
+추가 클라이언트 상태나 서버 상태는 없다. `basePath` prop에서 workspaceId를 파생해 링크 경로만 계산한다.
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+| --- | --- | --- | --- |
+| 단위/컴포넌트 테스트 | Sidebar 렌더링 결과의 href, target, aria-label 확인 | Vitest + React Testing Library | 기존 `Sidebar.test.tsx` 갱신 |
+| 라우트 helper 테스트 | basePath별 preview 경로 계산 확인 | Vitest | helper가 encoded workspaceId를 유지하는지 확인 |
+
+### Test Scenarios
+
+| # | 시나리오 | 사전 조건 | 기대 결과 |
+| --- | --- | --- | --- |
+| 1 | 워크스페이스 내부 미리보기 | `basePath="/workspaces/7"` | 링크 href가 `/chat/7`이고 새 탭으로 열린다 |
+| 2 | workspaceId 없는 fallback | `basePath="/workspaces"` | 링크 href가 공개 데모 선택 화면 `/demo`이다 |
+| 3 | 새 탭 안내 라벨 | workspaceId가 있는 미리보기 링크 렌더링 | 아이콘 aria-label이 현재 워크스페이스 미리보기 새 탭 동작을 설명한다 |
+| 4 | fallback 새 탭 안내 라벨 | workspaceId가 없는 미리보기 링크 렌더링 | 아이콘 aria-label이 공개 데모 선택 화면 새 탭 동작을 설명한다 |
+
+## Non-goals
+
+- `/demo` 공개 데모 선택 화면과 `/demo/chat/:workspaceId` 공개 데모 채팅 플로우는 변경하지 않는다.
+- 인증 사용자 채팅 화면의 WebSocket/API 동작은 변경하지 않는다.
+- 백엔드 API, OpenAPI generated client, DB schema는 변경하지 않는다.
+
+## Open Questions
+
+- 없음. 이슈 본문과 기존 라우트 구조로 범위를 확정할 수 있다.

--- a/frontend/src/shared/lib/demoRoutes.ts
+++ b/frontend/src/shared/lib/demoRoutes.ts
@@ -1,7 +1,9 @@
+export const DEMO_SELECTION_PATH = "/demo";
+
 export function buildDemoChatPath(
   workspaceId: number | string,
   searchParams?: URLSearchParams,
 ): string {
   const search = searchParams?.toString();
-  return `/demo/chat/${encodeURIComponent(String(workspaceId))}${search ? `?${search}` : ""}`;
+  return `${DEMO_SELECTION_PATH}/chat/${encodeURIComponent(String(workspaceId))}${search ? `?${search}` : ""}`;
 }

--- a/frontend/src/shared/lib/userChatRoutes.test.ts
+++ b/frontend/src/shared/lib/userChatRoutes.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildUserChatPath,
+  buildWorkspacePreviewChatPath,
+  extractWorkspaceIdFromBasePath,
+} from "./userChatRoutes";
+
+describe("userChatRoutes", () => {
+  it("사용자 채팅 경로를 workspaceId 기준으로 생성한다", () => {
+    expect(buildUserChatPath(7)).toBe("/chat/7");
+    expect(buildUserChatPath("team one")).toBe("/chat/team%20one");
+  });
+
+  it("workspace basePath에서 workspaceId를 추출한다", () => {
+    expect(extractWorkspaceIdFromBasePath("/workspaces/7")).toBe("7");
+    expect(extractWorkspaceIdFromBasePath("/workspaces/team%20one/dashboard")).toBe("team one");
+    expect(extractWorkspaceIdFromBasePath("/workspaces/7?tab=chat")).toBe("7");
+  });
+
+  it("workspaceId가 있는 basePath는 현재 워크스페이스 사용자 채팅 경로로 보낸다", () => {
+    expect(buildWorkspacePreviewChatPath("/workspaces/7")).toBe("/chat/7");
+    expect(buildWorkspacePreviewChatPath("/workspaces/team%20one/dashboard")).toBe(
+      "/chat/team%20one",
+    );
+  });
+
+  it("workspaceId를 추출할 수 없으면 공개 데모 선택 화면으로 보낸다", () => {
+    expect(buildWorkspacePreviewChatPath("/workspaces")).toBe("/demo");
+    expect(buildWorkspacePreviewChatPath("/settings")).toBe("/demo");
+  });
+});

--- a/frontend/src/shared/lib/userChatRoutes.ts
+++ b/frontend/src/shared/lib/userChatRoutes.ts
@@ -1,3 +1,30 @@
+import { DEMO_SELECTION_PATH } from "./demoRoutes";
+
 export function buildUserChatPath(workspaceId: string | number): string {
   return `/chat/${encodeURIComponent(String(workspaceId))}`;
+}
+
+function decodeRouteSegment(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}
+
+export function extractWorkspaceIdFromBasePath(basePath: string): string | null {
+  const [pathWithoutQuery] = basePath.split(/[?#]/);
+  const segments = pathWithoutQuery.split("/").filter(Boolean);
+
+  if (segments[0] !== "workspaces" || !segments[1]) {
+    return null;
+  }
+
+  return decodeRouteSegment(segments[1]);
+}
+
+export function buildWorkspacePreviewChatPath(basePath: string): string {
+  const workspaceId = extractWorkspaceIdFromBasePath(basePath);
+
+  return workspaceId ? buildUserChatPath(workspaceId) : DEMO_SELECTION_PATH;
 }

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
@@ -82,11 +82,8 @@ describe("Sidebar", () => {
 
     expect(screen.getByTitle("대시보드")).toHaveAttribute("href", "/workspaces/7/dashboard");
     expect(screen.getByTitle("상담 응대")).toHaveAttribute("href", "/workspaces/7/consultation");
-    expect(screen.getByTitle("시뮬레이션")).toHaveAttribute(
-      "href",
-      "/workspaces/7/simulation",
-    );
-    expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute("href", "/demo");
+    expect(screen.getByTitle("시뮬레이션")).toHaveAttribute("href", "/workspaces/7/simulation");
+    expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute("href", "/chat/7");
     expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute("target", "_blank");
     expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute("rel", "noopener noreferrer");
     expect(screen.getByTitle("도메인팩 관리")).toHaveAttribute(
@@ -95,28 +92,45 @@ describe("Sidebar", () => {
     );
   });
 
-  it("workspaceId를 추출할 수 없어도 사용자 화면 미리보기는 데모 선택 화면으로 보낸다", () => {
+  it("workspaceId를 추출하면 사용자 화면 미리보기를 현재 워크스페이스 채팅으로 보낸다", () => {
+    renderSidebar({ basePath: "/workspaces/7" });
+
+    expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute("href", "/chat/7");
+    expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute("target", "_blank");
+    expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("workspaceId를 추출할 수 없어도 사용자 화면 미리보기는 공개 데모 선택 화면으로 보낸다", () => {
     renderSidebar({ basePath: "/workspaces" });
 
     expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute("href", "/demo");
+    expect(screen.getByLabelText("공개 데모 선택 화면을 새 탭에서 엽니다")).toBeInTheDocument();
   });
 
-  it("외부 링크(사용자 화면 미리보기)에만 새 탭 안내 아이콘을 표시한다", () => {
+  it("새 탭 링크(사용자 화면 미리보기)에만 목적이 분명한 새 탭 안내 아이콘을 표시한다", () => {
     renderSidebar({ basePath: "/workspaces/7" });
 
-    const externalIcon = screen.getByLabelText("새 탭에서 열림");
-    expect(externalIcon).toBeInTheDocument();
-    expect(screen.getByTestId("sidebar-link-chat")).toContainElement(externalIcon);
-    expect(screen.getAllByLabelText("새 탭에서 열림")).toHaveLength(1);
+    const newTabIcon = screen.getByLabelText("현재 워크스페이스 사용자 화면을 새 탭에서 엽니다");
+    expect(newTabIcon).toBeInTheDocument();
+    expect(screen.getByTestId("sidebar-link-chat")).toContainElement(newTabIcon);
+    expect(
+      screen.getAllByLabelText("현재 워크스페이스 사용자 화면을 새 탭에서 엽니다"),
+    ).toHaveLength(1);
 
     expect(
-      screen.getByTestId("sidebar-link-consult").querySelector('[aria-label="새 탭에서 열림"]'),
+      screen
+        .getByTestId("sidebar-link-consult")
+        .querySelector('[aria-label="현재 워크스페이스 사용자 화면을 새 탭에서 엽니다"]'),
     ).toBeNull();
     expect(
-      screen.getByTestId("sidebar-link-simulation").querySelector('[aria-label="새 탭에서 열림"]'),
+      screen
+        .getByTestId("sidebar-link-simulation")
+        .querySelector('[aria-label="현재 워크스페이스 사용자 화면을 새 탭에서 엽니다"]'),
     ).toBeNull();
     expect(
-      screen.getByTestId("sidebar-domain-link").querySelector('[aria-label="새 탭에서 열림"]'),
+      screen
+        .getByTestId("sidebar-domain-link")
+        .querySelector('[aria-label="현재 워크스페이스 사용자 화면을 새 탭에서 엽니다"]'),
     ).toBeNull();
   });
 

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
@@ -1,6 +1,8 @@
 import type { CSSProperties, MouseEvent, ReactNode } from "react";
 import { ExternalLink } from "lucide-react";
 import { NavLink } from "react-router-dom";
+import { DEMO_SELECTION_PATH } from "@/shared/lib/demoRoutes";
+import { buildWorkspacePreviewChatPath } from "@/shared/lib/userChatRoutes";
 import { Icon } from "../atoms/Icon";
 import type { IconName } from "../atoms/Icon";
 import { AccountMenu } from "./AccountMenu";
@@ -31,11 +33,7 @@ interface TopNavItem {
   icon: IconName;
   label: string;
   getPath: (base: string) => string;
-  external?: boolean;
-}
-
-function getDemoPreviewPath(): string {
-  return "/demo";
+  openInNewTab?: boolean;
 }
 
 const TOP_NAV_ITEMS: TopNavItem[] = [
@@ -61,8 +59,8 @@ const TOP_NAV_ITEMS: TopNavItem[] = [
     key: "chat",
     icon: "msg",
     label: "사용자 화면 미리보기",
-    getPath: getDemoPreviewPath,
-    external: true,
+    getPath: buildWorkspacePreviewChatPath,
+    openInNewTab: true,
   },
   {
     key: "upload",
@@ -181,7 +179,8 @@ export function Sidebar({
             hoverBg={hoverBg}
             activeBg={activeBg}
             testId={`sidebar-link-${item.key}`}
-            target={item.external ? "_blank" : undefined}
+            target={item.openInNewTab ? "_blank" : undefined}
+            newTabLabel={item.openInNewTab ? getNewTabLabel(item.getPath(basePath)) : undefined}
           />
         ))}
 
@@ -230,6 +229,14 @@ interface SidebarLinkProps {
   activeBg: string;
   testId?: string;
   target?: "_blank";
+  newTabLabel?: string;
+}
+
+const NEW_TAB_PREVIEW_LABEL = "현재 워크스페이스 사용자 화면을 새 탭에서 엽니다";
+const NEW_TAB_PUBLIC_DEMO_LABEL = "공개 데모 선택 화면을 새 탭에서 엽니다";
+
+function getNewTabLabel(to: string): string {
+  return to === DEMO_SELECTION_PATH ? NEW_TAB_PUBLIC_DEMO_LABEL : NEW_TAB_PREVIEW_LABEL;
 }
 
 function buildLinkStyle({
@@ -272,6 +279,7 @@ function SidebarLink({
   activeBg,
   testId,
   target,
+  newTabLabel,
 }: SidebarLinkProps) {
   const expandedStyle: CSSProperties = buildLinkStyle({
     isActive,
@@ -294,23 +302,23 @@ function SidebarLink({
     }
   };
 
-  const isExternal = target === "_blank";
+  const opensInNewTab = target === "_blank";
   const content = (
     <>
       <Icon name={icon} size={16} />
       <span style={{ flex: 1, minWidth: 0 }}>{label}</span>
-      {isExternal ? (
+      {opensInNewTab ? (
         <ExternalLink
           size={13}
           role="img"
-          aria-label="새 탭에서 열림"
+          aria-label={newTabLabel ?? "새 탭에서 열림"}
           style={{ flexShrink: 0, color: "var(--ink-3)" }}
         />
       ) : null}
     </>
   );
 
-  if (isExternal) {
+  if (opensInNewTab) {
     return (
       <a
         href={to}


### PR DESCRIPTION
Closes #780

## 변경 사항

- 이슈 780 요구사항과 acceptance criteria를 `.agent/specs/780.md`에 정리했습니다.
- 사이드바의 `사용자 화면 미리보기` CTA가 `/demo` 선택 화면이 아니라 현재 `basePath`에서 추출한 workspaceId 기준 `/chat/{workspaceId}`로 열리도록 했습니다.
- workspaceId를 확인할 수 없는 fallback에서만 공개 데모 선택 화면 `/demo`를 유지했습니다.
- 새 탭 안내 aria-label을 현재 워크스페이스 미리보기와 공개 데모 fallback 목적에 맞게 구분했습니다.
- `userChatRoutes` helper와 `Sidebar` 테스트를 보강해 workspace 기준 경로와 fallback 경로가 섞이지 않도록 검증합니다.

## 검증

- `pnpm --dir frontend exec vp fmt --check src/shared/lib/demoRoutes.ts src/shared/lib/userChatRoutes.ts src/shared/lib/userChatRoutes.test.ts src/shared/ui/ostone/chrome/Sidebar.tsx src/shared/ui/ostone/chrome/Sidebar.test.tsx`
- `pnpm --dir frontend exec eslint src/shared/lib/demoRoutes.ts src/shared/lib/userChatRoutes.ts src/shared/lib/userChatRoutes.test.ts src/shared/ui/ostone/chrome/Sidebar.tsx src/shared/ui/ostone/chrome/Sidebar.test.tsx`
- `pnpm --dir frontend exec vp test src/shared/lib/userChatRoutes.test.ts src/shared/ui/ostone/chrome/Sidebar.test.tsx --run` (2 files, 19 tests)
- `pnpm --dir frontend test -- --run` (283 files, 2182 tests; API/FSD audits passed)
- `pnpm --dir frontend build` (Vite chunk-size warning만 표시)
- `git diff --check`

## 참고

- 구현 전 issue 780, `Sidebar`, `demoRoutes`, `userChatRoutes`, `App.tsx`의 `/chat/:workspaceId` 및 `/demo` route, `OstoneShell`의 `basePath` 전달, `frontend/DESIGN.md`, frontend FSD/test rules를 확인했습니다.
- spec review 2회 수행: issue fidelity 관점에서 workspace CTA, 공개 demo fallback, 새 탭 안내 요구사항을 매핑했고, repository compliance 관점에서 파일명/브랜치/affected paths와 검증 기준을 최종 diff에 맞췄습니다.
- self-review 3회 수행: Round 1에서 fallback aria-label과 spec drift를 발견해 수정했고, Round 2에서 internal new-tab 링크가 더 이상 external link로 오해되지 않도록 naming을 정리했으며, Round 3에서 staged diff 범위, whitespace, test/build evidence, route helper edge case를 확인했습니다.
- `pnpm --dir frontend lint`와 pre-commit hook의 `pnpm run lint:frontend`는 API/FSD audit 통과 후 이번 변경과 무관한 기존 frontend ESLint baseline 47건으로 실패합니다. 변경 파일 대상 ESLint, focused/full tests, build, diff checks는 통과했습니다.
- hook 실패는 repository-wide lint baseline 때문이라 변경 파일 대상 검증을 근거로 hook을 우회해 커밋했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 워크스페이스 미리보기 링크가 현재 워크스페이스 기준으로 자동 라우팅됩니다. 워크스페이스가 있으면 해당 워크스페이스의 채팅 페이지로, 없으면 공개 데모로 이동합니다.
  * 새 탭 오픈 시 목적지에 따른 맞춤 라벨이 제공됩니다.

* **Tests**
  * 사용자 채팅 경로 및 워크스페이스 ID 추출 로직에 대한 테스트가 추가되었습니다.
  * 워크스페이스 미리보기 링크 라우팅 테스트가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->