### PR TITLE
refactor(frontend): 도메인팩 상세가 워크스페이스 shell을 공유

### DIFF
--- a/.agent/specs/783.md
+++ b/.agent/specs/783.md
@@ -1,0 +1,131 @@
+# Frontend Spec: 도메인팩 상세 화면이 워크스페이스 shell을 공유한다
+
+## Goal
+
+도메인팩 상세 화면을 워크스페이스 내부 라우트로 편입하여 `WorkspaceLayout`이 sidebar, topbar, breadcrumb, workspace context를 일관되게 소유한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["사용자가 /workspaces/:workspaceId/domain-packs에 진입"] --> B["WorkspaceLayout shell 렌더링"]
+    B --> C["도메인팩 목록 표시"]
+    C --> D["사용자가 도메인팩 상세 URL로 이동"]
+    D --> E["동일 WorkspaceLayout shell 유지"]
+    E --> F["DomainPackRouteOutlet이 shell context 전달"]
+    F --> G["상세 하위 페이지가 breadcrumb/topbar 상태 설정"]
+```
+
+## Design Diff
+
+| 영역              | As-is                                                                  | To-be                                              | 변경 내용                                             |
+| ----------------- | ---------------------------------------------------------------------- | -------------------------------------------------- | ----------------------------------------------------- |
+| 라우트 소유권     | `/workspaces/:workspaceId/domain-packs/:packId`가 별도 top-level route | `/workspaces/:workspaceId`의 child route           | 상세 URL은 유지하되 `WorkspaceLayout` 아래에서 렌더링 |
+| shell 렌더링      | 도메인팩 상세 페이지가 `OstoneShell`을 직접 렌더링                     | 상세 페이지가 `ShellContext`로 topbar 상태 설정    | 중복 shell 생성 제거                                  |
+| breadcrumb/topbar | 각 상세 페이지가 shell props로 직접 전달                               | workspace shell context에 전달                     | workspace 내부 화면과 동일한 topbar 책임 구조 사용    |
+| sidebar active    | 상세 페이지별 shell active prop에 의존                                 | `WorkspaceLayout`의 pathname 기반 active 계산 사용 | domain-pack 상세도 workspace sidebar active 동작 공유 |
+
+## Component Tree
+
+```text
+App
+└─ Route /workspaces/:workspaceId
+   └─ WorkspaceLayout
+      ├─ OstoneShell
+      └─ Outlet context={ShellContext}
+         ├─ DomainPackListPage
+         └─ DomainPackRouteOutlet
+            └─ Outlet context={ShellContext}
+               ├─ DomainPackSummaryPage
+               ├─ IntentDraftReadPage
+               ├─ PolicyDraftReadPage
+               ├─ RiskDraftReadPage
+               ├─ SlotDraftReadPage
+               ├─ PackWorkflowListPage
+               ├─ WorkflowDraftReadPage
+               └─ WorkflowGraphViewerPage
+```
+
+## API Integration
+
+이 변경은 프론트엔드 라우팅과 layout 책임만 조정한다. 신규 API, generated client, query key 변경은 없다.
+
+## Data Flow
+
+```text
+WorkspaceLayout
+  └─ ShellContext
+      ├─ setCrumbs(Crumb[])
+      ├─ setTopbarRight(ReactNode | undefined)
+      └─ workspace
+
+DomainPack detail pages
+  ├─ route params/search params 해석
+  ├─ 기존 pack/version/workflow 조회 유지
+  └─ useEffect로 breadcrumb/topbar 상태 등록 및 unmount cleanup
+```
+
+## 수정 대상 파일
+
+| 파일                                                                 | 변경 유형 | 설명                                                                           |
+| -------------------------------------------------------------------- | --------- | ------------------------------------------------------------------------------ |
+| `frontend/src/app/App.tsx`                                           | update    | 도메인팩 상세 route를 workspace route 하위로 이동                              |
+| `frontend/src/shared/ui/ostone/chrome/ShellContext.ts`               | update    | link-aware breadcrumb를 전달할 수 있도록 crumb type 확장                       |
+| `frontend/src/pages/workspace/ui/WorkspaceLayout.tsx`                | update    | `Crumb[]` 상태와 도메인팩 상세 active 계산 유지                                |
+| `frontend/src/pages/domain-pack/ui/DomainPackRouteOutlet.tsx`        | update    | workspace shell context를 상세 하위 route에 전달                               |
+| `frontend/src/pages/domain-pack/ui/DomainPackShellState.tsx`         | new       | 상세 페이지가 `ShellContext`에 breadcrumb/topbar state를 등록하는 공통 wrapper |
+| `frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.tsx`        | update    | 직접 shell 렌더링 제거, shell context 사용                                     |
+| `frontend/src/pages/domain-pack/ui/IntentDraftReadPage.tsx`          | update    | 직접 shell 렌더링 제거, shell context 사용                                     |
+| `frontend/src/pages/domain-pack/ui/PolicyDraftReadPage.tsx`          | update    | 직접 shell 렌더링 제거, shell context 사용                                     |
+| `frontend/src/pages/domain-pack/ui/RiskDraftReadPage.tsx`            | update    | 직접 shell 렌더링 제거, shell context 사용                                     |
+| `frontend/src/pages/domain-pack/ui/SlotDraftReadPage.tsx`            | update    | 직접 shell 렌더링 제거, shell context 사용                                     |
+| `frontend/src/pages/domain-pack/ui/PackWorkflowListPage.tsx`         | update    | 직접 shell 렌더링 제거, shell context 사용                                     |
+| `frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx`        | update    | 직접 shell 렌더링 제거, shell context 사용                                     |
+| `frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.tsx`      | update    | 직접 shell 렌더링 제거, shell context 사용                                     |
+| `frontend/src/app/App.test.tsx`                                      | update    | 상세 URL이 workspace shell을 공유하는 routing regression 추가                  |
+| `frontend/src/pages/domain-pack/ui/DomainPackRouteOutlet.test.tsx`   | update    | outlet이 workspace shell context를 하위 route에 전달하는지 확인                |
+| `frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.test.tsx`   | update    | summary page의 breadcrumb shell context 등록 확인                              |
+| `frontend/src/pages/domain-pack/ui/IntentDraftReadPage.test.tsx`     | update    | intent detail page의 shell context host 기준 동작 확인                         |
+| `frontend/src/pages/domain-pack/ui/PolicyDraftReadPage.test.tsx`     | update    | policy detail page의 shell context host 기준 동작 확인                         |
+| `frontend/src/pages/domain-pack/ui/RiskDraftReadPage.test.tsx`       | update    | risk detail page의 shell context host 기준 동작 확인                           |
+| `frontend/src/pages/domain-pack/ui/SlotDraftReadPage.test.tsx`       | update    | slot detail page의 shell context host 기준 동작 확인                           |
+| `frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.test.tsx`   | update    | workflow detail page의 breadcrumb shell context 등록 확인                      |
+| `frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.test.tsx` | update    | graph viewer page의 shell context 등록 확인                                    |
+| `frontend/src/pages/domain-pack/ui/PackWorkflowListPage.test.tsx`    | update    | workflow list page의 shell context 등록 확인                                   |
+
+## State Management
+
+- `WorkspaceLayout`은 기존처럼 `topbarRight`와 `crumbs`를 local state로 보관한다.
+- 도메인팩 상세 페이지는 route params와 조회 결과로 만든 breadcrumb/topbar right node를 `ShellContext`에 등록한다.
+- 상세 페이지 unmount 시 `setCrumbs([])`와 `setTopbarRight(undefined)`로 workspace 기본 상태 복귀를 보장한다.
+
+## Tests
+
+### Test Strategy
+
+| 구분                    | 방법                           | 도구                           | 비고                                                       |
+| ----------------------- | ------------------------------ | ------------------------------ | ---------------------------------------------------------- |
+| 라우팅 regression       | 실제 `App` route 렌더링        | Vitest + React Testing Library | 상세 URL이 workspace shell/sidebar를 공유하는지 확인       |
+| 상세 페이지 단위 테스트 | `MemoryRouter` + shell context | Vitest + React Testing Library | 기존 상세 동작 유지 및 breadcrumb/topbar context 등록 확인 |
+| 정적 검증               | frontend focused test/build    | pnpm scripts                   | 변경 범위에 맞춰 frontend 검증                             |
+
+### Acceptance Criteria
+
+| #   | 기준                                                      | 기대 결과                                                            |
+| --- | --------------------------------------------------------- | -------------------------------------------------------------------- |
+| 1   | `/workspaces/:workspaceId/domain-packs/:packId` 상세 진입 | `WorkspaceLayout` 하위에서 상세 화면 렌더링                          |
+| 2   | 상세 하위 페이지 렌더링                                   | 상세 페이지가 직접 `OstoneShell`을 만들지 않고 `ShellContext`를 사용 |
+| 3   | sidebar active                                            | 도메인팩 상세 및 하위 섹션에서 sidebar의 도메인팩 항목이 active      |
+| 4   | breadcrumb/topbar                                         | workspace 내부 화면과 같은 topbar에서 breadcrumb와 우측 액션 표시    |
+| 5   | URL 유지                                                  | 기존 상세 및 하위 URL 경로 유지                                      |
+| 6   | 라우팅 테스트                                             | 상세 경로의 shell 공유를 검증하는 테스트 추가                        |
+
+### Non-goals
+
+- 도메인팩 상세 데이터 조회 API나 generated client 변경은 하지 않는다.
+- 도메인팩 상세 UI의 시각 디자인, 편집 플로우, 검토/배포 동작은 변경하지 않는다.
+- workspace shell 자체의 visual redesign은 하지 않는다.
+
+### Open Questions
+
+- 없음. 이슈 본문과 확인된 기존 경로 기준으로 구현 범위를 확정한다.

--- a/frontend/src/app/App.test.tsx
+++ b/frontend/src/app/App.test.tsx
@@ -1,5 +1,12 @@
 import { render, screen, waitFor } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vite-plus/test";
 import { App } from "./App";
 import { AppProviders } from "./providers";
 
@@ -64,7 +71,11 @@ describe("App", () => {
   });
 
   it("redirects legacy demo workspace chat URLs to the canonical demo chat URL", async () => {
-    window.history.pushState({}, "", "/demo/workspaces/42/chat?name=%EA%B9%80%EB%AF%BC%EC%A7%80");
+    window.history.pushState(
+      {},
+      "",
+      "/demo/workspaces/42/chat?name=%EA%B9%80%EB%AF%BC%EC%A7%80",
+    );
 
     render(
       <AppProviders>
@@ -80,7 +91,11 @@ describe("App", () => {
 
   it("redirects legacy authenticated workspace chat URLs to the user chat URL", async () => {
     seedAuthenticatedSession();
-    window.history.pushState({}, "", "/workspaces/42/chat?name=%EA%B9%80%EB%AF%BC%EC%A7%80");
+    window.history.pushState(
+      {},
+      "",
+      "/workspaces/42/chat?name=%EA%B9%80%EB%AF%BC%EC%A7%80",
+    );
 
     render(
       <AppProviders>
@@ -122,7 +137,9 @@ describe("App", () => {
           }),
         );
       }
-      if (url.startsWith("/api/v1/workspaces/1/dashboard/action-recommendations")) {
+      if (
+        url.startsWith("/api/v1/workspaces/1/dashboard/action-recommendations")
+      ) {
         return Promise.resolve(
           jsonResponse({
             workspaceId: 1,
@@ -158,5 +175,53 @@ describe("App", () => {
       "/api/v1/workspaces/1/dashboard/knowledge-pack-health",
       expect.objectContaining({ method: "GET" }),
     );
+  });
+
+  it("renders domain pack detail URLs inside the workspace shell", async () => {
+    seedAuthenticatedSession();
+
+    const workspaceBody = {
+      id: 1,
+      workspaceKey: "cs-team-alpha",
+      name: "CS Team Alpha",
+      description: null,
+      status: "ACTIVE",
+      myRole: "OWNER",
+      createdAt: "2026-04-01T00:00:00Z",
+      updatedAt: "2026-04-01T00:00:00Z",
+    };
+    const packBody = {
+      packId: 2,
+      name: "CS Pack",
+      code: "CS",
+      currentVersionId: null,
+      currentVersionNo: null,
+      versions: [],
+    };
+
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (url === "/api/v1/workspaces/1") {
+        return Promise.resolve(jsonResponse(workspaceBody));
+      }
+      if (url === "/api/v1/workspaces/1/domain-packs/2") {
+        return Promise.resolve(jsonResponse({ data: packBody }));
+      }
+      return Promise.resolve(jsonResponse({ data: [] }));
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+    window.history.pushState({}, "", "/workspaces/1/domain-packs/2");
+
+    render(
+      <AppProviders>
+        <App />
+      </AppProviders>,
+    );
+
+    expect((await screen.findAllByText("CS Pack")).length).toBeGreaterThan(0);
+    const domainLink = screen.getByTestId("sidebar-domain-link");
+    expect(domainLink).toHaveAttribute("href", "/workspaces/1/domain-packs");
+    expect(domainLink).toHaveAttribute("data-active", "true");
+    expect(screen.getByText("CStone")).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -1,4 +1,11 @@
-import { BrowserRouter, Routes, Route, Navigate, useLocation, useParams } from "react-router-dom";
+import {
+  BrowserRouter,
+  Routes,
+  Route,
+  Navigate,
+  useLocation,
+  useParams,
+} from "react-router-dom";
 import { LoginPage } from "../pages/login/ui/LoginPage";
 import { SignupPage } from "../pages/signup/ui/SignupPage";
 import { WorkspaceRootRedirect } from "../pages/workspace/ui/WorkspaceRootRedirect";
@@ -25,7 +32,11 @@ import { DomainPackRouteOutlet } from "../pages/domain-pack/ui/DomainPackRouteOu
 import { WorkspaceLayout } from "../pages/workspace/ui/WorkspaceLayout";
 import { WorkspaceDashboardPage } from "../pages/workspace/ui/WorkspaceDashboardPage";
 import { WorkspaceMembersPage } from "../pages/workspace/ui/WorkspaceMembersPage";
-import { BillingPage, BillingSuccessPage, BillingFailPage } from "../pages/billing";
+import {
+  BillingPage,
+  BillingSuccessPage,
+  BillingFailPage,
+} from "../pages/billing";
 import { WorkspaceWorkflowsPage } from "../pages/workspace/ui/WorkspaceWorkflowsPage";
 import { WorkspaceSimulationPage } from "../pages/workspace/ui/WorkspaceSimulationPage";
 import { WorkspaceUploadPage } from "../pages/upload/ui/WorkspaceUploadPage";
@@ -70,7 +81,10 @@ export function App() {
         <Route path="/login" element={<LoginPage />} />
         <Route path="/signup" element={<SignupPage />} />
         <Route path="/password-reset" element={<PasswordResetInitPage />} />
-        <Route path="/password-reset/complete" element={<PasswordResetCompletePage />} />
+        <Route
+          path="/password-reset/complete"
+          element={<PasswordResetCompletePage />}
+        />
         <Route
           path="/admin"
           element={
@@ -105,19 +119,67 @@ export function App() {
           <Route path="dashboard" element={<WorkspaceDashboardPage />} />
           <Route path="workflows" element={<WorkspaceWorkflowsPage />} />
           <Route path="simulation" element={<WorkspaceSimulationPage />} />
-          <Route path="pipeline" element={<Navigate to="../upload" replace />} />
+          <Route
+            path="pipeline"
+            element={<Navigate to="../upload" replace />}
+          />
           <Route path="consultation/history" element={<ChatHistoryPage />} />
-          <Route path="consultation/history/:sessionId" element={<ChatHistoryPage />} />
+          <Route
+            path="consultation/history/:sessionId"
+            element={<ChatHistoryPage />}
+          />
           <Route path="consultation" element={<ConsultationPage />} />
-          <Route path="consultation/:sessionId" element={<ConsultationPage />} />
+          <Route
+            path="consultation/:sessionId"
+            element={<ConsultationPage />}
+          />
           <Route path="upload" element={<WorkspaceUploadPage />} />
-          <Route path="pipeline-jobs/:pipelineJobId/review" element={<PipelineReviewPage />} />
+          <Route
+            path="pipeline-jobs/:pipelineJobId/review"
+            element={<PipelineReviewPage />}
+          />
           <Route path="domain-packs" element={<DomainPackListPage />} />
+          <Route
+            path="domain-packs/:packId"
+            element={<DomainPackRouteOutlet />}
+          >
+            <Route index element={<DomainPackSummaryPage />} />
+            <Route path="intents" element={<IntentDraftReadPage />}>
+              <Route path=":intentId" />
+            </Route>
+            <Route path="policies" element={<PolicyDraftReadPage />}>
+              <Route path=":policyId" />
+            </Route>
+            <Route path="risks" element={<RiskDraftReadPage />}>
+              <Route path=":riskId" />
+            </Route>
+            <Route path="slots" element={<SlotDraftReadPage />}>
+              <Route path=":slotId" />
+            </Route>
+            <Route path="workflows">
+              <Route index element={<PackWorkflowListPage />} />
+              <Route path=":workflowId" element={<WorkflowDraftReadPage />} />
+              <Route
+                path=":workflowId/graph"
+                element={<WorkflowGraphViewerPage />}
+              />
+            </Route>
+            <Route
+              path="versions/:versionId/*"
+              element={<LegacyDomainPackVersionRedirect />}
+            />
+            <Route
+              path="versions/:versionId"
+              element={<LegacyDomainPackVersionRedirect />}
+            />
+          </Route>
           <Route path="settings/members" element={<WorkspaceMembersPage />} />
           <Route
             path="billing"
             element={
-              <ErrorBoundary fallback={<div>페이지를 불러오는 중 오류가 발생했습니다.</div>}>
+              <ErrorBoundary
+                fallback={<div>페이지를 불러오는 중 오류가 발생했습니다.</div>}
+              >
                 <BillingPage />
               </ErrorBoundary>
             }
@@ -127,7 +189,9 @@ export function App() {
           path="/billing/success"
           element={
             <PrivateRoute>
-              <ErrorBoundary fallback={<div>페이지를 불러오는 중 오류가 발생했습니다.</div>}>
+              <ErrorBoundary
+                fallback={<div>페이지를 불러오는 중 오류가 발생했습니다.</div>}
+              >
                 <BillingSuccessPage />
               </ErrorBoundary>
             </PrivateRoute>
@@ -137,7 +201,9 @@ export function App() {
           path="/billing/fail"
           element={
             <PrivateRoute>
-              <ErrorBoundary fallback={<div>페이지를 불러오는 중 오류가 발생했습니다.</div>}>
+              <ErrorBoundary
+                fallback={<div>페이지를 불러오는 중 오류가 발생했습니다.</div>}
+              >
                 <BillingFailPage />
               </ErrorBoundary>
             </PrivateRoute>
@@ -146,7 +212,9 @@ export function App() {
         <Route
           path="/demo"
           element={
-            <ErrorBoundary fallback={<div>페이지를 불러오는 중 오류가 발생했습니다.</div>}>
+            <ErrorBoundary
+              fallback={<div>페이지를 불러오는 중 오류가 발생했습니다.</div>}
+            >
               <DemoPage />
             </ErrorBoundary>
           }
@@ -168,7 +236,10 @@ export function App() {
             </PrivateRoute>
           }
         />
-        <Route path="/demo/workspaces/:workspaceId/chat" element={<LegacyDemoChatRedirect />} />
+        <Route
+          path="/demo/workspaces/:workspaceId/chat"
+          element={<LegacyDemoChatRedirect />}
+        />
         <Route
           path="/upload"
           element={
@@ -193,35 +264,6 @@ export function App() {
             </PrivateRoute>
           }
         />
-        <Route
-          path="/workspaces/:workspaceId/domain-packs/:packId"
-          element={
-            <PrivateRoute>
-              <DomainPackRouteOutlet />
-            </PrivateRoute>
-          }
-        >
-          <Route index element={<DomainPackSummaryPage />} />
-          <Route path="intents" element={<IntentDraftReadPage />}>
-            <Route path=":intentId" />
-          </Route>
-          <Route path="policies" element={<PolicyDraftReadPage />}>
-            <Route path=":policyId" />
-          </Route>
-          <Route path="risks" element={<RiskDraftReadPage />}>
-            <Route path=":riskId" />
-          </Route>
-          <Route path="slots" element={<SlotDraftReadPage />}>
-            <Route path=":slotId" />
-          </Route>
-          <Route path="workflows">
-            <Route index element={<PackWorkflowListPage />} />
-            <Route path=":workflowId" element={<WorkflowDraftReadPage />} />
-            <Route path=":workflowId/graph" element={<WorkflowGraphViewerPage />} />
-          </Route>
-          <Route path="versions/:versionId/*" element={<LegacyDomainPackVersionRedirect />} />
-          <Route path="versions/:versionId" element={<LegacyDomainPackVersionRedirect />} />
-        </Route>
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
     </BrowserRouter>

--- a/frontend/src/pages/domain-pack/ui/DomainPackRouteOutlet.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackRouteOutlet.test.tsx
@@ -1,23 +1,51 @@
 import { render, screen } from "@testing-library/react";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import {
+  MemoryRouter,
+  Outlet,
+  Route,
+  Routes,
+  useOutletContext,
+} from "react-router-dom";
 import { describe, expect, it } from "vitest";
+import type { ShellContext } from "@/shared/ui/ostone/chrome";
 import { DomainPackRouteOutlet } from "./DomainPackRouteOutlet";
 
+function WorkspaceShellHost() {
+  const context: ShellContext = {
+    setCrumbs: () => undefined,
+    setTopbarRight: () => undefined,
+    workspace: { id: 1, name: "CS Team" },
+  } as ShellContext;
+
+  return <Outlet context={context} />;
+}
+
+function ShellContextProbe() {
+  const { workspace } = useOutletContext<ShellContext>();
+
+  return <div>{workspace?.name}</div>;
+}
+
 describe("DomainPackRouteOutlet", () => {
-  it("하위 route element를 렌더링한다", () => {
+  it("workspace shell context를 하위 route에 전달한다", () => {
     render(
       <MemoryRouter initialEntries={["/workspaces/1/domain-packs/2/intents"]}>
         <Routes>
           <Route
-            path="/workspaces/:workspaceId/domain-packs/:packId"
-            element={<DomainPackRouteOutlet />}
+            path="/workspaces/:workspaceId"
+            element={<WorkspaceShellHost />}
           >
-            <Route path="intents" element={<div>intent child</div>} />
+            <Route
+              path="domain-packs/:packId"
+              element={<DomainPackRouteOutlet />}
+            >
+              <Route path="intents" element={<ShellContextProbe />} />
+            </Route>
           </Route>
         </Routes>
       </MemoryRouter>,
     );
 
-    expect(screen.getByText("intent child")).toBeInTheDocument();
+    expect(screen.getByText("CS Team")).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/domain-pack/ui/DomainPackRouteOutlet.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackRouteOutlet.tsx
@@ -1,5 +1,8 @@
-import { Outlet } from "react-router-dom";
+import { Outlet, useOutletContext } from "react-router-dom";
+import type { ShellContext } from "@/shared/ui/ostone/chrome";
 
 export function DomainPackRouteOutlet() {
-  return <Outlet />;
+  const shellContext = useOutletContext<ShellContext>();
+
+  return <Outlet context={shellContext} />;
 }

--- a/frontend/src/pages/domain-pack/ui/DomainPackShellState.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackShellState.tsx
@@ -1,0 +1,31 @@
+import { useEffect, type ReactNode } from "react";
+import { useOutletContext } from "react-router-dom";
+import type { Crumb, ShellContext } from "@/shared/ui/ostone/chrome";
+
+interface DomainPackShellStateProps {
+  crumbs: Crumb[];
+  topbarRight?: ReactNode;
+  children: ReactNode;
+}
+
+const EMPTY_CRUMBS: Crumb[] = [];
+
+export function DomainPackShellState({
+  crumbs,
+  topbarRight,
+  children,
+}: DomainPackShellStateProps) {
+  const { setCrumbs, setTopbarRight } = useOutletContext<ShellContext>();
+
+  useEffect(() => {
+    setCrumbs(crumbs);
+    setTopbarRight(topbarRight);
+
+    return () => {
+      setCrumbs(EMPTY_CRUMBS);
+      setTopbarRight(undefined);
+    };
+  }, [crumbs, setCrumbs, setTopbarRight, topbarRight]);
+
+  return <>{children}</>;
+}

--- a/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.test.tsx
@@ -1,6 +1,13 @@
+import { useState } from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import {
+  MemoryRouter,
+  Outlet,
+  Route,
+  Routes,
+  useLocation,
+} from "react-router-dom";
 import { toast } from "sonner";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ApiRequestError } from "@/shared/api";
@@ -10,28 +17,14 @@ import {
   type ActivateMutationResult,
 } from "@/shared/api/generated/endpoints/activate-domain-pack-version-controller/activate-domain-pack-version-controller";
 import { useDiscard } from "@/shared/api/generated/endpoints/discard-draft-version-controller/discard-draft-version-controller";
-import { usePackDetail, useVersionDetail } from "@/features/domain-pack-summary-read";
+import {
+  usePackDetail,
+  useVersionDetail,
+} from "@/features/domain-pack-summary-read";
 import { DomainPackSummaryPage } from "./DomainPackSummaryPage";
 
 vi.mock("sonner", () => ({
   toast: { error: vi.fn(), success: vi.fn() },
-}));
-
-vi.mock("@/widgets/ostone-shell", () => ({
-  OstoneShell: ({
-    children,
-    crumbs,
-  }: {
-    children: React.ReactNode;
-    crumbs?: Array<string | { label: string }>;
-  }) => (
-    <div>
-      <div data-testid="shell-crumbs">
-        {crumbs?.map((crumb) => (typeof crumb === "string" ? crumb : crumb.label)).join(" / ")}
-      </div>
-      {children}
-    </div>
-  ),
 }));
 
 vi.mock("@/shared/ui/ostone/atoms/LoadingSpinner", () => ({
@@ -39,7 +32,13 @@ vi.mock("@/shared/ui/ostone/atoms/LoadingSpinner", () => ({
 }));
 
 vi.mock("@/shared/ui/ostone/atoms/ErrorState", () => ({
-  ErrorState: ({ message, onRetry }: { message: string; onRetry?: () => void }) => (
+  ErrorState: ({
+    message,
+    onRetry,
+  }: {
+    message: string;
+    onRetry?: () => void;
+  }) => (
     <div data-testid="error-state" role="alert">
       <span>{message}</span>
       {onRetry && (
@@ -88,7 +87,10 @@ vi.mock("@/features/domain-pack-summary-read", () => ({
       <button type="button" onClick={() => onDeploy(4)}>
         deploy version
       </button>
-      <button type="button" onClick={() => onApplyDraft(5, "변경사항 정리 메모")}>
+      <button
+        type="button"
+        onClick={() => onApplyDraft(5, "변경사항 정리 메모")}
+      >
         apply draft
       </button>
       <button type="button" onClick={() => onApplyDraft(5, "")}>
@@ -136,7 +138,9 @@ function makePackQuery(overrides: Record<string, unknown> = {}): any {
   };
 }
 
-type ActivateMockData = ActivateMutationResult["data"] & { description?: string };
+type ActivateMockData = ActivateMutationResult["data"] & {
+  description?: string;
+};
 
 function makeActivateResponse(data: ActivateMockData): ActivateMutationResult {
   return {
@@ -148,7 +152,26 @@ function makeActivateResponse(data: ActivateMockData): ActivateMutationResult {
 
 function LocationProbe() {
   const location = useLocation();
-  return <div data-testid="location">{`${location.pathname}${location.search}`}</div>;
+  return (
+    <div data-testid="location">{`${location.pathname}${location.search}`}</div>
+  );
+}
+
+function ShellHost() {
+  const [crumbs, setCrumbs] = useState<Array<string | { label: string }>>([]);
+  const [topbarRight, setTopbarRight] = useState<React.ReactNode>();
+
+  return (
+    <>
+      <div data-testid="shell-crumbs">
+        {crumbs
+          .map((crumb) => (typeof crumb === "string" ? crumb : crumb.label))
+          .join(" / ")}
+      </div>
+      <div data-testid="shell-topbar">{topbarRight}</div>
+      <Outlet context={{ setCrumbs, setTopbarRight, workspace: null }} />
+    </>
+  );
 }
 
 function renderPage(path = "/workspaces/1/domain-packs/2") {
@@ -161,13 +184,18 @@ function renderPage(path = "/workspaces/1/domain-packs/2") {
         <Routes>
           <Route
             path="/workspaces/:workspaceId/domain-packs/:packId"
-            element={
-              <>
-                <DomainPackSummaryPage />
-                <LocationProbe />
-              </>
-            }
-          />
+            element={<ShellHost />}
+          >
+            <Route
+              index
+              element={
+                <>
+                  <DomainPackSummaryPage />
+                  <LocationProbe />
+                </>
+              }
+            />
+          </Route>
         </Routes>
       </MemoryRouter>
     </QueryClientProvider>,
@@ -205,16 +233,22 @@ describe("DomainPackSummaryPage", () => {
       makePackQuery({ isError: true, error: new Error("fail"), refetch }),
     );
     renderPage();
-    expect(screen.getByRole("alert")).toHaveTextContent("Pack 정보를 불러오지 못했습니다.");
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Pack 정보를 불러오지 못했습니다.",
+    );
     fireEvent.click(screen.getByRole("button", { name: "다시 시도" }));
     expect(refetch).toHaveBeenCalled();
   });
 
   it('packDetail 404 에러 시 "Pack을 찾을 수 없습니다." 메시지를 표시한다', () => {
     const error404 = new ApiRequestError(404, "NOT_FOUND", "not found");
-    vi.mocked(usePackDetail).mockReturnValue(makePackQuery({ isError: true, error: error404 }));
+    vi.mocked(usePackDetail).mockReturnValue(
+      makePackQuery({ isError: true, error: error404 }),
+    );
     renderPage();
-    expect(screen.getByRole("alert")).toHaveTextContent("Pack을 찾을 수 없습니다.");
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Pack을 찾을 수 없습니다.",
+    );
   });
 
   it("정상 상태에서 VersionListPanel과 SummaryDetailPanel을 렌더링한다", () => {
@@ -237,7 +271,9 @@ describe("DomainPackSummaryPage", () => {
 
     renderPage();
 
-    expect(screen.getByTestId("shell-crumbs")).toHaveTextContent("도메인팩 / CS Pack");
+    expect(screen.getByTestId("shell-crumbs")).toHaveTextContent(
+      "도메인팩 / CS Pack",
+    );
     expect(screen.getByTestId("shell-crumbs")).not.toHaveTextContent("WS · 1");
   });
 
@@ -266,7 +302,9 @@ describe("DomainPackSummaryPage", () => {
     );
     expect(useVersionDetail).toHaveBeenCalledWith(1, 2, 3);
     expect(screen.getByTestId("selected-version-id")).toHaveTextContent("3");
-    expect(screen.getByTestId("shell-crumbs")).toHaveTextContent("도메인팩 / CS Pack / #2");
+    expect(screen.getByTestId("shell-crumbs")).toHaveTextContent(
+      "도메인팩 / CS Pack / #2",
+    );
   });
 
   it("배포중 버전이 없으면 최신 draft 버전을 기본 선택한다", async () => {
@@ -423,7 +461,9 @@ describe("DomainPackSummaryPage", () => {
     renderPage("/workspaces/1/domain-packs/2");
 
     await waitFor(() =>
-      expect(screen.getByTestId("location")).toHaveTextContent("/workspaces/1/domain-packs/2"),
+      expect(screen.getByTestId("location")).toHaveTextContent(
+        "/workspaces/1/domain-packs/2",
+      ),
     );
     expect(useVersionDetail).toHaveBeenCalledWith(1, 2, null);
     expect(screen.getByTestId("selected-version-id")).toHaveTextContent("none");
@@ -521,7 +561,9 @@ describe("DomainPackSummaryPage", () => {
     renderPage("/workspaces/1/domain-packs/2?versionId=3");
     fireEvent.click(screen.getByRole("button", { name: "deploy version" }));
 
-    expect(toast.error).toHaveBeenCalledWith("도메인팩 버전을 배포하지 못했습니다.");
+    expect(toast.error).toHaveBeenCalledWith(
+      "도메인팩 버전을 배포하지 못했습니다.",
+    );
   });
 
   it("버전 배포 실패 시 API 에러 메시지를 toast에 사용한다", () => {
@@ -622,7 +664,9 @@ describe("DomainPackSummaryPage", () => {
     );
 
     renderPage("/workspaces/1/domain-packs/2?versionId=5");
-    fireEvent.click(screen.getByRole("button", { name: "apply draft without description" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "apply draft without description" }),
+    );
 
     await waitFor(() => expect(activate).toHaveBeenCalled());
     expect(activate).toHaveBeenCalledWith(1, 2, 5, undefined);
@@ -630,7 +674,9 @@ describe("DomainPackSummaryPage", () => {
 
   it("Draft 적용 성공 후 기존 draft 상세 refetch 실패로 실패 toast를 띄우지 않는다", async () => {
     const packRefetch = vi.fn().mockRejectedValue(new Error("refetch failed"));
-    const versionRefetch = vi.fn().mockRejectedValue(new Error("old draft missing"));
+    const versionRefetch = vi
+      .fn()
+      .mockRejectedValue(new Error("old draft missing"));
     vi.mocked(activate).mockResolvedValue(makeActivateResponse({ id: 6 }));
     vi.mocked(usePackDetail).mockReturnValue(
       makePackQuery({
@@ -660,8 +706,12 @@ describe("DomainPackSummaryPage", () => {
     );
     expect(packRefetch).toHaveBeenCalled();
     expect(versionRefetch).toHaveBeenCalled();
-    expect(toast.success).toHaveBeenCalledWith("초안 수정버전이 적용되었습니다.");
-    expect(toast.error).not.toHaveBeenCalledWith("초안 수정버전을 적용하지 못했습니다.");
+    expect(toast.success).toHaveBeenCalledWith(
+      "초안 수정버전이 적용되었습니다.",
+    );
+    expect(toast.error).not.toHaveBeenCalledWith(
+      "초안 수정버전을 적용하지 못했습니다.",
+    );
   });
 
   it("Draft 적용 성공 응답의 description이 있으면 성공 처리한다", async () => {
@@ -694,7 +744,9 @@ describe("DomainPackSummaryPage", () => {
         "/workspaces/1/domain-packs/2?versionId=6",
       ),
     );
-    expect(toast.success).toHaveBeenCalledWith("초안 수정버전이 적용되었습니다.");
+    expect(toast.success).toHaveBeenCalledWith(
+      "초안 수정버전이 적용되었습니다.",
+    );
   });
 
   it("Draft 적용 성공 응답의 data.id로 적용된 버전으로 이동한다", async () => {
@@ -757,7 +809,9 @@ describe("DomainPackSummaryPage", () => {
         "/workspaces/1/domain-packs/2?versionId=8",
       ),
     );
-    expect(toast.success).toHaveBeenCalledWith("초안 수정버전이 적용되었습니다.");
+    expect(toast.success).toHaveBeenCalledWith(
+      "초안 수정버전이 적용되었습니다.",
+    );
   });
 
   it("Draft 적용 실패 시 상담사 용어의 실패 toast를 띄운다", async () => {
@@ -777,7 +831,9 @@ describe("DomainPackSummaryPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "apply draft" }));
 
     await waitFor(() =>
-      expect(toast.error).toHaveBeenCalledWith("초안 수정버전을 적용하지 못했습니다."),
+      expect(toast.error).toHaveBeenCalledWith(
+        "초안 수정버전을 적용하지 못했습니다.",
+      ),
     );
   });
 
@@ -810,7 +866,9 @@ describe("DomainPackSummaryPage", () => {
   });
 
   it("Draft 삭제 성공 후 운영 버전이 없으면 versionId를 제거한다", async () => {
-    const packRefetch = vi.fn().mockResolvedValue({ data: { currentVersionId: null } });
+    const packRefetch = vi
+      .fn()
+      .mockResolvedValue({ data: { currentVersionId: null } });
     let discardOnSuccess: (() => unknown) | undefined;
     const mutate = vi.fn(() => discardOnSuccess?.());
     vi.mocked(useDiscard).mockImplementation((options) => {
@@ -838,9 +896,13 @@ describe("DomainPackSummaryPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "delete draft" }));
 
     await waitFor(() =>
-      expect(screen.getByTestId("location")).toHaveTextContent("/workspaces/1/domain-packs/2"),
+      expect(screen.getByTestId("location")).toHaveTextContent(
+        "/workspaces/1/domain-packs/2",
+      ),
     );
-    expect(toast.success).toHaveBeenCalledWith("검토 중인 버전이 삭제되었습니다.");
+    expect(toast.success).toHaveBeenCalledWith(
+      "검토 중인 버전이 삭제되었습니다.",
+    );
   });
 
   it("currentVersionId가 없으면 PUBLISHED 버전이 하나뿐이어도 운영 버전을 추론하지 않는다", () => {
@@ -850,7 +912,9 @@ describe("DomainPackSummaryPage", () => {
           packId: 2,
           name: "CS Pack",
           code: "CS",
-          versions: [{ versionId: 4, versionNo: 2, lifecycleStatus: "PUBLISHED" }],
+          versions: [
+            { versionId: 4, versionNo: 2, lifecycleStatus: "PUBLISHED" },
+          ],
         },
       }),
     );
@@ -869,7 +933,9 @@ describe("DomainPackSummaryPage", () => {
           code: "CS",
           currentVersionId: 3,
           currentVersionNo: 7,
-          versions: [{ versionId: 3, versionNo: 7, lifecycleStatus: "PUBLISHED" }],
+          versions: [
+            { versionId: 3, versionNo: 7, lifecycleStatus: "PUBLISHED" },
+          ],
         },
       }),
     );
@@ -889,7 +955,9 @@ describe("DomainPackSummaryPage", () => {
           code: "CS",
           currentVersionId: 3,
           currentVersionNo: null,
-          versions: [{ versionId: 3, versionNo: 2, lifecycleStatus: "PUBLISHED" }],
+          versions: [
+            { versionId: 3, versionNo: 2, lifecycleStatus: "PUBLISHED" },
+          ],
         },
       }),
     );
@@ -926,11 +994,15 @@ describe("DomainPackSummaryPage", () => {
       }),
     );
     renderPage();
-    expect(screen.queryByRole("button", { name: "새 검토본 묶기" })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "새 검토본 묶기" }),
+    ).not.toBeInTheDocument();
   });
 
   it("packDetail 로딩 중 LoadingSpinner를 표시한다", () => {
-    vi.mocked(usePackDetail).mockReturnValue(makePackQuery({ isLoading: true }));
+    vi.mocked(usePackDetail).mockReturnValue(
+      makePackQuery({ isLoading: true }),
+    );
     renderPage();
     expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
     expect(screen.queryByTestId("version-list-panel")).not.toBeInTheDocument();
@@ -942,22 +1014,32 @@ describe("DomainPackSummaryPage", () => {
     );
     renderPage();
     await waitFor(() =>
-      expect(toast.error).toHaveBeenCalledWith("Pack 정보를 불러오지 못했습니다."),
+      expect(toast.error).toHaveBeenCalledWith(
+        "Pack 정보를 불러오지 못했습니다.",
+      ),
     );
     expect(toast.error).toHaveBeenCalledTimes(1);
   });
 
   it('packDetail 404 에러 시 toast.error를 "Pack을 찾을 수 없습니다."로 호출한다', async () => {
     const error404 = new ApiRequestError(404, "NOT_FOUND", "not found");
-    vi.mocked(usePackDetail).mockReturnValue(makePackQuery({ isError: true, error: error404 }));
+    vi.mocked(usePackDetail).mockReturnValue(
+      makePackQuery({ isError: true, error: error404 }),
+    );
     renderPage();
-    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("Pack을 찾을 수 없습니다."));
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith("Pack을 찾을 수 없습니다."),
+    );
   });
 
   it('packDetail 404 에러 시 "다시 시도" 버튼을 표시하지 않는다', () => {
     const error404 = new ApiRequestError(404, "NOT_FOUND", "not found");
-    vi.mocked(usePackDetail).mockReturnValue(makePackQuery({ isError: true, error: error404 }));
+    vi.mocked(usePackDetail).mockReturnValue(
+      makePackQuery({ isError: true, error: error404 }),
+    );
     renderPage();
-    expect(screen.queryByRole("button", { name: "다시 시도" })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "다시 시도" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
 import {
@@ -12,12 +12,14 @@ import { useDeploy } from "@/shared/api/generated/endpoints/deploy-domain-pack-v
 import { activate } from "@/shared/api/generated/endpoints/activate-domain-pack-version-controller/activate-domain-pack-version-controller";
 import type { ActivateDomainPackVersionRequest } from "@/shared/api/generated/zod";
 import { useDiscard } from "@/shared/api/generated/endpoints/discard-draft-version-controller/discard-draft-version-controller";
-import { OstoneShell } from "@/widgets/ostone-shell";
 import { LoadingSpinner } from "@/shared/ui/ostone/atoms/LoadingSpinner";
 import { ErrorState } from "@/shared/ui/ostone/atoms/ErrorState";
 import type { Crumb } from "@/shared/ui/ostone/chrome";
 import { parseRouteId } from "@/shared/lib/parseRouteId";
-import { domainPackPath, withVersionSearch } from "@/shared/lib/domainPackRoutes";
+import {
+  domainPackPath,
+  withVersionSearch,
+} from "@/shared/lib/domainPackRoutes";
 import {
   usePackDetail,
   useVersionDetail,
@@ -30,7 +32,10 @@ import type {
   DomainPackVersionDetail,
   DomainPackVersionSummary,
 } from "@/entities/domain-pack";
+import { DomainPackShellState } from "./DomainPackShellState";
 import styles from "./domain-pack-summary-page.module.css";
+
+const EMPTY_CRUMBS: Crumb[] = [];
 
 export function DomainPackSummaryPage() {
   const { workspaceId, packId } = useParams();
@@ -41,13 +46,17 @@ export function DomainPackSummaryPage() {
   const rawVersionId = search.get("versionId");
   const vId = rawVersionId === null ? null : parseRouteId(rawVersionId);
 
-  if (wsId === null || pId === null || (rawVersionId !== null && vId === null)) {
+  if (
+    wsId === null ||
+    pId === null ||
+    (rawVersionId !== null && vId === null)
+  ) {
     return (
-      <OstoneShell active="domain" crumbs={[]}>
+      <DomainPackShellState crumbs={EMPTY_CRUMBS}>
         <div className={styles.invalidParams} role="alert">
           잘못된 URL 파라미터입니다.
         </div>
-      </OstoneShell>
+      </DomainPackShellState>
     );
   }
 
@@ -82,15 +91,22 @@ function DomainPackSummaryPageContent({
   setSearch,
 }: ContentProps) {
   const queryClient = useQueryClient();
-  const packQuery = usePackDetail(wsId, packId) as UseQueryResult<DomainPackDetail>;
+  const packQuery = usePackDetail(
+    wsId,
+    packId,
+  ) as UseQueryResult<DomainPackDetail>;
   const pack = packQuery.data;
   const defaultVersionId = resolveDefaultVersionId(pack);
   const effectiveSelectedVersionId = selectedVersionId ?? defaultVersionId;
 
   useEffect(() => {
     if (!packQuery.isError) return;
-    const is404 = packQuery.error instanceof ApiRequestError && packQuery.error.status === 404;
-    toast.error(is404 ? "Pack을 찾을 수 없습니다." : "Pack 정보를 불러오지 못했습니다.");
+    const is404 =
+      packQuery.error instanceof ApiRequestError &&
+      packQuery.error.status === 404;
+    toast.error(
+      is404 ? "Pack을 찾을 수 없습니다." : "Pack 정보를 불러오지 못했습니다.",
+    );
   }, [packQuery.isError, packQuery.error]);
 
   useEffect(() => {
@@ -113,10 +129,12 @@ function DomainPackSummaryPageContent({
   const currentVersionId = pack?.currentVersionId ?? null;
   const currentVersionNo =
     pack?.currentVersionNo ??
-    pack?.versions?.find((version) => version.versionId === currentVersionId)?.versionNo ??
+    pack?.versions?.find((version) => version.versionId === currentVersionId)
+      ?.versionNo ??
     null;
   const selectedVersionNo =
-    pack?.versions?.find((v) => v.versionId === effectiveSelectedVersionId)?.versionNo ?? null;
+    pack?.versions?.find((v) => v.versionId === effectiveSelectedVersionId)
+      ?.versionNo ?? null;
 
   const deployMutation = useDeploy({
     mutation: {
@@ -131,12 +149,26 @@ function DomainPackSummaryPageContent({
   });
   const activateMutation = useMutation({
     mutationKey: ["activate-domain-pack-version"],
-    mutationFn: ({ workspaceId, packId, versionId, description }: ActivateDraftVariables) =>
-      activate(workspaceId, packId, versionId, buildActivateRequest(description)),
+    mutationFn: ({
+      workspaceId,
+      packId,
+      versionId,
+      description,
+    }: ActivateDraftVariables) =>
+      activate(
+        workspaceId,
+        packId,
+        versionId,
+        buildActivateRequest(description),
+      ),
     onSuccess: async (result, variables) => {
-      const activatedVersionId = resolveActivatedVersionId(result, variables.versionId);
+      const activatedVersionId = resolveActivatedVersionId(
+        result,
+        variables.versionId,
+      );
       const activatedDescription =
-        resolveActivatedDescription(result) ?? normalizeDescription(variables.description);
+        resolveActivatedDescription(result) ??
+        normalizeDescription(variables.description);
       updateVersionDescriptionCache(
         queryClient,
         variables.workspaceId,
@@ -163,14 +195,20 @@ function DomainPackSummaryPageContent({
       toast.success("초안 수정버전이 적용되었습니다.");
     },
     onError: (error) => {
-      toast.error(resolveVersionActionErrorMessage(error, "초안 수정버전을 적용하지 못했습니다."));
+      toast.error(
+        resolveVersionActionErrorMessage(
+          error,
+          "초안 수정버전을 적용하지 못했습니다.",
+        ),
+      );
     },
   });
   const discardMutation = useDiscard({
     mutation: {
       onSuccess: async () => {
         const refetched = await packQuery.refetch();
-        const targetVersionId = refetched.data?.currentVersionId ?? currentVersionId;
+        const targetVersionId =
+          refetched.data?.currentVersionId ?? currentVersionId;
         setSearch(
           (prev) => {
             const next = new URLSearchParams(prev);
@@ -187,7 +225,10 @@ function DomainPackSummaryPageContent({
       },
       onError: (error) => {
         toast.error(
-          resolveVersionActionErrorMessage(error, "검토 중인 버전을 삭제하지 못했습니다."),
+          resolveVersionActionErrorMessage(
+            error,
+            "검토 중인 버전을 삭제하지 못했습니다.",
+          ),
         );
       },
     },
@@ -209,7 +250,12 @@ function DomainPackSummaryPageContent({
   };
 
   const handleApplyDraft = (versionId: number, description?: string) => {
-    activateMutation.mutate({ workspaceId: wsId, packId, versionId, description });
+    activateMutation.mutate({
+      workspaceId: wsId,
+      packId,
+      versionId,
+      description,
+    });
   };
 
   const handleDiscardDraft = (versionId: number) => {
@@ -220,7 +266,7 @@ function DomainPackSummaryPageContent({
     });
   };
 
-  const buildSummaryCrumbs = (): Crumb[] => {
+  const summaryCrumbs = useMemo<Crumb[]>(() => {
     const items: Crumb[] = [
       { label: "도메인팩", href: `/workspaces/${wsId}/domain-packs` },
       {
@@ -231,34 +277,43 @@ function DomainPackSummaryPageContent({
     if (effectiveSelectedVersionId !== null && selectedVersionNo !== null) {
       items.push({
         label: `#${selectedVersionNo}`,
-        href: withVersionSearch(domainPackPath(wsId, packId), effectiveSelectedVersionId),
+        href: withVersionSearch(
+          domainPackPath(wsId, packId),
+          effectiveSelectedVersionId,
+        ),
       });
     }
     return items;
-  };
+  }, [effectiveSelectedVersionId, pack?.name, packId, selectedVersionNo, wsId]);
 
   if (packQuery.isLoading) {
     return (
-      <OstoneShell active="domain" crumbs={buildSummaryCrumbs()}>
+      <DomainPackShellState crumbs={summaryCrumbs}>
         <LoadingSpinner />
-      </OstoneShell>
+      </DomainPackShellState>
     );
   }
 
   if (packQuery.isError) {
-    const is404 = packQuery.error instanceof ApiRequestError && packQuery.error.status === 404;
+    const is404 =
+      packQuery.error instanceof ApiRequestError &&
+      packQuery.error.status === 404;
     return (
-      <OstoneShell active="domain" crumbs={buildSummaryCrumbs()}>
+      <DomainPackShellState crumbs={summaryCrumbs}>
         <ErrorState
-          message={is404 ? "Pack을 찾을 수 없습니다." : "Pack 정보를 불러오지 못했습니다."}
+          message={
+            is404
+              ? "Pack을 찾을 수 없습니다."
+              : "Pack 정보를 불러오지 못했습니다."
+          }
           onRetry={!is404 ? () => packQuery.refetch() : undefined}
         />
-      </OstoneShell>
+      </DomainPackShellState>
     );
   }
 
   return (
-    <OstoneShell active="domain" crumbs={buildSummaryCrumbs()}>
+    <DomainPackShellState crumbs={summaryCrumbs}>
       <div className={styles.page}>
         <header className={styles.pageHeader}>
           <div>
@@ -275,9 +330,15 @@ function DomainPackSummaryPageContent({
           wsId={wsId}
           packId={packId}
           versionId={effectiveSelectedVersionId}
-          deployingVersionId={deployMutation.isPending ? deployMutation.variables?.versionId : null}
+          deployingVersionId={
+            deployMutation.isPending
+              ? deployMutation.variables?.versionId
+              : null
+          }
           applyingVersionId={
-            activateMutation.isPending ? activateMutation.variables?.versionId : null
+            activateMutation.isPending
+              ? activateMutation.variables?.versionId
+              : null
           }
         />
 
@@ -297,13 +358,19 @@ function DomainPackSummaryPageContent({
             versions={pack?.versions ?? []}
             approvalReadinessEnabled
             deployingVersionId={
-              deployMutation.isPending ? deployMutation.variables?.versionId : null
+              deployMutation.isPending
+                ? deployMutation.variables?.versionId
+                : null
             }
             applyingVersionId={
-              activateMutation.isPending ? activateMutation.variables?.versionId : null
+              activateMutation.isPending
+                ? activateMutation.variables?.versionId
+                : null
             }
             discardingVersionId={
-              discardMutation.isPending ? discardMutation.variables?.draftVersionId : null
+              discardMutation.isPending
+                ? discardMutation.variables?.draftVersionId
+                : null
             }
             onDeploy={handleDeployVersion}
             onApplyDraft={handleApplyDraft}
@@ -311,7 +378,7 @@ function DomainPackSummaryPageContent({
           />
         </div>
       </div>
-    </OstoneShell>
+    </DomainPackShellState>
   );
 }
 
@@ -322,14 +389,19 @@ function resolveDeployErrorMessage(error: unknown): string {
   return "도메인팩 버전을 배포하지 못했습니다.";
 }
 
-function resolveVersionActionErrorMessage(error: unknown, fallback: string): string {
+function resolveVersionActionErrorMessage(
+  error: unknown,
+  fallback: string,
+): string {
   if (error instanceof ApiRequestError && error.message) {
     return error.message;
   }
   return fallback;
 }
 
-function buildActivateRequest(description?: string): ActivateDomainPackVersionRequest | undefined {
+function buildActivateRequest(
+  description?: string,
+): ActivateDomainPackVersionRequest | undefined {
   const normalizedDescription = normalizeDescription(description);
   if (normalizedDescription === undefined) return undefined;
   return { description: normalizedDescription };
@@ -355,7 +427,8 @@ function updateVersionDescriptionCache(
 }
 
 function resolveDefaultVersionId(pack?: DomainPackDetail): number | null {
-  const versions = pack?.versions?.filter((version) => version.versionId != null) ?? [];
+  const versions =
+    pack?.versions?.filter((version) => version.versionId != null) ?? [];
   if (versions.length === 0) return null;
 
   if (
@@ -366,17 +439,23 @@ function resolveDefaultVersionId(pack?: DomainPackDetail): number | null {
   }
 
   return (
-    pickLatestVersionId(versions.filter((version) => version.lifecycleStatus === "DRAFT")) ??
-    pickLatestVersionId(versions)
+    pickLatestVersionId(
+      versions.filter((version) => version.lifecycleStatus === "DRAFT"),
+    ) ?? pickLatestVersionId(versions)
   );
 }
 
-function pickLatestVersionId(versions: DomainPackVersionSummary[]): number | null {
-  const latest = versions.reduce<DomainPackVersionSummary | null>((best, version) => {
-    if (version.versionId == null) return best;
-    if (best === null) return version;
-    return compareVersionSummary(version, best) > 0 ? version : best;
-  }, null);
+function pickLatestVersionId(
+  versions: DomainPackVersionSummary[],
+): number | null {
+  const latest = versions.reduce<DomainPackVersionSummary | null>(
+    (best, version) => {
+      if (version.versionId == null) return best;
+      if (best === null) return version;
+      return compareVersionSummary(version, best) > 0 ? version : best;
+    },
+    null,
+  );
 
   return latest?.versionId ?? null;
 }
@@ -394,7 +473,8 @@ function compareVersionSummary(
   if (leftCreatedAt !== rightCreatedAt) return leftCreatedAt - rightCreatedAt;
 
   return (
-    (left.versionId ?? Number.NEGATIVE_INFINITY) - (right.versionId ?? Number.NEGATIVE_INFINITY)
+    (left.versionId ?? Number.NEGATIVE_INFINITY) -
+    (right.versionId ?? Number.NEGATIVE_INFINITY)
   );
 }
 

--- a/frontend/src/pages/domain-pack/ui/IntentDraftReadPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/IntentDraftReadPage.test.tsx
@@ -1,5 +1,6 @@
+import { useState } from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Outlet, Route, Routes } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiRequestError } from "@/shared/api";
 import { IntentDraftReadPage } from "./IntentDraftReadPage";
@@ -36,7 +37,12 @@ const mocks = vi.hoisted(() => ({
       ],
       changedWorkflows: [],
       changedFieldCounts: { name: 1, description: 0 },
-      changedWorkflowFieldCounts: { name: 0, description: 0, graphText: 0, graphStructure: 0 },
+      changedWorkflowFieldCounts: {
+        name: 0,
+        description: 0,
+        graphText: 0,
+        graphStructure: 0,
+      },
       changedByDraftIntentId: {},
       changedByDraftWorkflowId: {},
       totalChangedComponents: 1,
@@ -57,27 +63,15 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("react-router-dom", async () => {
-  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  const actual =
+    await vi.importActual<typeof import("react-router-dom")>(
+      "react-router-dom",
+    );
   return {
     ...actual,
     useNavigate: () => mocks.navigate,
   };
 });
-
-vi.mock("@/widgets/ostone-shell", () => ({
-  OstoneShell: ({
-    children,
-    topbarRight,
-  }: {
-    children: React.ReactNode;
-    topbarRight?: React.ReactNode;
-  }) => (
-    <main>
-      {topbarRight}
-      {children}
-    </main>
-  ),
-}));
 
 vi.mock("sonner", () => ({
   toast: {
@@ -132,8 +126,14 @@ vi.mock("@/entities/intent", async (importOriginal) => {
       intentListState,
     }: {
       intentId: number | null;
-      headerActions?: (detail: { id: number; intentCode: string }) => React.ReactNode;
-      afterHeader?: (detail: { id: number; intentCode: string }) => React.ReactNode;
+      headerActions?: (detail: {
+        id: number;
+        intentCode: string;
+      }) => React.ReactNode;
+      afterHeader?: (detail: {
+        id: number;
+        intentCode: string;
+      }) => React.ReactNode;
       beforeJsonCards?: () => React.ReactNode;
       children?: (detail: {
         id: number;
@@ -222,9 +222,15 @@ vi.mock("@/features/approve-intent", () => ({
 vi.mock("@/features/intent-revision-draft", () => ({
   IntentRevisionDiffPanel: () => <div>revision diff</div>,
   IntentRevisionRecoveryBanner: () => <div>recovery banner</div>,
-  IntentRevisionDraftActions: ({ onRetrySummary }: { onRetrySummary: () => void }) => (
+  IntentRevisionDraftActions: ({
+    onRetrySummary,
+  }: {
+    onRetrySummary: () => void;
+  }) => (
     <div>
-      <span>수정 내용의 적용 및 삭제는 도메인팩 화면에서 진행할 수 있습니다.</span>
+      <span>
+        수정 내용의 적용 및 삭제는 도메인팩 화면에서 진행할 수 있습니다.
+      </span>
       <button type="button" onClick={onRetrySummary}>
         retry summary
       </button>
@@ -247,7 +253,9 @@ vi.mock("@/features/intent-revision-draft", () => ({
         </button>
         <button
           type="button"
-          onClick={() => void onSave({ name: "환불 문의 수정", description: "수정 설명" })}
+          onClick={() =>
+            void onSave({ name: "환불 문의 수정", description: "수정 설명" })
+          }
         >
           save revision
         </button>
@@ -267,11 +275,14 @@ vi.mock("@/features/intent-revision-draft", () => ({
     getVersionDetail: mocks.getVersionDetail,
   },
   parseIntentRevisionDraftSource: (summaryJson?: string) =>
-    summaryJson?.includes("INTENT_REVISION") ? { type: "INTENT_REVISION", baseVersionId: 2 } : null,
+    summaryJson?.includes("INTENT_REVISION")
+      ? { type: "INTENT_REVISION", baseVersionId: 2 }
+      : null,
   resolveSingleExistingDraft: (
     versions?: Array<{ versionId?: number; lifecycleStatus?: string }>,
   ) => {
-    const drafts = versions?.filter((version) => version.lifecycleStatus === "DRAFT") ?? [];
+    const drafts =
+      versions?.filter((version) => version.lifecycleStatus === "DRAFT") ?? [];
     return drafts.length === 1 && drafts[0]?.versionId != null
       ? { status: "resolved", versionId: drafts[0].versionId }
       : { status: "invalid" };
@@ -291,15 +302,34 @@ vi.mock("@/features/intent-revision-draft", () => ({
   }),
 }));
 
+function ShellHost() {
+  const [crumbs, setCrumbs] = useState<Array<string | { label: string }>>([]);
+  const [topbarRight, setTopbarRight] = useState<React.ReactNode>();
+
+  return (
+    <>
+      <div data-testid="shell-crumbs">
+        {crumbs
+          .map((crumb) => (typeof crumb === "string" ? crumb : crumb.label))
+          .join(" / ")}
+      </div>
+      <div data-testid="shell-topbar">{topbarRight}</div>
+      <Outlet context={{ setCrumbs, setTopbarRight, workspace: null }} />
+    </>
+  );
+}
+
 function renderPage(path: string) {
   return render(
     <MemoryRouter initialEntries={[path]}>
       <Routes>
         <Route
-          path="/workspaces/:workspaceId/domain-packs/:packId/intents"
-          element={<IntentDraftReadPage />}
+          path="/workspaces/:workspaceId/domain-packs/:packId"
+          element={<ShellHost />}
         >
-          <Route path=":intentId" />
+          <Route path="intents" element={<IntentDraftReadPage />}>
+            <Route path=":intentId" />
+          </Route>
         </Route>
       </Routes>
     </MemoryRouter>,
@@ -351,7 +381,12 @@ describe("IntentDraftReadPage", () => {
         ],
         changedWorkflows: [],
         changedFieldCounts: { name: 1, description: 0 },
-        changedWorkflowFieldCounts: { name: 0, description: 0, graphText: 0, graphStructure: 0 },
+        changedWorkflowFieldCounts: {
+          name: 0,
+          description: 0,
+          graphText: 0,
+          graphStructure: 0,
+        },
         changedByDraftIntentId: {},
         changedByDraftWorkflowId: {},
         totalChangedComponents: 1,
@@ -366,7 +401,9 @@ describe("IntentDraftReadPage", () => {
   it("잘못된 URL 파라미터면 alert를 표시한다", () => {
     renderPage("/workspaces/abc/domain-packs/7/intents?versionId=3");
 
-    expect(screen.getByRole("alert")).toHaveTextContent("잘못된 URL 파라미터입니다.");
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "잘못된 URL 파라미터입니다.",
+    );
   });
 
   it("intent 선택 시 상세 URL로 이동한다", () => {
@@ -446,7 +483,11 @@ describe("IntentDraftReadPage", () => {
 
   it("운영 버전이 바뀐 상태에서 저장하면 pack을 새로고침하고 안내한다", async () => {
     mocks.saveIntentRevisionDraft.mockRejectedValue(
-      new ApiRequestError(409, "DOMAIN_PACK_VERSION_NOT_CURRENT", "version changed"),
+      new ApiRequestError(
+        409,
+        "DOMAIN_PACK_VERSION_NOT_CURRENT",
+        "version changed",
+      ),
     );
     renderPage("/workspaces/1/domain-packs/7/intents/10?versionId=3");
 
@@ -477,16 +518,26 @@ describe("IntentDraftReadPage", () => {
       summaryJson: '{"draftSource":"INTENT_REVISION"}',
     });
     mocks.saveIntentRevisionDraft.mockRejectedValue(
-      new ApiRequestError(409, "DOMAIN_PACK_DRAFT_ALREADY_EXISTS", "draft exists"),
+      new ApiRequestError(
+        409,
+        "DOMAIN_PACK_DRAFT_ALREADY_EXISTS",
+        "draft exists",
+      ),
     );
     renderPage("/workspaces/1/domain-packs/7/intents/10?versionId=3");
 
     fireEvent.click(screen.getByRole("button", { name: "수정" }));
     fireEvent.click(screen.getByRole("button", { name: "save revision" }));
 
-    await waitFor(() => expect(screen.getByText("진행 중인 초안이 있습니다.")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(
+        screen.getByText("진행 중인 초안이 있습니다."),
+      ).toBeInTheDocument(),
+    );
     expect(
-      screen.getByText(/이미 진행 중인 Draft가 있어 새 수정 초안을 만들 수 없습니다./),
+      screen.getByText(
+        /이미 진행 중인 Draft가 있어 새 수정 초안을 만들 수 없습니다./,
+      ),
     ).toBeInTheDocument();
   });
 
@@ -501,7 +552,11 @@ describe("IntentDraftReadPage", () => {
     };
     mocks.packRefetch.mockResolvedValue({ data: mocks.packData });
     mocks.saveIntentRevisionDraft.mockRejectedValue(
-      new ApiRequestError(409, "DOMAIN_PACK_DRAFT_ALREADY_EXISTS", "draft exists"),
+      new ApiRequestError(
+        409,
+        "DOMAIN_PACK_DRAFT_ALREADY_EXISTS",
+        "draft exists",
+      ),
     );
     renderPage("/workspaces/1/domain-packs/7/intents/10?versionId=3");
 
@@ -513,7 +568,9 @@ describe("IntentDraftReadPage", () => {
         "초안 상태를 확인할 수 없습니다. 목록을 새로고침해 주세요.",
       ),
     );
-    expect(screen.queryByText("진행 중인 초안이 있습니다.")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("진행 중인 초안이 있습니다."),
+    ).not.toBeInTheDocument();
   });
 
   it("기존 초안 dialog에서 이동을 확정하면 해당 초안의 같은 intent로 이동한다", async () => {
@@ -531,13 +588,21 @@ describe("IntentDraftReadPage", () => {
       summaryJson: '{"draftSource":"INTENT_REVISION"}',
     });
     mocks.saveIntentRevisionDraft.mockRejectedValue(
-      new ApiRequestError(409, "DOMAIN_PACK_DRAFT_ALREADY_EXISTS", "draft exists"),
+      new ApiRequestError(
+        409,
+        "DOMAIN_PACK_DRAFT_ALREADY_EXISTS",
+        "draft exists",
+      ),
     );
     renderPage("/workspaces/1/domain-packs/7/intents/10?versionId=3");
 
     fireEvent.click(screen.getByRole("button", { name: "수정" }));
     fireEvent.click(screen.getByRole("button", { name: "save revision" }));
-    await waitFor(() => expect(screen.getByText("진행 중인 초안이 있습니다.")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(
+        screen.getByText("진행 중인 초안이 있습니다."),
+      ).toBeInTheDocument(),
+    );
     fireEvent.click(screen.getByRole("button", { name: "이동" }));
 
     await waitFor(() =>
@@ -586,7 +651,9 @@ describe("IntentDraftReadPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "수정" }));
     fireEvent.click(screen.getByRole("button", { name: "save revision" }));
 
-    await waitFor(() => expect(mocks.toastError).toHaveBeenCalledWith("이름이 너무 깁니다."));
+    await waitFor(() =>
+      expect(mocks.toastError).toHaveBeenCalledWith("이름이 너무 깁니다."),
+    );
     expect(mocks.versionRefetch).not.toHaveBeenCalled();
     expect(mocks.navigate).not.toHaveBeenCalled();
   });
@@ -603,7 +670,9 @@ describe("IntentDraftReadPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "mark dirty" }));
     fireEvent.click(screen.getByRole("button", { name: "select intent" }));
 
-    expect(await screen.findByText("저장하지 않고 이동할까요?")).toBeInTheDocument();
+    expect(
+      await screen.findByText("저장하지 않고 이동할까요?"),
+    ).toBeInTheDocument();
     expect(mocks.navigate).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole("button", { name: "이동" }));
@@ -646,10 +715,16 @@ describe("IntentDraftReadPage", () => {
     renderPage("/workspaces/1/domain-packs/7/intents/10?versionId=6");
 
     expect(
-      screen.getByText("수정 내용의 적용 및 삭제는 도메인팩 화면에서 진행할 수 있습니다."),
+      screen.getByText(
+        "수정 내용의 적용 및 삭제는 도메인팩 화면에서 진행할 수 있습니다.",
+      ),
     ).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "apply revision" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "discard revision" })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "apply revision" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "discard revision" }),
+    ).not.toBeInTheDocument();
     expect(mocks.activateVersion).not.toHaveBeenCalled();
     expect(mocks.discardDraft).not.toHaveBeenCalled();
   });

--- a/frontend/src/pages/domain-pack/ui/IntentDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/IntentDraftReadPage.tsx
@@ -1,8 +1,18 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
-import { IntentDetailPanel, type IntentDetail, type IntentListState } from "@/entities/intent";
-import { usePackDetail, VersionSafetyBanner } from "@/features/domain-pack-summary-read";
-import { IntentTreePanel, MatchedWorkflowSection } from "@/features/intent-draft-read/ui";
+import {
+  IntentDetailPanel,
+  type IntentDetail,
+  type IntentListState,
+} from "@/entities/intent";
+import {
+  usePackDetail,
+  VersionSafetyBanner,
+} from "@/features/domain-pack-summary-read";
+import {
+  IntentTreePanel,
+  MatchedWorkflowSection,
+} from "@/features/intent-draft-read/ui";
 import { useIntentList } from "@/features/intent-draft-read/model/useIntentList";
 import { IntentDetailWithApproval } from "@/features/approve-intent";
 import {
@@ -28,8 +38,10 @@ import { Pill, type PillTone } from "@/shared/ui/ostone/atoms";
 import type { Crumb } from "@/shared/ui/ostone/chrome";
 import { buildDomainPackCrumbs } from "@/shared/lib/domainPackRoutes";
 import { parseRouteId } from "@/shared/lib/parseRouteId";
-import { OstoneShell } from "@/widgets/ostone-shell";
+import { DomainPackShellState } from "./DomainPackShellState";
 import styles from "./intent-draft-read-page.module.css";
+
+const EMPTY_CRUMBS: Crumb[] = [];
 
 export function IntentDraftReadPage() {
   const { workspaceId, packId, intentId } = useParams();
@@ -40,13 +52,18 @@ export function IntentDraftReadPage() {
   const vId = parseRouteId(search.get("versionId") ?? undefined);
   const iId = intentId ? parseRouteId(intentId) : null;
 
-  if (wsId === null || pId === null || vId === null || (intentId !== undefined && iId === null)) {
+  if (
+    wsId === null ||
+    pId === null ||
+    vId === null ||
+    (intentId !== undefined && iId === null)
+  ) {
     return (
-      <OstoneShell active="domain" crumbs={[]}>
+      <DomainPackShellState crumbs={EMPTY_CRUMBS}>
         <div className={styles.invalidParams} role="alert">
           잘못된 URL 파라미터입니다.
         </div>
-      </OstoneShell>
+      </DomainPackShellState>
     );
   }
 
@@ -65,10 +82,16 @@ function IntentDraftReadContent({
   iId: number | null;
 }) {
   const controller = useIntentDraftReadController({ wsId, pId, vId, iId });
-  const intentListState = useIntentList(wsId, pId, vId, controller.listRefreshKey);
+  const intentListState = useIntentList(
+    wsId,
+    pId,
+    vId,
+    controller.listRefreshKey,
+  );
   const packDetail = usePackDetail(wsId, pId).data;
   const packName = packDetail?.name ?? `PACK · ${pId}`;
-  const versionNo = packDetail?.versions?.find((v) => v.versionId === vId)?.versionNo ?? vId;
+  const versionNo =
+    packDetail?.versions?.find((v) => v.versionId === vId)?.versionNo ?? vId;
 
   const versionLabel = getVersionLabel({
     lifecycleStatus: controller.versionDetail?.lifecycleStatus,
@@ -92,29 +115,42 @@ function IntentDraftReadContent({
     [wsId, pId, vId, packName, versionNo, controller.selectedIntentCode],
   );
 
-  const topbarRight = (
-    <div
-      style={{
-        display: "flex",
-        alignItems: "center",
-        gap: "var(--s-3)",
-      }}
-    >
-      <Pill tone={versionLabelTone(versionLabel)}>{versionLabel}</Pill>
-      {controller.isRevisionDraft && (
-        <IntentRevisionDraftActions
-          summary={summaryState.status === "ready" ? summaryState.data : undefined}
-          isSummaryLoading={summaryState.status === "loading"}
-          summaryError={summaryState.status === "error" ? summaryState.message : null}
-          isPending={controller.isMutationPending}
-          onRetrySummary={controller.retrySummary}
-        />
-      )}
-    </div>
+  const topbarRight = useMemo(
+    () => (
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "var(--s-3)",
+        }}
+      >
+        <Pill tone={versionLabelTone(versionLabel)}>{versionLabel}</Pill>
+        {controller.isRevisionDraft && (
+          <IntentRevisionDraftActions
+            summary={
+              summaryState.status === "ready" ? summaryState.data : undefined
+            }
+            isSummaryLoading={summaryState.status === "loading"}
+            summaryError={
+              summaryState.status === "error" ? summaryState.message : null
+            }
+            isPending={controller.isMutationPending}
+            onRetrySummary={controller.retrySummary}
+          />
+        )}
+      </div>
+    ),
+    [
+      controller.isMutationPending,
+      controller.isRevisionDraft,
+      controller.retrySummary,
+      summaryState,
+      versionLabel,
+    ],
   );
 
   return (
-    <OstoneShell active="intent" crumbs={crumbs} topbarRight={topbarRight}>
+    <DomainPackShellState crumbs={crumbs} topbarRight={topbarRight}>
       <div className={styles.pageWrapper}>
         <VersionSafetyBanner wsId={wsId} packId={pId} versionId={vId} />
         <IntentDraftTwoPane
@@ -130,7 +166,7 @@ function IntentDraftReadContent({
 
       <PendingNavigationDialog controller={controller} />
       <ExistingDraftDialog controller={controller} />
-    </OstoneShell>
+    </DomainPackShellState>
   );
 }
 
@@ -154,7 +190,9 @@ function IntentDraftTwoPane({
   intentListState: IntentListState;
 }) {
   return (
-    <div className={`${styles.twoPane} ${hasSelection ? styles.hasSelection : ""}`}>
+    <div
+      className={`${styles.twoPane} ${hasSelection ? styles.hasSelection : ""}`}
+    >
       <div className={styles.listSlot}>
         <IntentTreePanel
           intentListState={intentListState}
@@ -194,16 +232,24 @@ function IntentDetailSlot({
     intentId: number;
     versionId: number;
   } | null>(null);
-  const isEditingIntent = editingTarget?.intentId === iId && editingTarget.versionId === vId;
+  const isEditingIntent =
+    editingTarget?.intentId === iId && editingTarget.versionId === vId;
   const setEditingIntent = useCallback(
     (next: boolean) => {
-      setEditingTarget(next && iId !== null ? { intentId: iId, versionId: vId } : null);
+      setEditingTarget(
+        next && iId !== null ? { intentId: iId, versionId: vId } : null,
+      );
     },
     [iId, vId],
   );
 
   const renderMatchedWorkflows = (detail: IntentDetail) => (
-    <MatchedWorkflowSection wsId={wsId} packId={pId} versionId={vId} intentId={detail.id ?? null} />
+    <MatchedWorkflowSection
+      wsId={wsId}
+      packId={pId}
+      versionId={vId}
+      intentId={detail.id ?? null}
+    />
   );
 
   if (iId === null) {
@@ -264,7 +310,9 @@ function IntentDetailSlot({
           intentCode={detail.intentCode ?? null}
           onChange={controller.setSelectedIntentCode}
         />
-        {controller.recoveryVersionId === vId ? <IntentRevisionRecoveryBanner /> : null}
+        {controller.recoveryVersionId === vId ? (
+          <IntentRevisionRecoveryBanner />
+        ) : null}
       </>
     ),
     beforeJsonCards: () =>
@@ -314,12 +362,18 @@ function IntentDetailSlot({
 
   return (
     <div className={styles.detailSlot}>
-      <IntentDetailPanel {...detailSharedProps}>{renderRevisionEditor}</IntentDetailPanel>
+      <IntentDetailPanel {...detailSharedProps}>
+        {renderRevisionEditor}
+      </IntentDetailPanel>
     </div>
   );
 }
 
-function PendingNavigationDialog({ controller }: { controller: IntentDraftController }) {
+function PendingNavigationDialog({
+  controller,
+}: {
+  controller: IntentDraftController;
+}) {
   return (
     <AlertDialog
       open={controller.pendingNavigation !== null}
@@ -347,7 +401,11 @@ function PendingNavigationDialog({ controller }: { controller: IntentDraftContro
   );
 }
 
-function ExistingDraftDialog({ controller }: { controller: IntentDraftController }) {
+function ExistingDraftDialog({
+  controller,
+}: {
+  controller: IntentDraftController;
+}) {
   const target = controller.existingDraftTarget;
 
   return (
@@ -369,7 +427,10 @@ function ExistingDraftDialog({ controller }: { controller: IntentDraftController
           >
             취소
           </Button>
-          <Button type="button" onClick={controller.confirmExistingDraftNavigation}>
+          <Button
+            type="button"
+            onClick={controller.confirmExistingDraftNavigation}
+          >
             이동
           </Button>
         </AlertDialogFooter>
@@ -416,7 +477,9 @@ function getVersionLabel({
   return "확인 중";
 }
 
-function getExistingDraftDescription(target: ExistingDraftTarget | null): string {
+function getExistingDraftDescription(
+  target: ExistingDraftTarget | null,
+): string {
   return target?.sourceType === "INTENT_REVISION"
     ? "기존 상담 유형 수정 검토본으로 이동하거나 도메인팩 화면에서 검토본을 적용 또는 폐기해 주세요."
     : "기존 검토본으로 이동하거나 도메인팩 화면에서 검토본을 적용 또는 폐기해 주세요.";

--- a/frontend/src/pages/domain-pack/ui/PackWorkflowListPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/PackWorkflowListPage.test.tsx
@@ -1,6 +1,13 @@
+import { useState } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import {
+  MemoryRouter,
+  Outlet,
+  Route,
+  Routes,
+  useLocation,
+} from "react-router-dom";
 
 import { PackWorkflowListPage } from "./PackWorkflowListPage";
 
@@ -44,23 +51,42 @@ vi.mock("@/features/workflow-list", () => ({
   )),
 }));
 
-vi.mock("@/widgets/ostone-shell", () => ({
-  OstoneShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-}));
-
-const ROUTE = "/workspaces/:workspaceId/domain-packs/:packId/workflows";
-
 function NavigatedRoute() {
   const loc = useLocation();
   return <div data-testid="navigated">{loc.pathname + loc.search}</div>;
+}
+
+function ShellHost() {
+  const [crumbs, setCrumbs] = useState<Array<string | { label: string }>>([]);
+  const [topbarRight, setTopbarRight] = useState<React.ReactNode>();
+
+  return (
+    <>
+      <div data-testid="shell-crumbs">
+        {crumbs
+          .map((crumb) => (typeof crumb === "string" ? crumb : crumb.label))
+          .join(" / ")}
+      </div>
+      <div data-testid="shell-topbar">{topbarRight}</div>
+      <Outlet context={{ setCrumbs, setTopbarRight, workspace: null }} />
+    </>
+  );
 }
 
 function renderPage(path: string) {
   return render(
     <MemoryRouter initialEntries={[path]}>
       <Routes>
-        <Route path={ROUTE} element={<PackWorkflowListPage />} />
-        <Route path="/workspaces" element={<div data-testid="workspaces-root">root</div>} />
+        <Route
+          path="/workspaces/:workspaceId/domain-packs/:packId"
+          element={<ShellHost />}
+        >
+          <Route path="workflows" element={<PackWorkflowListPage />} />
+        </Route>
+        <Route
+          path="/workspaces"
+          element={<div data-testid="workspaces-root">root</div>}
+        />
         <Route path="*" element={<NavigatedRoute />} />
       </Routes>
     </MemoryRouter>,
@@ -73,13 +99,21 @@ beforeEach(() => {
 
 describe("PackWorkflowListPage", () => {
   it("유효하지 않은 wsId는 /workspaces 로 redirect", () => {
-    mockUseListWorkflows.mockReturnValue({ isLoading: false, isError: false, data: undefined });
+    mockUseListWorkflows.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: undefined,
+    });
     renderPage("/workspaces/abc/domain-packs/2/workflows?versionId=3");
     expect(screen.getByTestId("workspaces-root")).toBeInTheDocument();
   });
 
   it("loading 시 loading state 가 노출된다", () => {
-    mockUseListWorkflows.mockReturnValue({ isLoading: true, isError: false, data: undefined });
+    mockUseListWorkflows.mockReturnValue({
+      isLoading: true,
+      isError: false,
+      data: undefined,
+    });
     renderPage("/workspaces/1/domain-packs/2/workflows?versionId=3");
     expect(screen.getByTestId("pack-workflows-loading")).toBeInTheDocument();
   });
@@ -152,7 +186,11 @@ describe("PackWorkflowListPage", () => {
     mockUseListWorkflows.mockReturnValue({
       isLoading: false,
       isError: false,
-      data: { data: [{ id: 42, name: "Click me", workflowCode: null, description: null }] },
+      data: {
+        data: [
+          { id: 42, name: "Click me", workflowCode: null, description: null },
+        ],
+      },
     });
     renderPage("/workspaces/1/domain-packs/2/workflows?versionId=3");
     fireEvent.click(screen.getByTestId("mock-card-42"));

--- a/frontend/src/pages/domain-pack/ui/PackWorkflowListPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/PackWorkflowListPage.tsx
@@ -1,19 +1,27 @@
 import { useMemo } from "react";
-import { Navigate, useNavigate, useParams, useSearchParams } from "react-router-dom";
+import {
+  Navigate,
+  useNavigate,
+  useParams,
+  useSearchParams,
+} from "react-router-dom";
 
 import { usePackDetail } from "@/features/domain-pack-summary-read";
 import { useListWorkflows } from "@/shared/api/generated/endpoints/workflow-definition-controller/workflow-definition-controller";
 import { unwrapApiResponse } from "@/shared/api/unwrapApiResponse";
 import type { WorkflowDefinitionSummary } from "@/shared/api/generated/zod";
 import type { WorkspaceWorkflowEntry } from "@/entities/workflow";
-import { buildDomainPackCrumbs, domainPackSectionPath } from "@/shared/lib/domainPackRoutes";
+import {
+  buildDomainPackCrumbs,
+  domainPackSectionPath,
+} from "@/shared/lib/domainPackRoutes";
 import { parseRouteId } from "@/shared/lib/parseRouteId";
-import { OstoneShell } from "@/widgets/ostone-shell";
 import { LoadingSpinner } from "@/shared/ui/ostone/atoms/LoadingSpinner";
 import { ErrorState } from "@/shared/ui/ostone/atoms/ErrorState";
 import { EmptyState } from "@/shared/ui/ostone/atoms/EmptyState";
 import type { Crumb } from "@/shared/ui/ostone/chrome";
 import { WorkflowListView } from "@/features/workflow-list";
+import { DomainPackShellState } from "./DomainPackShellState";
 
 export function PackWorkflowListPage() {
   const navigate = useNavigate();
@@ -29,7 +37,10 @@ export function PackWorkflowListPage() {
     enabled: wsId !== null && pId !== null && vId !== null,
   }).data;
   const packName = packDetail?.name ?? `PACK · ${pId ?? "?"}`;
-  const versionNo = packDetail?.versions?.find((v) => v.versionId === vId)?.versionNo ?? vId ?? 0;
+  const versionNo =
+    packDetail?.versions?.find((v) => v.versionId === vId)?.versionNo ??
+    vId ??
+    0;
 
   const query = useListWorkflows(wsId ?? 0, pId ?? 0, vId ?? 0, undefined, {
     query: { enabled },
@@ -37,9 +48,13 @@ export function PackWorkflowListPage() {
 
   const entries = useMemo<WorkspaceWorkflowEntry[]>(() => {
     if (!enabled) return [];
-    const list = unwrapApiResponse<WorkflowDefinitionSummary[]>(query.data) ?? [];
+    const list =
+      unwrapApiResponse<WorkflowDefinitionSummary[]>(query.data) ?? [];
     return list
-      .filter((wf): wf is WorkflowDefinitionSummary & { id: number } => typeof wf.id === "number")
+      .filter(
+        (wf): wf is WorkflowDefinitionSummary & { id: number } =>
+          typeof wf.id === "number",
+      )
       .map<WorkspaceWorkflowEntry>((wf) => ({
         packId: pId!,
         packName: packName,
@@ -52,27 +67,39 @@ export function PackWorkflowListPage() {
       }));
   }, [enabled, query.data, packName, pId, vId]);
 
+  const crumbs = useMemo<Crumb[]>(() => {
+    if (wsId === null || pId === null || vId === null) {
+      return ["도메인팩 관리", "워크플로우"];
+    }
+
+    return buildDomainPackCrumbs({
+      wsId,
+      pId,
+      vId,
+      packName,
+      versionNo,
+      section: { label: "워크플로우", path: "workflows" },
+    });
+  }, [packName, pId, versionNo, vId, wsId]);
+
   if (!enabled) {
     return <Navigate to="/workspaces" replace />;
   }
 
-  const crumbs: Crumb[] = buildDomainPackCrumbs({
-    wsId,
-    pId,
-    vId,
-    packName,
-    versionNo,
-    section: { label: "워크플로우", path: "workflows" },
-  });
-
   const handleOpen = (entry: WorkspaceWorkflowEntry) => {
     navigate(
-      domainPackSectionPath(wsId, entry.packId, entry.versionId, "workflows", entry.workflowId),
+      domainPackSectionPath(
+        wsId,
+        entry.packId,
+        entry.versionId,
+        "workflows",
+        entry.workflowId,
+      ),
     );
   };
 
   return (
-    <OstoneShell active="workflows" crumbs={crumbs}>
+    <DomainPackShellState crumbs={crumbs}>
       <div style={{ padding: "24px", height: "100%", overflow: "auto" }}>
         {query.isLoading && (
           <div
@@ -94,7 +121,10 @@ export function PackWorkflowListPage() {
 
         {!query.isLoading && query.isError && (
           <div data-testid="pack-workflows-error">
-            <ErrorState message="워크플로우 목록을 불러오지 못했습니다." onRetry={query.refetch} />
+            <ErrorState
+              message="워크플로우 목록을 불러오지 못했습니다."
+              onRetry={query.refetch}
+            />
           </div>
         )}
 
@@ -105,9 +135,13 @@ export function PackWorkflowListPage() {
         )}
 
         {!query.isLoading && !query.isError && entries.length > 0 && (
-          <WorkflowListView entries={entries} onOpen={handleOpen} testIdPrefix="pack-workflows" />
+          <WorkflowListView
+            entries={entries}
+            onOpen={handleOpen}
+            testIdPrefix="pack-workflows"
+          />
         )}
       </div>
-    </OstoneShell>
+    </DomainPackShellState>
   );
 }

--- a/frontend/src/pages/domain-pack/ui/PolicyDraftReadPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/PolicyDraftReadPage.test.tsx
@@ -1,12 +1,16 @@
+import { useState } from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Outlet, Route, Routes } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 import { PolicyDraftReadPage } from "./PolicyDraftReadPage";
 
 const navigate = vi.fn();
 
 vi.mock("react-router-dom", async () => {
-  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  const actual =
+    await vi.importActual<typeof import("react-router-dom")>(
+      "react-router-dom",
+    );
   return {
     ...actual,
     useNavigate: () => navigate,
@@ -39,15 +43,34 @@ vi.mock("@/features/update-policy", () => ({
   ),
 }));
 
+function ShellHost() {
+  const [crumbs, setCrumbs] = useState<Array<string | { label: string }>>([]);
+  const [topbarRight, setTopbarRight] = useState<React.ReactNode>();
+
+  return (
+    <>
+      <div data-testid="shell-crumbs">
+        {crumbs
+          .map((crumb) => (typeof crumb === "string" ? crumb : crumb.label))
+          .join(" / ")}
+      </div>
+      <div data-testid="shell-topbar">{topbarRight}</div>
+      <Outlet context={{ setCrumbs, setTopbarRight, workspace: null }} />
+    </>
+  );
+}
+
 function renderPage(path: string) {
   return render(
     <MemoryRouter initialEntries={[path]}>
       <Routes>
         <Route
-          path="/workspaces/:workspaceId/domain-packs/:packId/policies"
-          element={<PolicyDraftReadPage />}
+          path="/workspaces/:workspaceId/domain-packs/:packId"
+          element={<ShellHost />}
         >
-          <Route path=":policyId" />
+          <Route path="policies" element={<PolicyDraftReadPage />}>
+            <Route path=":policyId" />
+          </Route>
         </Route>
       </Routes>
     </MemoryRouter>,
@@ -61,7 +84,9 @@ describe("PolicyDraftReadPage", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "select policy" }));
 
-    expect(navigate).toHaveBeenCalledWith("/workspaces/1/domain-packs/7/policies/4?versionId=101");
+    expect(navigate).toHaveBeenCalledWith(
+      "/workspaces/1/domain-packs/7/policies/4?versionId=101",
+    );
   });
 
   it("정책 상세에서 수정 화면 전환을 처리한다", () => {
@@ -70,7 +95,9 @@ describe("PolicyDraftReadPage", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "edit policy" }));
 
-    expect(screen.getByRole("button", { name: "close editor" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "close editor" }),
+    ).toBeInTheDocument();
   });
 
   it("정책 상세에서 다른 정책 선택 시 현재 상세 route를 replace한다", () => {
@@ -79,9 +106,12 @@ describe("PolicyDraftReadPage", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "select policy" }));
 
-    expect(navigate).toHaveBeenCalledWith("/workspaces/1/domain-packs/7/policies/4?versionId=101", {
-      replace: true,
-    });
+    expect(navigate).toHaveBeenCalledWith(
+      "/workspaces/1/domain-packs/7/policies/4?versionId=101",
+      {
+        replace: true,
+      },
+    );
   });
 
   it("정책 상세에서 목록 버튼을 누르면 선택 없는 목록 URL로 replace한다", () => {
@@ -90,14 +120,19 @@ describe("PolicyDraftReadPage", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "목록" }));
 
-    expect(navigate).toHaveBeenCalledWith("/workspaces/1/domain-packs/7/policies?versionId=101", {
-      replace: true,
-    });
+    expect(navigate).toHaveBeenCalledWith(
+      "/workspaces/1/domain-packs/7/policies?versionId=101",
+      {
+        replace: true,
+      },
+    );
   });
 
   it("잘못된 URL 파라미터면 alert를 표시한다", () => {
     renderPage("/workspaces/abc/domain-packs/7/policies?versionId=101");
 
-    expect(screen.getByRole("alert")).toHaveTextContent("잘못된 URL 파라미터입니다.");
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "잘못된 URL 파라미터입니다.",
+    );
   });
 });

--- a/frontend/src/pages/domain-pack/ui/PolicyDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/PolicyDraftReadPage.tsx
@@ -1,7 +1,13 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
-import { usePackDetail, VersionSafetyBanner } from "@/features/domain-pack-summary-read";
-import { PolicyDetailPanel, PolicyListPanel } from "@/features/policy-draft-read/ui";
+import {
+  usePackDetail,
+  VersionSafetyBanner,
+} from "@/features/domain-pack-summary-read";
+import {
+  PolicyDetailPanel,
+  PolicyListPanel,
+} from "@/features/policy-draft-read/ui";
 import { PolicyEditPanel } from "@/features/update-policy";
 import {
   buildDomainPackCrumbs,
@@ -11,7 +17,7 @@ import {
 import { parseRouteId } from "@/shared/lib/parseRouteId";
 import { Pill } from "@/shared/ui/ostone/atoms";
 import type { Crumb } from "@/shared/ui/ostone/chrome";
-import { OstoneShell } from "@/widgets/ostone-shell";
+import { DomainPackShellState } from "./DomainPackShellState";
 import styles from "./policy-draft-read-page.module.css";
 
 interface EditingPolicyState {
@@ -23,7 +29,9 @@ export function PolicyDraftReadPage() {
   const { workspaceId, packId, policyId } = useParams();
   const [search] = useSearchParams();
   const navigate = useNavigate();
-  const [editingPolicy, setEditingPolicy] = useState<EditingPolicyState | null>(null);
+  const [editingPolicy, setEditingPolicy] = useState<EditingPolicyState | null>(
+    null,
+  );
   const listSlotRef = useRef<HTMLDivElement>(null);
   const shouldFocusListRef = useRef(false);
 
@@ -31,14 +39,19 @@ export function PolicyDraftReadPage() {
   const pId = parseRouteId(packId);
   const vId = parseRouteId(search.get("versionId") ?? undefined);
   const selectedPolicyId = policyId ? parseRouteId(policyId) : null;
-  const hasInvalidPolicyId = policyId !== undefined && selectedPolicyId === null;
+  const hasInvalidPolicyId =
+    policyId !== undefined && selectedPolicyId === null;
   const routeKey = `${wsId}:${pId}:${vId}:${selectedPolicyId}`;
 
   const packDetail = usePackDetail(wsId ?? 0, pId ?? 0, {
-    enabled: wsId !== null && pId !== null && vId !== null && !hasInvalidPolicyId,
+    enabled:
+      wsId !== null && pId !== null && vId !== null && !hasInvalidPolicyId,
   }).data;
   const packName = packDetail?.name ?? `PACK · ${pId ?? "?"}`;
-  const versionNo = packDetail?.versions?.find((v) => v.versionId === vId)?.versionNo ?? vId ?? 0;
+  const versionNo =
+    packDetail?.versions?.find((v) => v.versionId === vId)?.versionNo ??
+    vId ??
+    0;
   const hasSelection = selectedPolicyId !== null;
 
   useEffect(() => {
@@ -47,13 +60,39 @@ export function PolicyDraftReadPage() {
     shouldFocusListRef.current = false;
   }, [hasSelection]);
 
+  const crumbs = useMemo<Crumb[]>(() => {
+    if (wsId === null || pId === null || vId === null || hasInvalidPolicyId) {
+      return ["도메인팩 관리"];
+    }
+
+    return buildDomainPackCrumbs({
+      wsId,
+      pId,
+      vId,
+      packName,
+      versionNo,
+      section: { label: "응대 기준", path: "policies" },
+      selectedLabel: selectedPolicyId !== null ? `#${selectedPolicyId}` : null,
+    });
+  }, [
+    hasInvalidPolicyId,
+    packName,
+    pId,
+    selectedPolicyId,
+    versionNo,
+    vId,
+    wsId,
+  ]);
+
+  const topbarRight = useMemo(() => <Pill tone="mute">조회/수정</Pill>, []);
+
   if (wsId === null || pId === null || vId === null || hasInvalidPolicyId) {
     return (
-      <OstoneShell active="domain" crumbs={["도메인팩 관리"]}>
+      <DomainPackShellState crumbs={crumbs}>
         <div className={styles.invalidParams} role="alert">
           잘못된 URL 파라미터입니다.
         </div>
-      </OstoneShell>
+      </DomainPackShellState>
     );
   }
 
@@ -68,38 +107,35 @@ export function PolicyDraftReadPage() {
   };
 
   const activeEditingPolicyId =
-    editingPolicy?.routeKey === routeKey && editingPolicy.policyId === selectedPolicyId
+    editingPolicy?.routeKey === routeKey &&
+    editingPolicy.policyId === selectedPolicyId
       ? editingPolicy.policyId
       : null;
 
   const handleBackToList = () => {
     setEditingPolicy(null);
     shouldFocusListRef.current = true;
-    navigate(domainPackSectionPath(wsId, pId, vId, "policies"), { replace: true });
+    navigate(domainPackSectionPath(wsId, pId, vId, "policies"), {
+      replace: true,
+    });
   };
 
-  const crumbs: Crumb[] = buildDomainPackCrumbs({
-    wsId,
-    pId,
-    vId,
-    packName,
-    versionNo,
-    section: { label: "응대 기준", path: "policies" },
-    selectedLabel: selectedPolicyId !== null ? `#${selectedPolicyId}` : null,
-  });
-
-  const topbarRight = <Pill tone="mute">조회/수정</Pill>;
-
   return (
-    <OstoneShell active="policy" crumbs={crumbs} topbarRight={topbarRight}>
+    <DomainPackShellState crumbs={crumbs} topbarRight={topbarRight}>
       <div className={styles.pageWrapper}>
         <VersionSafetyBanner wsId={wsId} packId={pId} versionId={vId} />
         {hasSelection && (
-          <button type="button" className={styles.backButton} onClick={handleBackToList}>
+          <button
+            type="button"
+            className={styles.backButton}
+            onClick={handleBackToList}
+          >
             목록
           </button>
         )}
-        <div className={`${styles.twoPane} ${hasSelection ? styles.hasSelection : ""}`}>
+        <div
+          className={`${styles.twoPane} ${hasSelection ? styles.hasSelection : ""}`}
+        >
           <div
             ref={listSlotRef}
             className={styles.listSlot}
@@ -135,6 +171,6 @@ export function PolicyDraftReadPage() {
           </div>
         </div>
       </div>
-    </OstoneShell>
+    </DomainPackShellState>
   );
 }

--- a/frontend/src/pages/domain-pack/ui/RiskDraftReadPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/RiskDraftReadPage.test.tsx
@@ -1,12 +1,16 @@
+import { useState } from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Outlet, Route, Routes } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 import { RiskDraftReadPage } from "./RiskDraftReadPage";
 
 const navigate = vi.fn();
 
 vi.mock("react-router-dom", async () => {
-  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  const actual =
+    await vi.importActual<typeof import("react-router-dom")>(
+      "react-router-dom",
+    );
   return {
     ...actual,
     useNavigate: () => navigate,
@@ -45,15 +49,34 @@ vi.mock("@/features/update-risk", () => ({
   ),
 }));
 
+function ShellHost() {
+  const [crumbs, setCrumbs] = useState<Array<string | { label: string }>>([]);
+  const [topbarRight, setTopbarRight] = useState<React.ReactNode>();
+
+  return (
+    <>
+      <div data-testid="shell-crumbs">
+        {crumbs
+          .map((crumb) => (typeof crumb === "string" ? crumb : crumb.label))
+          .join(" / ")}
+      </div>
+      <div data-testid="shell-topbar">{topbarRight}</div>
+      <Outlet context={{ setCrumbs, setTopbarRight, workspace: null }} />
+    </>
+  );
+}
+
 function renderPage(path: string) {
   return render(
     <MemoryRouter initialEntries={[path]}>
       <Routes>
         <Route
-          path="/workspaces/:workspaceId/domain-packs/:packId/risks"
-          element={<RiskDraftReadPage />}
+          path="/workspaces/:workspaceId/domain-packs/:packId"
+          element={<ShellHost />}
         >
-          <Route path=":riskId" />
+          <Route path="risks" element={<RiskDraftReadPage />}>
+            <Route path=":riskId" />
+          </Route>
         </Route>
       </Routes>
     </MemoryRouter>,
@@ -67,7 +90,9 @@ describe("RiskDraftReadPage", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "select risk" }));
 
-    expect(navigate).toHaveBeenCalledWith("/workspaces/1/domain-packs/7/risks/4?versionId=101");
+    expect(navigate).toHaveBeenCalledWith(
+      "/workspaces/1/domain-packs/7/risks/4?versionId=101",
+    );
   });
 
   it("위험요소 상세에서 다른 위험요소 선택 시 현재 상세 route를 replace한다", () => {
@@ -76,9 +101,12 @@ describe("RiskDraftReadPage", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "select risk" }));
 
-    expect(navigate).toHaveBeenCalledWith("/workspaces/1/domain-packs/7/risks/4?versionId=101", {
-      replace: true,
-    });
+    expect(navigate).toHaveBeenCalledWith(
+      "/workspaces/1/domain-packs/7/risks/4?versionId=101",
+      {
+        replace: true,
+      },
+    );
   });
 
   it("위험요소 상세에서 목록 버튼을 누르면 선택 없는 목록 URL로 replace한다", () => {
@@ -87,9 +115,12 @@ describe("RiskDraftReadPage", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "목록" }));
 
-    expect(navigate).toHaveBeenCalledWith("/workspaces/1/domain-packs/7/risks?versionId=101", {
-      replace: true,
-    });
+    expect(navigate).toHaveBeenCalledWith(
+      "/workspaces/1/domain-packs/7/risks?versionId=101",
+      {
+        replace: true,
+      },
+    );
   });
 
   it("수정 버튼을 누르면 편집 패널로 전환하고 닫을 수 있다", () => {
@@ -114,6 +145,8 @@ describe("RiskDraftReadPage", () => {
   it("잘못된 URL 파라미터면 alert를 표시한다", () => {
     renderPage("/workspaces/abc/domain-packs/7/risks?versionId=101");
 
-    expect(screen.getByRole("alert")).toHaveTextContent("잘못된 URL 파라미터입니다.");
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "잘못된 URL 파라미터입니다.",
+    );
   });
 });

--- a/frontend/src/pages/domain-pack/ui/RiskDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/RiskDraftReadPage.tsx
@@ -1,6 +1,9 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
-import { usePackDetail, VersionSafetyBanner } from "@/features/domain-pack-summary-read";
+import {
+  usePackDetail,
+  VersionSafetyBanner,
+} from "@/features/domain-pack-summary-read";
 import { RiskDetailPanel, RiskListPanel } from "@/features/risk-draft-read/ui";
 import { RiskEditPanel } from "@/features/update-risk";
 import {
@@ -11,7 +14,7 @@ import {
 import { parseRouteId } from "@/shared/lib/parseRouteId";
 import { Pill } from "@/shared/ui/ostone/atoms";
 import type { Crumb } from "@/shared/ui/ostone/chrome";
-import { OstoneShell } from "@/widgets/ostone-shell";
+import { DomainPackShellState } from "./DomainPackShellState";
 import styles from "./risk-draft-read-page.module.css";
 
 interface EditingRiskState {
@@ -38,7 +41,10 @@ export function RiskDraftReadPage() {
     enabled: wsId !== null && pId !== null && vId !== null && !hasInvalidRiskId,
   }).data;
   const packName = packDetail?.name ?? `PACK · ${pId ?? "?"}`;
-  const versionNo = packDetail?.versions?.find((v) => v.versionId === vId)?.versionNo ?? vId ?? 0;
+  const versionNo =
+    packDetail?.versions?.find((v) => v.versionId === vId)?.versionNo ??
+    vId ??
+    0;
   const hasSelection = selectedRiskId !== null;
 
   useEffect(() => {
@@ -47,13 +53,31 @@ export function RiskDraftReadPage() {
     shouldFocusListRef.current = false;
   }, [hasSelection]);
 
+  const crumbs = useMemo<Crumb[]>(() => {
+    if (wsId === null || pId === null || vId === null || hasInvalidRiskId) {
+      return ["도메인팩 관리"];
+    }
+
+    return buildDomainPackCrumbs({
+      wsId,
+      pId,
+      vId,
+      packName,
+      versionNo,
+      section: { label: "주의 사항", path: "risks" },
+      selectedLabel: selectedRiskId !== null ? `#${selectedRiskId}` : null,
+    });
+  }, [hasInvalidRiskId, packName, pId, selectedRiskId, versionNo, vId, wsId]);
+
+  const topbarRight = useMemo(() => <Pill tone="mute">조회/수정</Pill>, []);
+
   if (wsId === null || pId === null || vId === null || hasInvalidRiskId) {
     return (
-      <OstoneShell active="domain" crumbs={["도메인팩 관리"]}>
+      <DomainPackShellState crumbs={crumbs}>
         <div className={styles.invalidParams} role="alert">
           잘못된 URL 파라미터입니다.
         </div>
-      </OstoneShell>
+      </DomainPackShellState>
     );
   }
 
@@ -68,28 +92,22 @@ export function RiskDraftReadPage() {
     navigate(domainPackSectionPath(wsId, pId, vId, "risks"), { replace: true });
   };
 
-  const crumbs: Crumb[] = buildDomainPackCrumbs({
-    wsId,
-    pId,
-    vId,
-    packName,
-    versionNo,
-    section: { label: "주의 사항", path: "risks" },
-    selectedLabel: selectedRiskId !== null ? `#${selectedRiskId}` : null,
-  });
-
-  const topbarRight = <Pill tone="mute">조회/수정</Pill>;
-
   return (
-    <OstoneShell active="risk" crumbs={crumbs} topbarRight={topbarRight}>
+    <DomainPackShellState crumbs={crumbs} topbarRight={topbarRight}>
       <div className={styles.pageWrapper}>
         <VersionSafetyBanner wsId={wsId} packId={pId} versionId={vId} />
         {hasSelection && (
-          <button type="button" className={styles.backButton} onClick={handleBackToList}>
+          <button
+            type="button"
+            className={styles.backButton}
+            onClick={handleBackToList}
+          >
             목록
           </button>
         )}
-        <div className={`${styles.twoPane} ${hasSelection ? styles.hasSelection : ""}`}>
+        <div
+          className={`${styles.twoPane} ${hasSelection ? styles.hasSelection : ""}`}
+        >
           <div
             ref={listSlotRef}
             className={styles.listSlot}
@@ -133,6 +151,6 @@ export function RiskDraftReadPage() {
           </div>
         </div>
       </div>
-    </OstoneShell>
+    </DomainPackShellState>
   );
 }

--- a/frontend/src/pages/domain-pack/ui/SlotDraftReadPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/SlotDraftReadPage.test.tsx
@@ -1,12 +1,16 @@
+import { useState } from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Outlet, Route, Routes } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 import { SlotDraftReadPage } from "./SlotDraftReadPage";
 
 const navigate = vi.fn();
 
 vi.mock("react-router-dom", async () => {
-  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  const actual =
+    await vi.importActual<typeof import("react-router-dom")>(
+      "react-router-dom",
+    );
   return {
     ...actual,
     useNavigate: () => navigate,
@@ -29,15 +33,34 @@ vi.mock("@/features/slot-draft-read/ui", () => ({
   ),
 }));
 
+function ShellHost() {
+  const [crumbs, setCrumbs] = useState<Array<string | { label: string }>>([]);
+  const [topbarRight, setTopbarRight] = useState<React.ReactNode>();
+
+  return (
+    <>
+      <div data-testid="shell-crumbs">
+        {crumbs
+          .map((crumb) => (typeof crumb === "string" ? crumb : crumb.label))
+          .join(" / ")}
+      </div>
+      <div data-testid="shell-topbar">{topbarRight}</div>
+      <Outlet context={{ setCrumbs, setTopbarRight, workspace: null }} />
+    </>
+  );
+}
+
 function renderPage(path: string) {
   return render(
     <MemoryRouter initialEntries={[path]}>
       <Routes>
         <Route
-          path="/workspaces/:workspaceId/domain-packs/:packId/slots"
-          element={<SlotDraftReadPage />}
+          path="/workspaces/:workspaceId/domain-packs/:packId"
+          element={<ShellHost />}
         >
-          <Route path=":slotId" />
+          <Route path="slots" element={<SlotDraftReadPage />}>
+            <Route path=":slotId" />
+          </Route>
         </Route>
       </Routes>
     </MemoryRouter>,
@@ -51,7 +74,9 @@ describe("SlotDraftReadPage", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "select slot" }));
 
-    expect(navigate).toHaveBeenCalledWith("/workspaces/1/domain-packs/7/slots/4?versionId=101");
+    expect(navigate).toHaveBeenCalledWith(
+      "/workspaces/1/domain-packs/7/slots/4?versionId=101",
+    );
   });
 
   it("슬롯 상세에서 다른 슬롯 선택 시 현재 상세 route를 replace한다", () => {
@@ -60,14 +85,19 @@ describe("SlotDraftReadPage", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "select slot" }));
 
-    expect(navigate).toHaveBeenCalledWith("/workspaces/1/domain-packs/7/slots/4?versionId=101", {
-      replace: true,
-    });
+    expect(navigate).toHaveBeenCalledWith(
+      "/workspaces/1/domain-packs/7/slots/4?versionId=101",
+      {
+        replace: true,
+      },
+    );
   });
 
   it("잘못된 URL 파라미터면 alert를 표시한다", () => {
     renderPage("/workspaces/abc/domain-packs/7/slots?versionId=101");
 
-    expect(screen.getByRole("alert")).toHaveTextContent("잘못된 URL 파라미터입니다.");
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "잘못된 URL 파라미터입니다.",
+    );
   });
 });

--- a/frontend/src/pages/domain-pack/ui/SlotDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/SlotDraftReadPage.tsx
@@ -1,15 +1,22 @@
+import { useMemo } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
-import { SlotListPanel, SlotDetailPanel } from "../../../features/slot-draft-read/ui";
+import {
+  SlotListPanel,
+  SlotDetailPanel,
+} from "../../../features/slot-draft-read/ui";
 import {
   buildDomainPackCrumbs,
   domainPackSectionPath,
   shouldReplaceDomainPackChildRoute,
 } from "../../../shared/lib/domainPackRoutes";
 import { parseRouteId } from "../../../shared/lib/parseRouteId";
-import { usePackDetail, VersionSafetyBanner } from "@/features/domain-pack-summary-read";
+import {
+  usePackDetail,
+  VersionSafetyBanner,
+} from "@/features/domain-pack-summary-read";
 import { Pill } from "@/shared/ui/ostone/atoms";
 import type { Crumb } from "@/shared/ui/ostone/chrome";
-import { OstoneShell } from "@/widgets/ostone-shell";
+import { DomainPackShellState } from "./DomainPackShellState";
 import styles from "./slot-draft-read-page.module.css";
 
 export function SlotDraftReadPage() {
@@ -24,18 +31,50 @@ export function SlotDraftReadPage() {
 
   const packDetail = usePackDetail(wsId ?? 0, pId ?? 0, {
     enabled:
-      wsId !== null && pId !== null && vId !== null && (slotId === undefined || sId !== null),
+      wsId !== null &&
+      pId !== null &&
+      vId !== null &&
+      (slotId === undefined || sId !== null),
   }).data;
   const packName = packDetail?.name ?? `PACK · ${pId ?? "?"}`;
-  const versionNo = packDetail?.versions?.find((v) => v.versionId === vId)?.versionNo ?? vId ?? 0;
+  const versionNo =
+    packDetail?.versions?.find((v) => v.versionId === vId)?.versionNo ??
+    vId ??
+    0;
+  const crumbs = useMemo<Crumb[]>(() => {
+    if (
+      wsId === null ||
+      pId === null ||
+      vId === null ||
+      (slotId !== undefined && sId === null)
+    ) {
+      return ["도메인팩 관리"];
+    }
 
-  if (wsId === null || pId === null || vId === null || (slotId !== undefined && sId === null)) {
+    return buildDomainPackCrumbs({
+      wsId,
+      pId,
+      vId,
+      packName,
+      versionNo,
+      section: { label: "확인 항목", path: "slots" },
+      selectedLabel: sId !== null ? `#${sId}` : null,
+    });
+  }, [packName, pId, sId, slotId, versionNo, vId, wsId]);
+  const topbarRight = useMemo(() => <Pill tone="mute">읽기 전용</Pill>, []);
+
+  if (
+    wsId === null ||
+    pId === null ||
+    vId === null ||
+    (slotId !== undefined && sId === null)
+  ) {
     return (
-      <OstoneShell active="domain" crumbs={["도메인팩 관리"]}>
+      <DomainPackShellState crumbs={crumbs}>
         <div className={styles.invalidParams} role="alert">
           잘못된 URL 파라미터입니다.
         </div>
-      </OstoneShell>
+      </DomainPackShellState>
     );
   }
 
@@ -50,23 +89,13 @@ export function SlotDraftReadPage() {
 
   const hasSelection = sId !== null;
 
-  const crumbs: Crumb[] = buildDomainPackCrumbs({
-    wsId,
-    pId,
-    vId,
-    packName,
-    versionNo,
-    section: { label: "확인 항목", path: "slots" },
-    selectedLabel: sId !== null ? `#${sId}` : null,
-  });
-
-  const topbarRight = <Pill tone="mute">읽기 전용</Pill>;
-
   return (
-    <OstoneShell active="slot" crumbs={crumbs} topbarRight={topbarRight}>
+    <DomainPackShellState crumbs={crumbs} topbarRight={topbarRight}>
       <div className={styles.pageWrapper}>
         <VersionSafetyBanner wsId={wsId} packId={pId} versionId={vId} />
-        <div className={`${styles.twoPane} ${hasSelection ? styles.hasSelection : ""}`}>
+        <div
+          className={`${styles.twoPane} ${hasSelection ? styles.hasSelection : ""}`}
+        >
           <div className={styles.listSlot}>
             <SlotListPanel
               wsId={wsId}
@@ -77,10 +106,15 @@ export function SlotDraftReadPage() {
             />
           </div>
           <div className={styles.detailSlot}>
-            <SlotDetailPanel wsId={wsId} packId={pId} versionId={vId} slotId={sId} />
+            <SlotDetailPanel
+              wsId={wsId}
+              packId={pId}
+              versionId={vId}
+              slotId={sId}
+            />
           </div>
         </div>
       </div>
-    </OstoneShell>
+    </DomainPackShellState>
   );
 }

--- a/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.test.tsx
@@ -1,6 +1,13 @@
+import { useState } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import {
+  MemoryRouter,
+  Outlet,
+  Route,
+  Routes,
+  useLocation,
+} from "react-router-dom";
 import { ApiRequestError } from "@/shared/api";
 import { WorkflowDraftReadPage } from "./WorkflowDraftReadPage";
 
@@ -12,13 +19,18 @@ const mockGetWorkflowBottleneckAnalysis = vi.fn();
 const mockToastSuccess = vi.fn();
 const mockToastError = vi.fn();
 vi.mock("@/entities/workflow", () => ({
-  useGetWorkflowDefinition: (...args: unknown[]) => mockUseGetWorkflowDefinition(...args),
+  useGetWorkflowDefinition: (...args: unknown[]) =>
+    mockUseGetWorkflowDefinition(...args),
 }));
 
 vi.mock("@/features/domain-pack-summary-read", () => ({
   usePackDetail: (...args: unknown[]) => mockUsePackDetail(...args),
   formatLifecycleStatus: (status?: string | null) =>
-    status === "PUBLISHED" ? "운영 가능" : status === "DRAFT" ? "검토 중" : "상태 없음",
+    status === "PUBLISHED"
+      ? "운영 가능"
+      : status === "DRAFT"
+        ? "검토 중"
+        : "상태 없음",
   VersionSafetyBanner: () => null,
 }));
 
@@ -33,7 +45,11 @@ vi.mock("@/features/update-workflow", () => ({
   InlineWorkflowEditor: vi.fn(({ workflow, onClose, onDirtyChange }) => (
     <div data-testid="inline-editor">
       editing {workflow.workflowCode}
-      <button type="button" data-testid="editor-dirty" onClick={() => onDirtyChange(true)}>
+      <button
+        type="button"
+        data-testid="editor-dirty"
+        onClick={() => onDirtyChange(true)}
+      >
         dirty
       </button>
       <button type="button" data-testid="editor-close" onClick={onClose}>
@@ -49,17 +65,10 @@ vi.mock("@/features/workflow-viewer/ui/GraphViewer", () => ({
   )),
 }));
 
-vi.mock("@/widgets/ostone-shell", () => ({
-  OstoneShell: ({ children, crumbs }: { children: React.ReactNode; crumbs: string[] }) => (
-    <div>
-      <div data-testid="crumbs">{crumbs.join(" / ")}</div>
-      {children}
-    </div>
-  ),
-}));
 vi.mock("@/features/intent-revision-draft", () => ({
   intentRevisionDraftApi: {
-    createRevisionDraft: (...args: unknown[]) => mockCreateRevisionDraft(...args),
+    createRevisionDraft: (...args: unknown[]) =>
+      mockCreateRevisionDraft(...args),
   },
 }));
 vi.mock(
@@ -75,11 +84,28 @@ vi.mock("sonner", () => ({
   },
 }));
 
-const ROUTE = "/workspaces/:workspaceId/domain-packs/:packId/workflows/:workflowId?";
-
 function LocationProbe() {
   const location = useLocation();
-  return <div data-testid="location">{`${location.pathname}${location.search}`}</div>;
+  return (
+    <div data-testid="location">{`${location.pathname}${location.search}`}</div>
+  );
+}
+
+function ShellHost() {
+  const [crumbs, setCrumbs] = useState<Array<string | { label: string }>>([]);
+  const [topbarRight, setTopbarRight] = useState<React.ReactNode>();
+
+  return (
+    <>
+      <div data-testid="crumbs">
+        {crumbs
+          .map((crumb) => (typeof crumb === "string" ? crumb : crumb.label))
+          .join(" / ")}
+      </div>
+      <div data-testid="shell-topbar">{topbarRight}</div>
+      <Outlet context={{ setCrumbs, setTopbarRight, workspace: null }} />
+    </>
+  );
 }
 
 function renderPage(path: string, state?: unknown) {
@@ -95,14 +121,19 @@ function renderPage(path: string, state?: unknown) {
     >
       <Routes>
         <Route
-          path={ROUTE}
-          element={
-            <>
-              <WorkflowDraftReadPage />
-              <LocationProbe />
-            </>
-          }
-        />
+          path="/workspaces/:workspaceId/domain-packs/:packId"
+          element={<ShellHost />}
+        >
+          <Route
+            path="workflows/:workflowId?"
+            element={
+              <>
+                <WorkflowDraftReadPage />
+                <LocationProbe />
+              </>
+            }
+          />
+        </Route>
         <Route path="*" element={<LocationProbe />} />
       </Routes>
     </MemoryRouter>,
@@ -134,7 +165,9 @@ beforeEach(() => {
     policyHitTop: [],
     riskHitTop: [],
     humanInterventionPoints: [],
-    improvementHints: ["선택 기간에 개선 우선순위를 판단할 병목 신호가 아직 충분하지 않습니다."],
+    improvementHints: [
+      "선택 기간에 개선 우선순위를 판단할 병목 신호가 아직 충분하지 않습니다.",
+    ],
   });
   mockUsePackDetail.mockReturnValue({
     data: {
@@ -153,7 +186,9 @@ describe("WorkflowDraftReadPage", () => {
   it("유효하지 않은 URL 파라미터는 에러 메시지를 보여준다", () => {
     mockUseGetWorkflowDefinition.mockReturnValue({ isLoading: false });
     renderPage("/workspaces/abc/domain-packs/2/workflows?versionId=3");
-    expect(screen.getByRole("alert")).toHaveTextContent("잘못된 URL 파라미터입니다.");
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "잘못된 URL 파라미터입니다.",
+    );
   });
 
   it("workflowId가 없으면 좌측 사이드바에서 선택하라는 안내를 표시한다", () => {
@@ -197,10 +232,14 @@ describe("WorkflowDraftReadPage", () => {
       },
     });
     renderPage("/workspaces/1/domain-packs/2/workflows/10?versionId=3");
-    expect(screen.getByTestId("workflow-detail-title")).toHaveTextContent("환불 처리");
+    expect(screen.getByTestId("workflow-detail-title")).toHaveTextContent(
+      "환불 처리",
+    );
     expect(screen.queryByText("refund.standard")).not.toBeInTheDocument();
     expect(screen.getByText("노드 2개")).toBeInTheDocument();
-    expect(screen.getByTestId("graph-viewer")).toHaveTextContent("graph nodes: 2");
+    expect(screen.getByTestId("graph-viewer")).toHaveTextContent(
+      "graph nodes: 2",
+    );
   });
 
   it("운영 실행 병목 분석 패널을 표시한다", async () => {
@@ -213,7 +252,9 @@ describe("WorkflowDraftReadPage", () => {
       completedCount: 1,
       failedCount: 1,
       runningCount: 1,
-      transitions: [{ stateFrom: "collect_slots", stateTo: "verify_policy", passCount: 2 }],
+      transitions: [
+        { stateFrom: "collect_slots", stateTo: "verify_policy", passCount: 2 },
+      ],
       longestDwellState: {
         stateName: "collect_slots",
         metricValue: 420,
@@ -244,7 +285,9 @@ describe("WorkflowDraftReadPage", () => {
           description: "상담사 개입 action이 자주 발생한 state",
         },
       ],
-      improvementHints: ["order_id slot 수집 문구와 검증 규칙을 우선 점검하세요."],
+      improvementHints: [
+        "order_id slot 수집 문구와 검증 규칙을 우선 점검하세요.",
+      ],
     });
     mockUseGetWorkflowDefinition.mockReturnValue({
       isLoading: false,
@@ -259,9 +302,9 @@ describe("WorkflowDraftReadPage", () => {
 
     renderPage("/workspaces/1/domain-packs/2/workflows/10?versionId=3");
 
-    expect(await screen.findByTestId("workflow-analysis-panel")).toHaveTextContent(
-      "운영 실행 병목 분석",
-    );
+    expect(
+      await screen.findByTestId("workflow-analysis-panel"),
+    ).toHaveTextContent("운영 실행 병목 분석");
     expect(screen.getByText("전체 실행")).toBeInTheDocument();
     expect(screen.getAllByText("collect_slots").length).toBeGreaterThan(0);
     expect(screen.getAllByText("verify_policy").length).toBeGreaterThan(0);
@@ -272,7 +315,9 @@ describe("WorkflowDraftReadPage", () => {
   });
 
   it("운영 실행 병목 분석 로딩 상태를 표시한다", async () => {
-    mockGetWorkflowBottleneckAnalysis.mockReturnValueOnce(new Promise(() => undefined));
+    mockGetWorkflowBottleneckAnalysis.mockReturnValueOnce(
+      new Promise(() => undefined),
+    );
     mockUseGetWorkflowDefinition.mockReturnValue({
       isLoading: false,
       isError: false,
@@ -286,9 +331,9 @@ describe("WorkflowDraftReadPage", () => {
 
     renderPage("/workspaces/1/domain-packs/2/workflows/10?versionId=3");
 
-    expect(await screen.findByTestId("workflow-analysis-loading")).toHaveTextContent(
-      "워크플로우 병목 분석을 불러오는 중입니다.",
-    );
+    expect(
+      await screen.findByTestId("workflow-analysis-loading"),
+    ).toHaveTextContent("워크플로우 병목 분석을 불러오는 중입니다.");
   });
 
   it("운영 실행 병목 분석 데이터가 없으면 빈 상태를 표시한다", async () => {
@@ -305,9 +350,9 @@ describe("WorkflowDraftReadPage", () => {
 
     renderPage("/workspaces/1/domain-packs/2/workflows/10?versionId=3");
 
-    expect(await screen.findByTestId("workflow-analysis-empty")).toHaveTextContent(
-      "선택 기간에 분석할 운영 실행 로그가 없습니다.",
-    );
+    expect(
+      await screen.findByTestId("workflow-analysis-empty"),
+    ).toHaveTextContent("선택 기간에 분석할 운영 실행 로그가 없습니다.");
   });
 
   it("운영 실행 병목 분석 실패 상태에서 다시 시도할 수 있다", async () => {
@@ -352,17 +397,21 @@ describe("WorkflowDraftReadPage", () => {
 
     renderPage("/workspaces/1/domain-packs/2/workflows/10?versionId=3");
 
-    expect(await screen.findByTestId("workflow-analysis-error")).toHaveTextContent(
+    expect(
+      await screen.findByTestId("workflow-analysis-error"),
+    ).toHaveTextContent("워크플로우 병목 분석을 불러오지 못했습니다.");
+    expect(mockToastError).toHaveBeenCalledWith(
       "워크플로우 병목 분석을 불러오지 못했습니다.",
     );
-    expect(mockToastError).toHaveBeenCalledWith("워크플로우 병목 분석을 불러오지 못했습니다.");
 
     fireEvent.click(screen.getByRole("button", { name: "다시 시도" }));
 
-    expect(await screen.findByTestId("workflow-analysis-panel")).toHaveTextContent(
-      "1분 15초 평균 체류",
-    );
-    expect(screen.getByText("멈춘 실행이 관측되지 않았습니다.")).toBeInTheDocument();
+    expect(
+      await screen.findByTestId("workflow-analysis-panel"),
+    ).toHaveTextContent("1분 15초 평균 체류");
+    expect(
+      screen.getByText("멈춘 실행이 관측되지 않았습니다."),
+    ).toBeInTheDocument();
     expect(mockGetWorkflowBottleneckAnalysis).toHaveBeenCalledTimes(2);
   });
 
@@ -405,7 +454,9 @@ describe("WorkflowDraftReadPage", () => {
     renderPage("/workspaces/1/domain-packs/2/workflows/10?versionId=3");
     expect(screen.queryByTestId("inline-editor")).not.toBeInTheDocument();
     fireEvent.click(screen.getByTestId("edit-toggle"));
-    expect(screen.getByTestId("inline-editor")).toHaveTextContent("editing refund.standard");
+    expect(screen.getByTestId("inline-editor")).toHaveTextContent(
+      "editing refund.standard",
+    );
     expect(mockCreateRevisionDraft).not.toHaveBeenCalled();
   });
 
@@ -413,7 +464,9 @@ describe("WorkflowDraftReadPage", () => {
     mockUsePackDetail.mockReturnValue({
       data: {
         name: "CS Pack",
-        versions: [{ versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" }],
+        versions: [
+          { versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" },
+        ],
       },
       refetch: vi.fn().mockResolvedValue({
         data: {
@@ -454,7 +507,9 @@ describe("WorkflowDraftReadPage", () => {
     mockUsePackDetail.mockReturnValue({
       data: {
         name: "CS Pack",
-        versions: [{ versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" }],
+        versions: [
+          { versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" },
+        ],
       },
       refetch: vi.fn(),
     });
@@ -485,7 +540,9 @@ describe("WorkflowDraftReadPage", () => {
     mockUsePackDetail.mockReturnValue({
       data: {
         name: "CS Pack",
-        versions: [{ versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" }],
+        versions: [
+          { versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" },
+        ],
       },
       refetch: vi.fn().mockResolvedValue({
         data: {
@@ -528,7 +585,9 @@ describe("WorkflowDraftReadPage", () => {
     mockUsePackDetail.mockReturnValue({
       data: {
         name: "CS Pack",
-        versions: [{ versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" }],
+        versions: [
+          { versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" },
+        ],
       },
       refetch: vi.fn().mockResolvedValue({
         data: {
@@ -559,8 +618,12 @@ describe("WorkflowDraftReadPage", () => {
     renderPage("/workspaces/1/domain-packs/2/workflows/10?versionId=3");
     fireEvent.click(screen.getByTestId("edit-toggle"));
 
-    expect(await screen.findByText("진행 중인 검토본이 있습니다")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "기존 검토본으로 이동" }));
+    expect(
+      await screen.findByText("진행 중인 검토본이 있습니다"),
+    ).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", { name: "기존 검토본으로 이동" }),
+    );
     await waitFor(() =>
       expect(screen.getByTestId("location")).toHaveTextContent(
         "/workspaces/1/domain-packs/2/workflows/55?versionId=5",
@@ -572,11 +635,15 @@ describe("WorkflowDraftReadPage", () => {
     mockUsePackDetail.mockReturnValue({
       data: {
         name: "CS Pack",
-        versions: [{ versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" }],
+        versions: [
+          { versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" },
+        ],
       },
       refetch: vi.fn().mockResolvedValue({
         data: {
-          versions: [{ versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" }],
+          versions: [
+            { versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" },
+          ],
         },
       }),
     });
@@ -602,14 +669,18 @@ describe("WorkflowDraftReadPage", () => {
         "진행 중인 검토본을 확인할 수 없습니다. 도메인팩 화면에서 상태를 확인해 주세요.",
       ),
     );
-    expect(screen.queryByText("진행 중인 검토본이 있습니다")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("진행 중인 검토본이 있습니다"),
+    ).not.toBeInTheDocument();
   });
 
   it("기존 DRAFT 충돌 후 같은 workflow를 찾지 못하면 이동 dialog를 열지 않는다", async () => {
     mockUsePackDetail.mockReturnValue({
       data: {
         name: "CS Pack",
-        versions: [{ versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" }],
+        versions: [
+          { versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" },
+        ],
       },
       refetch: vi.fn().mockResolvedValue({
         data: {
@@ -645,16 +716,22 @@ describe("WorkflowDraftReadPage", () => {
         "기존 검토본에서 같은 워크플로우를 찾지 못했습니다.",
       ),
     );
-    expect(screen.queryByText("진행 중인 검토본이 있습니다")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("진행 중인 검토본이 있습니다"),
+    ).not.toBeInTheDocument();
   });
 
   it("기존 DRAFT 충돌 후 pack refetch가 실패하면 에러를 안내하고 dialog를 열지 않는다", async () => {
-    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
     try {
       mockUsePackDetail.mockReturnValue({
         data: {
           name: "CS Pack",
-          versions: [{ versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" }],
+          versions: [
+            { versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" },
+          ],
         },
         refetch: vi.fn().mockRejectedValue(new Error("refetch failed")),
       });
@@ -675,24 +752,32 @@ describe("WorkflowDraftReadPage", () => {
       renderPage("/workspaces/1/domain-packs/2/workflows/10?versionId=3");
       fireEvent.click(screen.getByTestId("edit-toggle"));
 
-      await waitFor(() => expect(mockToastError).toHaveBeenCalledWith("refetch failed"));
+      await waitFor(() =>
+        expect(mockToastError).toHaveBeenCalledWith("refetch failed"),
+      );
       expect(consoleError).toHaveBeenCalledWith(
         "Failed to resolve existing workflow draft",
         expect.any(Error),
       );
-      expect(screen.queryByText("진행 중인 검토본이 있습니다")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("진행 중인 검토본이 있습니다"),
+      ).not.toBeInTheDocument();
     } finally {
       consoleError.mockRestore();
     }
   });
 
   it("기존 DRAFT 충돌 후 workflow 목록 조회가 실패하면 에러를 안내한다", async () => {
-    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
     try {
       mockUsePackDetail.mockReturnValue({
         data: {
           name: "CS Pack",
-          versions: [{ versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" }],
+          versions: [
+            { versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" },
+          ],
         },
         refetch: vi.fn().mockResolvedValue({
           data: {
@@ -721,7 +806,9 @@ describe("WorkflowDraftReadPage", () => {
       renderPage("/workspaces/1/domain-packs/2/workflows/10?versionId=3");
       fireEvent.click(screen.getByTestId("edit-toggle"));
 
-      await waitFor(() => expect(mockToastError).toHaveBeenCalledWith("workflow list failed"));
+      await waitFor(() =>
+        expect(mockToastError).toHaveBeenCalledWith("workflow list failed"),
+      );
       expect(consoleError).toHaveBeenCalled();
     } finally {
       consoleError.mockRestore();
@@ -744,7 +831,9 @@ describe("WorkflowDraftReadPage", () => {
     fireEvent.click(screen.getByTestId("editor-dirty"));
     fireEvent.click(screen.getByTestId("editor-close"));
 
-    expect(await screen.findByText("변경 내역을 버릴까요?")).toBeInTheDocument();
+    expect(
+      await screen.findByText("변경 내역을 버릴까요?"),
+    ).toBeInTheDocument();
     expect(screen.getByTestId("inline-editor")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "계속 편집" }));
@@ -772,7 +861,9 @@ describe("WorkflowDraftReadPage", () => {
     fireEvent.click(screen.getByTestId("editor-dirty"));
     fireEvent.click(screen.getByRole("button", { name: "목록" }));
 
-    expect(await screen.findByText("변경 내역을 버릴까요?")).toBeInTheDocument();
+    expect(
+      await screen.findByText("변경 내역을 버릴까요?"),
+    ).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "변경 내역 버리기" }));
 
     await waitFor(() =>
@@ -810,12 +901,18 @@ describe("WorkflowDraftReadPage", () => {
     mockUsePackDetail.mockReturnValue({
       data: {
         name: "CS Pack",
-        versions: [{ versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" }],
+        versions: [
+          { versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" },
+        ],
       },
       refetch: vi.fn(),
     });
     mockCreateRevisionDraft.mockRejectedValue(
-      new ApiRequestError(400, "DOMAIN_PACK_VERSION_NOT_CURRENT", "현재 운영 버전이 아닙니다."),
+      new ApiRequestError(
+        400,
+        "DOMAIN_PACK_VERSION_NOT_CURRENT",
+        "현재 운영 버전이 아닙니다.",
+      ),
     );
     mockUseGetWorkflowDefinition.mockReturnValue({
       isLoading: false,
@@ -831,7 +928,9 @@ describe("WorkflowDraftReadPage", () => {
     renderPage("/workspaces/1/domain-packs/2/workflows/10?versionId=3");
     fireEvent.click(screen.getByTestId("edit-toggle"));
 
-    await waitFor(() => expect(mockToastError).toHaveBeenCalledWith("현재 운영 버전이 아닙니다."));
+    await waitFor(() =>
+      expect(mockToastError).toHaveBeenCalledWith("현재 운영 버전이 아닙니다."),
+    );
   });
 
   it("편집 모드에서는 상단 보기 버튼을 렌더하지 않는다", () => {
@@ -890,7 +989,9 @@ describe("WorkflowDraftReadPage", () => {
     renderPage("/workspaces/1/domain-packs/2/workflows/10?versionId=3");
     // legacy panels gone
     expect(screen.queryByText(/검토 중 · v0\.4/)).not.toBeInTheDocument();
-    expect(screen.queryByText("Card payment refund flow")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Card payment refund flow"),
+    ).not.toBeInTheDocument();
     expect(screen.queryByText("Selected node")).not.toBeInTheDocument();
     expect(screen.queryByText(/Edit graph/)).not.toBeInTheDocument();
     // tab list gone

--- a/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx
@@ -1,5 +1,10 @@
 import { type ReactNode, useEffect, useMemo, useState } from "react";
-import { useLocation, useNavigate, useParams, useSearchParams } from "react-router-dom";
+import {
+  useLocation,
+  useNavigate,
+  useParams,
+  useSearchParams,
+} from "react-router-dom";
 import { toast } from "sonner";
 import {
   formatLifecycleStatus,
@@ -13,9 +18,11 @@ import type {
 } from "@/features/consultation/api/consultationApi";
 import { InlineWorkflowEditor } from "@/features/update-workflow";
 import { intentRevisionDraftApi } from "@/features/intent-revision-draft";
-import { buildDomainPackCrumbs, domainPackSectionPath } from "@/shared/lib/domainPackRoutes";
+import {
+  buildDomainPackCrumbs,
+  domainPackSectionPath,
+} from "@/shared/lib/domainPackRoutes";
 import { parseRouteId } from "@/shared/lib/parseRouteId";
-import { OstoneShell } from "@/widgets/ostone-shell";
 import { Pill, Mono, Icon } from "@/shared/ui/ostone/atoms";
 import type { Crumb } from "@/shared/ui/ostone/chrome";
 import { Button } from "@/shared/ui/button";
@@ -36,6 +43,7 @@ import { listWorkflows } from "@/shared/api/generated/endpoints/workflow-definit
 import type { WorkflowDefinitionSummary } from "@/shared/api/generated/zod";
 import { unwrapApiResponse } from "@/shared/api/unwrapApiResponse";
 import { GraphViewer } from "@/features/workflow-viewer/ui/GraphViewer";
+import { DomainPackShellState } from "./DomainPackShellState";
 import styles from "./workflow-draft-read-page.module.css";
 
 type AnalysisState = "loading" | "error" | "empty" | "ready";
@@ -83,7 +91,13 @@ function formatInclusivePeriodEnd(value: string): string {
   return date.toISOString().slice(0, 10);
 }
 
-function HitList({ title, items }: { title: string; items: WorkflowHitMetric[] }) {
+function HitList({
+  title,
+  items,
+}: {
+  title: string;
+  items: WorkflowHitMetric[];
+}) {
   return (
     <section className={styles.analysisListGroup} aria-label={title}>
       <h4>{title}</h4>
@@ -119,16 +133,24 @@ function WorkflowBottleneckAnalysisPanel({
 }) {
   if (state === "loading") {
     return (
-      <section className={styles.analysisPanel} data-testid="workflow-analysis-loading">
+      <section
+        className={styles.analysisPanel}
+        data-testid="workflow-analysis-loading"
+      >
         <LoadingSpinner />
-        <p className={styles.analysisEmptyText}>워크플로우 병목 분석을 불러오는 중입니다.</p>
+        <p className={styles.analysisEmptyText}>
+          워크플로우 병목 분석을 불러오는 중입니다.
+        </p>
       </section>
     );
   }
 
   if (state === "error") {
     return (
-      <section className={styles.analysisPanel} data-testid="workflow-analysis-error">
+      <section
+        className={styles.analysisPanel}
+        data-testid="workflow-analysis-error"
+      >
         <ErrorState
           message={error ?? "워크플로우 병목 분석을 불러오지 못했습니다."}
           onRetry={onRetry}
@@ -139,34 +161,47 @@ function WorkflowBottleneckAnalysisPanel({
 
   if (state === "empty" || !analysis) {
     return (
-      <section className={styles.analysisPanel} data-testid="workflow-analysis-empty">
+      <section
+        className={styles.analysisPanel}
+        data-testid="workflow-analysis-empty"
+      >
         <div className={styles.analysisHeader}>
           <div>
             <span className={styles.analysisEyebrow}>Bottleneck Analysis</span>
             <h3>운영 실행 병목 분석</h3>
           </div>
         </div>
-        <p className={styles.analysisEmptyText}>선택 기간에 분석할 운영 실행 로그가 없습니다.</p>
+        <p className={styles.analysisEmptyText}>
+          선택 기간에 분석할 운영 실행 로그가 없습니다.
+        </p>
       </section>
     );
   }
 
   return (
-    <section className={styles.analysisPanel} data-testid="workflow-analysis-panel">
+    <section
+      className={styles.analysisPanel}
+      data-testid="workflow-analysis-panel"
+    >
       <div className={styles.analysisHeader}>
         <div>
           <span className={styles.analysisEyebrow}>Bottleneck Analysis</span>
           <h3>운영 실행 병목 분석</h3>
           <p>
-            상태 전이와 runtime decision 로그를 기준으로 slot, policy, risk 개선 지점을 요약합니다.
+            상태 전이와 runtime decision 로그를 기준으로 slot, policy, risk 개선
+            지점을 요약합니다.
           </p>
         </div>
         <span className={styles.analysisPeriod}>
-          {analysis.periodStart.slice(0, 10)} ~ {formatInclusivePeriodEnd(analysis.periodEnd)}
+          {analysis.periodStart.slice(0, 10)} ~{" "}
+          {formatInclusivePeriodEnd(analysis.periodEnd)}
         </span>
       </div>
 
-      <div className={styles.analysisMetricGrid} aria-label="워크플로우 실행 상태 요약">
+      <div
+        className={styles.analysisMetricGrid}
+        aria-label="워크플로우 실행 상태 요약"
+      >
         <article>
           <span>전체 실행</span>
           <strong>{formatMetricCount(analysis.totalExecutionCount)}</strong>
@@ -221,7 +256,9 @@ function WorkflowBottleneckAnalysisPanel({
             </div>
           ))
         ) : (
-          <p className={styles.analysisEmptyText}>표시할 상태 전이가 없습니다.</p>
+          <p className={styles.analysisEmptyText}>
+            표시할 상태 전이가 없습니다.
+          </p>
         )}
       </div>
 
@@ -231,7 +268,10 @@ function WorkflowBottleneckAnalysisPanel({
         <HitList title="Risk Hit TOP 5" items={analysis.riskHitTop} />
       </div>
 
-      <section className={styles.analysisListGroup} aria-label="상담사 개입 발생 지점">
+      <section
+        className={styles.analysisListGroup}
+        aria-label="상담사 개입 발생 지점"
+      >
         <h4>상담사 개입 지점</h4>
         {analysis.humanInterventionPoints.length > 0 ? (
           <ol>
@@ -246,7 +286,9 @@ function WorkflowBottleneckAnalysisPanel({
             ))}
           </ol>
         ) : (
-          <p className={styles.analysisEmptyText}>상담사 개입 지점이 관측되지 않았습니다.</p>
+          <p className={styles.analysisEmptyText}>
+            상담사 개입 지점이 관측되지 않았습니다.
+          </p>
         )}
       </section>
 
@@ -272,7 +314,8 @@ export function WorkflowDraftReadPage() {
     versionId: number;
     workflowId: number;
   } | null>(null);
-  const [analysis, setAnalysis] = useState<WorkspaceWorkflowBottleneckAnalysis | null>(null);
+  const [analysis, setAnalysis] =
+    useState<WorkspaceWorkflowBottleneckAnalysis | null>(null);
   const [isAnalysisLoading, setIsAnalysisLoading] = useState(false);
   const [analysisError, setAnalysisError] = useState<string | null>(null);
 
@@ -281,14 +324,17 @@ export function WorkflowDraftReadPage() {
   const vId = parseRouteId(search.get("versionId") ?? undefined);
   const wfId = workflowId ? parseRouteId(workflowId) : null;
 
-  const enabled = wsId !== null && pId !== null && vId !== null && wfId !== null;
+  const enabled =
+    wsId !== null && pId !== null && vId !== null && wfId !== null;
 
   const packQuery = usePackDetail(wsId ?? 0, pId ?? 0, {
     enabled: wsId !== null && pId !== null && vId !== null && wfId !== null,
   });
   const packDetail = packQuery.data;
   const packName = packDetail?.name ?? `PACK · ${pId ?? "?"}`;
-  const selectedVersion = packDetail?.versions?.find((v) => v.versionId === vId);
+  const selectedVersion = packDetail?.versions?.find(
+    (v) => v.versionId === vId,
+  );
   const versionNo = selectedVersion?.versionNo ?? vId ?? 0;
   const lifecycleStatus = selectedVersion?.lifecycleStatus ?? null;
   const workflowReturnTo = readWorkflowReturnTo(location.state);
@@ -337,7 +383,10 @@ export function WorkflowDraftReadPage() {
     setIsAnalysisLoading(true);
     setAnalysisError(null);
     try {
-      const data = await consultationApi.getWorkflowBottleneckAnalysis(wsId, wfId);
+      const data = await consultationApi.getWorkflowBottleneckAnalysis(
+        wsId,
+        wfId,
+      );
       setAnalysis(data);
     } catch (error) {
       console.error("Failed to load workflow bottleneck analysis:", error);
@@ -363,7 +412,10 @@ export function WorkflowDraftReadPage() {
       setIsAnalysisLoading(true);
       setAnalysisError(null);
       try {
-        const data = await consultationApi.getWorkflowBottleneckAnalysis(wsId, wfId);
+        const data = await consultationApi.getWorkflowBottleneckAnalysis(
+          wsId,
+          wfId,
+        );
         if (ignore) return;
         setAnalysis(data);
       } catch (error) {
@@ -386,6 +438,23 @@ export function WorkflowDraftReadPage() {
     };
   }, [wsId, wfId, enabled]);
 
+  const crumbs = useMemo<Crumb[]>(() => {
+    if (wsId === null || pId === null || vId === null) {
+      return ["도메인팩 관리"];
+    }
+
+    return buildDomainPackCrumbs({
+      wsId,
+      pId,
+      vId,
+      packName,
+      versionNo,
+      section: { label: "워크플로우", path: "workflows" },
+      selectedLabel:
+        workflow?.workflowCode ?? (wfId !== null ? `#${wfId}` : null),
+    });
+  }, [packName, pId, versionNo, vId, wfId, workflow?.workflowCode, wsId]);
+
   if (
     wsId === null ||
     pId === null ||
@@ -393,11 +462,11 @@ export function WorkflowDraftReadPage() {
     (workflowId !== undefined && wfId === null)
   ) {
     return (
-      <OstoneShell active="domain" crumbs={["도메인팩 관리"]}>
+      <DomainPackShellState crumbs={crumbs}>
         <div role="alert" style={{ padding: "24px", color: "var(--danger)" }}>
           잘못된 URL 파라미터입니다.
         </div>
-      </OstoneShell>
+      </DomainPackShellState>
     );
   }
 
@@ -414,17 +483,32 @@ export function WorkflowDraftReadPage() {
     setPendingClose(() => next);
   };
 
-  const navigateToWorkflow = (versionId: number, targetWorkflowId: number | null) => {
+  const navigateToWorkflow = (
+    versionId: number,
+    targetWorkflowId: number | null,
+  ) => {
     navigate(
-      domainPackSectionPath(wsId, pId, versionId, "workflows", targetWorkflowId ?? undefined),
+      domainPackSectionPath(
+        wsId,
+        pId,
+        versionId,
+        "workflows",
+        targetWorkflowId ?? undefined,
+      ),
       { replace: true },
     );
   };
 
-  const findWorkflowIdByCode = async (versionId: number, workflowCode: string) => {
+  const findWorkflowIdByCode = async (
+    versionId: number,
+    workflowCode: string,
+  ) => {
     const response = await listWorkflows(wsId, pId, versionId);
-    const workflows = (unwrapApiResponse(response) ?? []) as WorkflowDefinitionSummary[];
-    const target = workflows.find((entry) => entry.workflowCode === workflowCode);
+    const workflows = (unwrapApiResponse(response) ??
+      []) as WorkflowDefinitionSummary[];
+    const target = workflows.find(
+      (entry) => entry.workflowCode === workflowCode,
+    );
     return typeof target?.id === "number" ? target.id : null;
   };
 
@@ -432,7 +516,8 @@ export function WorkflowDraftReadPage() {
     try {
       const refetched = await packQuery.refetch();
       const drafts = (refetched.data?.versions ?? []).filter(
-        (version) => version.lifecycleStatus === "DRAFT" && version.versionId != null,
+        (version) =>
+          version.lifecycleStatus === "DRAFT" && version.versionId != null,
       );
 
       if (drafts.length !== 1 || drafts[0].versionId == null) {
@@ -443,7 +528,10 @@ export function WorkflowDraftReadPage() {
       }
 
       const draftVersionId = drafts[0].versionId;
-      const draftWorkflowId = await findWorkflowIdByCode(draftVersionId, workflowCode);
+      const draftWorkflowId = await findWorkflowIdByCode(
+        draftVersionId,
+        workflowCode,
+      );
 
       if (draftWorkflowId == null) {
         toast.error("기존 검토본에서 같은 워크플로우를 찾지 못했습니다.");
@@ -468,9 +556,12 @@ export function WorkflowDraftReadPage() {
   const handleBackToList = () => {
     guardEditorClose(() => {
       closeEditor();
-      navigate(workflowReturnTo ?? domainPackSectionPath(wsId, pId, vId, "workflows"), {
-        replace: true,
-      });
+      navigate(
+        workflowReturnTo ?? domainPackSectionPath(wsId, pId, vId, "workflows"),
+        {
+          replace: true,
+        },
+      );
     });
   };
 
@@ -482,15 +573,21 @@ export function WorkflowDraftReadPage() {
     }
 
     if (!workflow.workflowCode) {
-      toast.error("워크플로우 코드를 확인할 수 없어 수정 검토본을 만들 수 없습니다.");
+      toast.error(
+        "워크플로우 코드를 확인할 수 없어 수정 검토본을 만들 수 없습니다.",
+      );
       return;
     }
 
     setCreatingDraft(true);
     try {
-      const { draftVersionId } = await intentRevisionDraftApi.createRevisionDraft(wsId, pId, vId);
+      const { draftVersionId } =
+        await intentRevisionDraftApi.createRevisionDraft(wsId, pId, vId);
       await packQuery.refetch();
-      const draftWorkflowId = await findWorkflowIdByCode(draftVersionId, workflow.workflowCode);
+      const draftWorkflowId = await findWorkflowIdByCode(
+        draftVersionId,
+        workflow.workflowCode,
+      );
       if (draftWorkflowId === null) {
         toast.error("수정 검토본에서 같은 워크플로우를 찾지 못했습니다.");
         navigateToWorkflow(draftVersionId, null);
@@ -501,12 +598,18 @@ export function WorkflowDraftReadPage() {
       setEditDirty(false);
       toast.success("워크플로우 수정 검토본이 생성되었습니다.");
     } catch (error) {
-      if (error instanceof ApiRequestError && error.code === "DOMAIN_PACK_DRAFT_ALREADY_EXISTS") {
+      if (
+        error instanceof ApiRequestError &&
+        error.code === "DOMAIN_PACK_DRAFT_ALREADY_EXISTS"
+      ) {
         await resolveExistingDraft(workflow.workflowCode);
         return;
       }
       toast.error(
-        resolveWorkflowActionErrorMessage(error, "워크플로우 수정 검토본 생성에 실패했습니다."),
+        resolveWorkflowActionErrorMessage(
+          error,
+          "워크플로우 수정 검토본 생성에 실패했습니다.",
+        ),
       );
     } finally {
       setCreatingDraft(false);
@@ -528,16 +631,6 @@ export function WorkflowDraftReadPage() {
     navigateToWorkflow(target.versionId, target.workflowId);
   };
 
-  const crumbs: Crumb[] = buildDomainPackCrumbs({
-    wsId: wsId!,
-    pId: pId!,
-    vId: vId!,
-    packName,
-    versionNo,
-    section: { label: "워크플로우", path: "workflows" },
-    selectedLabel: workflow?.workflowCode ?? (wfId !== null ? `#${wfId}` : null),
-  });
-
   let graphContent: ReactNode;
   if (isEditing && workflow) {
     graphContent = (
@@ -553,7 +646,10 @@ export function WorkflowDraftReadPage() {
     );
   } else if (graph) {
     graphContent = (
-      <div data-testid="workflow-graph-viewer" style={{ width: "100%", height: "100%" }}>
+      <div
+        data-testid="workflow-graph-viewer"
+        style={{ width: "100%", height: "100%" }}
+      >
         <GraphViewer graph={graph} />
       </div>
     );
@@ -566,24 +662,34 @@ export function WorkflowDraftReadPage() {
   }
 
   return (
-    <OstoneShell active="workflows" crumbs={crumbs}>
+    <DomainPackShellState crumbs={crumbs}>
       <div className={styles.detailPage}>
         <VersionSafetyBanner wsId={wsId!} packId={pId!} versionId={vId} />
         <div className={styles.detailHeader}>
           <div className={styles.titleGroup}>
             <div className={styles.titleStack}>
-              <h2 data-testid="workflow-detail-title" className={styles.detailTitle}>
-                {workflow?.name || (query.isLoading ? "워크플로우 로드 중..." : "워크플로우")}
+              <h2
+                data-testid="workflow-detail-title"
+                className={styles.detailTitle}
+              >
+                {workflow?.name ||
+                  (query.isLoading ? "워크플로우 로드 중..." : "워크플로우")}
               </h2>
               {workflow?.description && (
-                <p className={styles.detailDescription}>{workflow.description}</p>
+                <p className={styles.detailDescription}>
+                  {workflow.description}
+                </p>
               )}
             </div>
             {workflow && lifecycleStatus && lifecycleStatus !== "PUBLISHED" && (
-              <Pill tone="signal">{formatLifecycleStatus(lifecycleStatus)}</Pill>
+              <Pill tone="signal">
+                {formatLifecycleStatus(lifecycleStatus)}
+              </Pill>
             )}
             {workflow && isEditing && <Pill tone="ink">수정 중</Pill>}
-            {workflow && <Mono className={styles.nodeCount}>노드 {nodeCount}개</Mono>}
+            {workflow && (
+              <Mono className={styles.nodeCount}>노드 {nodeCount}개</Mono>
+            )}
           </div>
 
           <div className={styles.headerActions}>
@@ -614,9 +720,15 @@ export function WorkflowDraftReadPage() {
           </div>
         </div>
 
-        <div className={styles.canvasFrame} data-editing={isEditing ? "true" : "false"}>
+        <div
+          className={styles.canvasFrame}
+          data-editing={isEditing ? "true" : "false"}
+        >
           {!enabled && (
-            <div data-testid="workflow-select-empty" className={styles.centerState}>
+            <div
+              data-testid="workflow-select-empty"
+              className={styles.centerState}
+            >
               좌측 사이드바에서 워크플로우를 선택하세요.
             </div>
           )}
@@ -637,7 +749,11 @@ export function WorkflowDraftReadPage() {
             </div>
           )}
 
-          {enabled && !query.isLoading && !query.isError && workflow && graphContent}
+          {enabled &&
+            !query.isLoading &&
+            !query.isError &&
+            workflow &&
+            graphContent}
         </div>
         {enabled && !isEditing && (
           <WorkflowBottleneckAnalysisPanel
@@ -655,7 +771,9 @@ export function WorkflowDraftReadPage() {
         }}
       >
         <AlertDialogContent size="sm" className={styles.discardDialog}>
-          <AlertDialogTitle className={styles.discardTitle}>변경 내역을 버릴까요?</AlertDialogTitle>
+          <AlertDialogTitle className={styles.discardTitle}>
+            변경 내역을 버릴까요?
+          </AlertDialogTitle>
           <AlertDialogDescription className={styles.discardDescription}>
             저장하지 않고 이동하면 현재 편집 중인 변경 내역이 버려집니다.
           </AlertDialogDescription>
@@ -668,7 +786,11 @@ export function WorkflowDraftReadPage() {
             >
               계속 편집
             </Button>
-            <Button type="button" className={styles.discardButton} onClick={confirmPendingClose}>
+            <Button
+              type="button"
+              className={styles.discardButton}
+              onClick={confirmPendingClose}
+            >
               변경 내역 버리기
             </Button>
           </AlertDialogFooter>
@@ -683,11 +805,15 @@ export function WorkflowDraftReadPage() {
         <AlertDialogContent size="sm">
           <AlertDialogTitle>진행 중인 검토본이 있습니다</AlertDialogTitle>
           <AlertDialogDescription>
-            새 검토본을 만들 수 없습니다. 기존 검토본에서 계속 편집하거나, 도메인팩 화면에서
-            검토본을 적용 또는 폐기한 뒤 다시 시도하세요.
+            새 검토본을 만들 수 없습니다. 기존 검토본에서 계속 편집하거나,
+            도메인팩 화면에서 검토본을 적용 또는 폐기한 뒤 다시 시도하세요.
           </AlertDialogDescription>
           <AlertDialogFooter>
-            <Button type="button" variant="outline" onClick={() => setExistingDraftTarget(null)}>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setExistingDraftTarget(null)}
+            >
               취소
             </Button>
             <Button type="button" onClick={confirmExistingDraftNavigation}>
@@ -696,7 +822,7 @@ export function WorkflowDraftReadPage() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-    </OstoneShell>
+    </DomainPackShellState>
   );
 }
 
@@ -706,7 +832,10 @@ function readWorkflowReturnTo(state: unknown): string | null {
   return typeof value === "string" && value.startsWith("/") ? value : null;
 }
 
-function resolveWorkflowActionErrorMessage(error: unknown, fallback: string): string {
+function resolveWorkflowActionErrorMessage(
+  error: unknown,
+  fallback: string,
+): string {
   if (error instanceof ApiRequestError && error.message) {
     return error.message;
   }

--- a/frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.test.tsx
@@ -1,6 +1,13 @@
+import { useState } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
-import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import {
+  MemoryRouter,
+  Outlet,
+  Route,
+  Routes,
+  useLocation,
+} from "react-router-dom";
 import type { WorkflowDefinitionDetail } from "@/shared/api/generated/zod";
 import { WorkflowGraphViewerPage } from "./WorkflowGraphViewerPage";
 
@@ -12,37 +19,41 @@ vi.mock("@/features/domain-pack-summary-read", () => ({
 }));
 
 vi.mock("@/entities/workflow", () => ({
-  useGetWorkflowDefinition: (...args: unknown[]) => mockUseGetWorkflowDefinition(...args),
+  useGetWorkflowDefinition: (...args: unknown[]) =>
+    mockUseGetWorkflowDefinition(...args),
 }));
 
 vi.mock("@/features/workflow-viewer/ui/GraphViewer", () => ({
   GraphViewer: () => <div data-testid="graph-viewer">Graph</div>,
 }));
 
-vi.mock("@/widgets/ostone-shell", () => ({
-  OstoneShell: ({
-    active,
-    children,
-  }: {
-    active: string;
-    crumbs: unknown[];
-    children: React.ReactNode;
-  }) => (
-    <div>
-      <div data-testid="shell-active">{active}</div>
-      {children}
-    </div>
-  ),
-}));
-
-const ROUTE = "/workspaces/:workspaceId/domain-packs/:packId/workflows/:workflowId/graph";
-
 function LocationProbe() {
   const location = useLocation();
-  return <div data-testid="location">{`${location.pathname}${location.search}`}</div>;
+  return (
+    <div data-testid="location">{`${location.pathname}${location.search}`}</div>
+  );
 }
 
-function renderPage(path = "/workspaces/1/domain-packs/2/workflows/4/graph?versionId=3") {
+function ShellHost() {
+  const [crumbs, setCrumbs] = useState<Array<string | { label: string }>>([]);
+  const [topbarRight, setTopbarRight] = useState<React.ReactNode>();
+
+  return (
+    <>
+      <div data-testid="shell-crumbs">
+        {crumbs
+          .map((crumb) => (typeof crumb === "string" ? crumb : crumb.label))
+          .join(" / ")}
+      </div>
+      <div data-testid="shell-topbar">{topbarRight}</div>
+      <Outlet context={{ setCrumbs, setTopbarRight, workspace: null }} />
+    </>
+  );
+}
+
+function renderPage(
+  path = "/workspaces/1/domain-packs/2/workflows/4/graph?versionId=3",
+) {
   render(
     <MemoryRouter
       initialEntries={[
@@ -54,14 +65,19 @@ function renderPage(path = "/workspaces/1/domain-packs/2/workflows/4/graph?versi
     >
       <Routes>
         <Route
-          path={ROUTE}
-          element={
-            <>
-              <WorkflowGraphViewerPage />
-              <LocationProbe />
-            </>
-          }
-        />
+          path="/workspaces/:workspaceId/domain-packs/:packId"
+          element={<ShellHost />}
+        >
+          <Route
+            path="workflows/:workflowId/graph"
+            element={
+              <>
+                <WorkflowGraphViewerPage />
+                <LocationProbe />
+              </>
+            }
+          />
+        </Route>
         <Route path="*" element={<LocationProbe />} />
       </Routes>
     </MemoryRouter>,
@@ -89,7 +105,7 @@ describe("WorkflowGraphViewerPage", () => {
 
     renderPage();
     expect(screen.getByTestId("loading-state")).toBeInTheDocument();
-    expect(screen.getByTestId("shell-active")).toHaveTextContent("workflows");
+    expect(screen.getByTestId("shell-crumbs")).toHaveTextContent("워크플로우");
   });
 
   it("shows error state when error is present", () => {
@@ -162,7 +178,9 @@ describe("WorkflowGraphViewerPage", () => {
     });
 
     renderPage("/workspaces/1/domain-packs/2/workflows/4/graph");
-    expect(screen.getByTestId("url-error-state")).toHaveTextContent("잘못된 URL 파라미터입니다.");
+    expect(screen.getByTestId("url-error-state")).toHaveTextContent(
+      "잘못된 URL 파라미터입니다.",
+    );
   });
 
   it("shows graph data error state when graphJson is malformed", () => {

--- a/frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.tsx
@@ -5,7 +5,10 @@ import { useGetWorkflowDefinition } from "@/entities/workflow";
 import type { WorkflowGraph } from "@/entities/workflow";
 import { usePackDetail } from "@/features/domain-pack-summary-read";
 import { GraphViewer } from "@/features/workflow-viewer/ui/GraphViewer";
-import { buildDomainPackCrumbs, domainPackSectionPath } from "@/shared/lib/domainPackRoutes";
+import {
+  buildDomainPackCrumbs,
+  domainPackSectionPath,
+} from "@/shared/lib/domainPackRoutes";
 import { parseRouteId } from "@/shared/lib/parseRouteId";
 import type { Crumb } from "@/shared/ui/ostone/chrome";
 import { Button } from "@/shared/ui/button";
@@ -13,15 +16,26 @@ import { EmptyState } from "@/shared/ui/ostone/atoms/EmptyState";
 import { ErrorState } from "@/shared/ui/ostone/atoms/ErrorState";
 import { Icon } from "@/shared/ui/ostone/atoms";
 import { LoadingSpinner } from "@/shared/ui/ostone/atoms/LoadingSpinner";
-import { OstoneShell } from "@/widgets/ostone-shell";
+import { DomainPackShellState } from "./DomainPackShellState";
 import styles from "./WorkflowGraphViewerPage.module.css";
 
 function isWorkflowGraph(value: unknown): value is WorkflowGraph {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
-  const graph = value as { nodes?: unknown; edges?: unknown; direction?: unknown };
+  if (typeof value !== "object" || value === null || Array.isArray(value))
+    return false;
+  const graph = value as {
+    nodes?: unknown;
+    edges?: unknown;
+    direction?: unknown;
+  };
   const hasValidDirection =
-    graph.direction === undefined || graph.direction === "LR" || graph.direction === "TB";
-  return Array.isArray(graph.nodes) && Array.isArray(graph.edges) && hasValidDirection;
+    graph.direction === undefined ||
+    graph.direction === "LR" ||
+    graph.direction === "TB";
+  return (
+    Array.isArray(graph.nodes) &&
+    Array.isArray(graph.edges) &&
+    hasValidDirection
+  );
 }
 
 type GraphParseResult =
@@ -37,13 +51,17 @@ function parseWorkflowGraph(rawGraph: unknown): GraphParseResult {
   if (typeof rawGraph === "string") {
     try {
       const parsed: unknown = JSON.parse(rawGraph);
-      return isWorkflowGraph(parsed) ? { status: "ready", graph: parsed } : { status: "invalid" };
+      return isWorkflowGraph(parsed)
+        ? { status: "ready", graph: parsed }
+        : { status: "invalid" };
     } catch {
       return { status: "invalid" };
     }
   }
 
-  return isWorkflowGraph(rawGraph) ? { status: "ready", graph: rawGraph } : { status: "invalid" };
+  return isWorkflowGraph(rawGraph)
+    ? { status: "ready", graph: rawGraph }
+    : { status: "invalid" };
 }
 
 export function WorkflowGraphViewerPage() {
@@ -56,7 +74,8 @@ export function WorkflowGraphViewerPage() {
   const vsId = parseRouteId(search.get("versionId") ?? undefined);
   const wfId = parseRouteId(workflowId);
 
-  const enabled = wsId !== null && pkId !== null && vsId !== null && wfId !== null;
+  const enabled =
+    wsId !== null && pkId !== null && vsId !== null && wfId !== null;
 
   const { data, isLoading, error } = useGetWorkflowDefinition({
     workspaceId: wsId ?? 0,
@@ -70,9 +89,15 @@ export function WorkflowGraphViewerPage() {
     enabled: enabled,
   }).data;
   const packName = packDetail?.name ?? `PACK · ${pkId ?? "?"}`;
-  const versionNo = packDetail?.versions?.find((v) => v.versionId === vsId)?.versionNo ?? vsId ?? 0;
+  const versionNo =
+    packDetail?.versions?.find((v) => v.versionId === vsId)?.versionNo ??
+    vsId ??
+    0;
 
-  const graphResult = useMemo(() => parseWorkflowGraph(data?.graphJson), [data?.graphJson]);
+  const graphResult = useMemo(
+    () => parseWorkflowGraph(data?.graphJson),
+    [data?.graphJson],
+  );
 
   useEffect(() => {
     if (error) {
@@ -80,18 +105,22 @@ export function WorkflowGraphViewerPage() {
     }
   }, [error]);
 
-  const crumbs: Crumb[] =
-    wsId !== null && pkId !== null && vsId !== null
-      ? buildDomainPackCrumbs({
-          wsId,
-          pId: pkId,
-          vId: vsId,
-          packName,
-          versionNo,
-          section: { label: "워크플로우", path: "workflows" },
-          selectedLabel: data?.workflowCode ?? (wfId !== null ? `#${wfId} 흐름도` : "흐름도"),
-        })
-      : ["도메인팩 관리", "워크플로우 그래프"];
+  const crumbs = useMemo<Crumb[]>(() => {
+    if (wsId === null || pkId === null || vsId === null) {
+      return ["도메인팩 관리", "워크플로우 그래프"];
+    }
+
+    return buildDomainPackCrumbs({
+      wsId,
+      pId: pkId,
+      vId: vsId,
+      packName,
+      versionNo,
+      section: { label: "워크플로우", path: "workflows" },
+      selectedLabel:
+        data?.workflowCode ?? (wfId !== null ? `#${wfId} 흐름도` : "흐름도"),
+    });
+  }, [data?.workflowCode, packName, pkId, versionNo, vsId, wfId, wsId]);
 
   const listPath =
     wsId !== null && pkId !== null
@@ -103,15 +132,19 @@ export function WorkflowGraphViewerPage() {
       : null;
 
   const pageTitle =
-    data?.name ?? data?.workflowCode ?? (wfId !== null ? `워크플로우 #${wfId}` : "워크플로우 그래프");
+    data?.name ??
+    data?.workflowCode ??
+    (wfId !== null ? `워크플로우 #${wfId}` : "워크플로우 그래프");
 
   const shell = (children: ReactNode) => (
-    <OstoneShell active="workflows" crumbs={crumbs}>
+    <DomainPackShellState crumbs={crumbs}>
       <div className={styles.page}>
         <div className={styles.header}>
           <div className={styles.titleStack}>
             <h2 className={styles.title}>{pageTitle}</h2>
-            {data?.description && <p className={styles.description}>{data.description}</p>}
+            {data?.description && (
+              <p className={styles.description}>{data.description}</p>
+            )}
           </div>
           <div className={styles.actions}>
             <Button
@@ -137,12 +170,16 @@ export function WorkflowGraphViewerPage() {
         </div>
         <div className={styles.canvasFrame}>{children}</div>
       </div>
-    </OstoneShell>
+    </DomainPackShellState>
   );
 
   if (!enabled) {
     return shell(
-      <div role="alert" data-testid="url-error-state" className={styles.centerState}>
+      <div
+        role="alert"
+        data-testid="url-error-state"
+        className={styles.centerState}
+      >
         <ErrorState message="잘못된 URL 파라미터입니다." />
       </div>,
     );
@@ -152,7 +189,9 @@ export function WorkflowGraphViewerPage() {
     return shell(
       <div data-testid="loading-state" className={styles.loadingState}>
         <LoadingSpinner />
-        <span className={styles.loadingText}>워크플로우 데이터를 불러오는 중...</span>
+        <span className={styles.loadingText}>
+          워크플로우 데이터를 불러오는 중...
+        </span>
       </div>,
     );
   }
@@ -162,7 +201,9 @@ export function WorkflowGraphViewerPage() {
       <div data-testid="error-state" className={styles.centerState}>
         <ErrorState
           message={
-            error instanceof Error ? error.message : "데이터를 불러오는 중 오류가 발생했습니다."
+            error instanceof Error
+              ? error.message
+              : "데이터를 불러오는 중 오류가 발생했습니다."
           }
         />
       </div>,

--- a/frontend/src/pages/workspace/ui/WorkspaceLayout.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceLayout.tsx
@@ -1,8 +1,15 @@
 import { useMemo, useState, type ReactNode } from "react";
 import { Navigate, Outlet, useLocation, useParams } from "react-router-dom";
-import type { ShellContext, SidebarActive } from "@/shared/ui/ostone/chrome";
+import type {
+  Crumb,
+  ShellContext,
+  SidebarActive,
+} from "@/shared/ui/ostone/chrome";
 
-import { mapWorkspaceActionError, type WorkspaceResponse } from "@/entities/workspace";
+import {
+  mapWorkspaceActionError,
+  type WorkspaceResponse,
+} from "@/entities/workspace";
 import { useGetWorkspace } from "@/shared/api/generated/endpoints/workspace-controller/workspace-controller";
 import { ErrorState } from "@/shared/ui/ostone/atoms/ErrorState";
 import { LoadingSpinner } from "@/shared/ui/ostone/atoms/LoadingSpinner";
@@ -27,9 +34,11 @@ export function WorkspaceLayout() {
   const { workspaceId } = useParams();
   const location = useLocation();
   const parsedWorkspaceId = parseRouteId(workspaceId);
-  const basePath = parsedWorkspaceId ? `/workspaces/${parsedWorkspaceId}` : "/workspaces";
+  const basePath = parsedWorkspaceId
+    ? `/workspaces/${parsedWorkspaceId}`
+    : "/workspaces";
   const [topbarRight, setTopbarRight] = useState<ReactNode>(null);
-  const [crumbs, setCrumbs] = useState<string[]>([]);
+  const [crumbs, setCrumbs] = useState<Crumb[]>([]);
   const active = getActiveFromPath(location.pathname);
 
   const {
@@ -40,11 +49,19 @@ export function WorkspaceLayout() {
   } = useGetWorkspace(parsedWorkspaceId ?? 0, {
     query: { enabled: parsedWorkspaceId !== null },
   });
-  const workspace = fetchedWorkspace ? (fetchedWorkspace as unknown as WorkspaceResponse) : null;
-  const error = parsedWorkspaceId !== null && fetchError ? mapWorkspaceActionError(fetchError) : "";
+  const workspace = fetchedWorkspace
+    ? (fetchedWorkspace as unknown as WorkspaceResponse)
+    : null;
+  const error =
+    parsedWorkspaceId !== null && fetchError
+      ? mapWorkspaceActionError(fetchError)
+      : "";
   const isLoading = parsedWorkspaceId !== null && isFetchingWorkspace;
 
-  const defaultCrumbs = useMemo(() => (workspace?.name ? [workspace.name] : []), [workspace]);
+  const defaultCrumbs = useMemo(
+    () => (workspace?.name ? [workspace.name] : []),
+    [workspace],
+  );
 
   if (parsedWorkspaceId === null) {
     return <Navigate to="/workspaces" replace />;

--- a/frontend/src/shared/ui/ostone/chrome/ShellContext.ts
+++ b/frontend/src/shared/ui/ostone/chrome/ShellContext.ts
@@ -1,8 +1,9 @@
 import type { ReactNode } from "react";
 import type { WorkspaceResponse } from "@/shared/api/generated/zod";
+import type { Crumb } from "./Topbar";
 
 export interface ShellContext {
   setTopbarRight: (node: ReactNode | undefined) => void;
-  setCrumbs: (crumbs: string[]) => void;
+  setCrumbs: (crumbs: Crumb[]) => void;
   workspace: WorkspaceResponse | null;
 }


### PR DESCRIPTION
Closes #783

## 변경 사항

- 이슈 783 요구사항과 acceptance criteria를 `.agent/specs/783.md`에 정리했습니다.
- `/workspaces/:workspaceId/domain-packs/:packId` 상세 route와 하위 상세 route를 `WorkspaceLayout` 하위로 이동해 기존 URL을 유지하면서 workspace shell을 공유하도록 했습니다.
- `DomainPackRouteOutlet`이 workspace `ShellContext`를 상세 하위 route에 전달하고, 도메인팩 상세 페이지들은 `DomainPackShellState`로 breadcrumb/topbar state를 등록하도록 했습니다.
- `ShellContext`의 breadcrumb 타입을 `Crumb[]`로 확장해 기존 link-aware domain pack breadcrumb를 workspace topbar에서 유지합니다.
- app routing regression과 상세 페이지 단위 테스트를 shell context host 기준으로 보강했습니다.

## 검증

- `pnpm --dir frontend exec vp test run src/app/App.test.tsx src/pages/domain-pack/ui/DomainPackRouteOutlet.test.tsx src/pages/domain-pack/ui/DomainPackSummaryPage.test.tsx src/pages/domain-pack/ui/IntentDraftReadPage.test.tsx src/pages/domain-pack/ui/PolicyDraftReadPage.test.tsx src/pages/domain-pack/ui/RiskDraftReadPage.test.tsx src/pages/domain-pack/ui/SlotDraftReadPage.test.tsx src/pages/domain-pack/ui/PackWorkflowListPage.test.tsx src/pages/domain-pack/ui/WorkflowDraftReadPage.test.tsx src/pages/domain-pack/ui/WorkflowGraphViewerPage.test.tsx` (10 files, 115 tests)
- `pnpm run build:frontend` (Vite chunk-size warning만 표시)
- `pnpm --dir frontend audit:fsd && pnpm --dir frontend audit:api`
- `pnpm --dir frontend exec eslint src/app/App.tsx src/app/App.test.tsx src/shared/ui/ostone/chrome/ShellContext.ts src/pages/workspace/ui/WorkspaceLayout.tsx src/pages/domain-pack/ui/DomainPackRouteOutlet.tsx src/pages/domain-pack/ui/DomainPackRouteOutlet.test.tsx src/pages/domain-pack/ui/DomainPackShellState.tsx src/pages/domain-pack/ui/DomainPackSummaryPage.tsx src/pages/domain-pack/ui/DomainPackSummaryPage.test.tsx src/pages/domain-pack/ui/IntentDraftReadPage.tsx src/pages/domain-pack/ui/IntentDraftReadPage.test.tsx src/pages/domain-pack/ui/PolicyDraftReadPage.tsx src/pages/domain-pack/ui/PolicyDraftReadPage.test.tsx src/pages/domain-pack/ui/RiskDraftReadPage.tsx src/pages/domain-pack/ui/RiskDraftReadPage.test.tsx src/pages/domain-pack/ui/SlotDraftReadPage.tsx src/pages/domain-pack/ui/SlotDraftReadPage.test.tsx src/pages/domain-pack/ui/PackWorkflowListPage.tsx src/pages/domain-pack/ui/PackWorkflowListPage.test.tsx src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx src/pages/domain-pack/ui/WorkflowDraftReadPage.test.tsx src/pages/domain-pack/ui/WorkflowGraphViewerPage.tsx src/pages/domain-pack/ui/WorkflowGraphViewerPage.test.tsx`
- `git diff --check`
- `git diff --cached --check`

## 참고

- 구현 전 issue 783, `App.tsx`, `WorkspaceLayout`, `DomainPackRouteOutlet`, 도메인팩 상세 페이지들, 기존 route/page tests, `frontend/DESIGN.md`, frontend FSD/test/code-review rules를 확인했습니다.
- spec review 2회 수행: issue fidelity 관점에서 route nesting, direct shell 제거, sidebar/topbar/breadcrumb 공유, URL 유지, routing test 요구사항을 매핑했고, repository compliance 관점에서 파일명/브랜치/affected paths를 최종 diff에 맞췄습니다.
- self-review 3회 수행: Round 1에서 route ownership과 detail URL 보존을 확인했고, Round 2에서 outlet context forwarding, FSD import 방향, `Crumb[]` topbar contract를 확인했으며, Round 3에서 stale spec path, untracked file 포함, touched-file ESLint, focused tests/build evidence를 확인했습니다.
- `pnpm run lint:frontend`와 pre-commit hook은 API/FSD audit 통과 후 이번 변경과 무관한 기존 frontend ESLint baseline 45건으로 실패합니다. 변경 파일 대상 ESLint, focused tests, build, diff checks는 통과했습니다.
- hook 실패는 repository-wide lint baseline 때문이라 변경 파일 대상 검증을 근거로 hook을 우회해 커밋했습니다.