### PR TITLE
chore(ml): pre-commit ml 검사를 디렉터리 전체 명령으로 고정

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -7,9 +7,11 @@ export default {
     if (filtered.length === 0) return [];
     return ["pnpm run lint:frontend", "pnpm run format:frontend"];
   },
-  "ml/**/*.py": [
+  // ml 검사는 디렉터리 전체 명령이므로 함수형으로 staged 파일 인자 전달을 막는다.
+  // 배열형이면 `mypy . <파일>`이 되어 항상 duplicate module 오류로 실패한다.
+  "ml/**/*.py": () => [
     "pnpm run lint:ml",
-    "pnpm run format:ml",
+    "pnpm run format:ml:check",
     "pnpm run typecheck:ml",
   ],
 };


### PR DESCRIPTION
## 변경 사항

- lint-staged의 `ml/**/*.py` 항목을 frontend와 같은 함수형으로 바꿔 staged 파일 경로가 명령 인자로 덧붙지 않게 했습니다.
- 배열형에서는 `pnpm run typecheck:ml <절대경로...>`가 `mypy . <파일>`로 실행되어 항상 `Duplicate module named ...` 오류로 실패했고, ml 파일을 포함한 모든 커밋이 pre-commit에서 차단되었습니다(#793 본문에도 hook 우회 기록이 있습니다).
- hook에서 `format:ml`(전체 재작성) 대신 `format:ml:check`(검사)를 사용해 커밋 중 작업 트리를 수정하지 않게 했습니다. backend hook(`format:backend:check`)과 같은 패턴입니다.

## 검증

- 수정된 설정으로 ml 파일 4개가 staged된 상태에서 `pnpm exec lint-staged` 실행 → lint:ml / format:ml:check / typecheck:ml 전부 통과
- 기존 배열형 설정에서는 같은 staged 세트가 typecheck:ml의 duplicate module 오류로 실패함을 재현했습니다.
- 기준선은 #795에서 green으로 복구되어 디렉터리 전체 검사가 통과합니다.