### PR TITLE
feat(ml): 피드백 질문 후보를 다양성과 품질 기준으로 선별

### DIFF
--- a/.agent/specs/773.md
+++ b/.agent/specs/773.md
@@ -1,0 +1,93 @@
+# ML Feedback Question Selection Diversity
+
+## Goal
+
+human feedback checkpoint 질문 후보를 단순 nested loop 순서가 아니라 다양성·품질 가드를 적용한 점수 기반 선별로 뽑아, 하나의 source cluster나 약한 후보가 질문 슬롯을 독식하지 않게 한다.
+
+## Problem
+
+job 42에서 기본 12개 질문이 모두 `same_source_cluster_split` / `cannot_link` 권고였고, 첫 번째 큰 source cluster의 entrypoint 조합이 질문 한도를 모두 소진했다. `90388#issue-02`, `90162#issue-01` 같은 caselet이 반복 노출되었고, `must_link` 후보는 한 건도 생성되지 않았다. flow split 지표는 `reviewRequiredWorkflowCount=56/59`, `highConfidenceWorkflowCount=0`으로, 후보 풀 대부분이 review 대상이라 선별 없이 순서대로 채우면 품질이 낮은 질문이 상위로 올라온다.
+
+현재 `feedback_candidate_generation`은:
+
+- `_cannot_link_questions`가 source cluster 순회 중 첫 번째 큰 cluster에서 pair를 만들다 한도에 도달하면 멈춘다.
+- caselet 반복 노출 제한이 없다.
+- `cannot_link`가 한도를 다 쓰면 `_must_link_questions`는 호출되지 못한다.
+- `mixed_residual`/약한 label 후보를 거르는 가드가 없다.
+- 선별 근거 metric을 남기지 않는다 (PR #793의 `qualityKpis`는 결과 계측만 한다).
+
+## Affected Paths
+
+| Area | Path | Purpose |
+| --- | --- | --- |
+| ML | `ml/src/pipeline/stages/feedback_candidate_generation/main.py` | 질문 artifact 생성, 선별 로직 호출 |
+| ML (신규) | `ml/src/pipeline/stages/feedback_candidate_generation/selection.py` | 후보 수집·점수화·예산/상한 기반 선별 |
+| ML test | `ml/tests/stages/test_feedback_candidate_generation_main.py` | 기존 schema/문구 검증 유지 |
+| ML test (신규) | `ml/tests/stages/test_feedback_candidate_selection.py` | job 42 증상 축소 fixture 회귀 테스트 |
+
+선별 입력은 flow_splitting 산출물(`clusters.json`, `workflow_entrypoints.json`)의 기존 필드만 사용한다. `ml/src/pipeline/stages/flow_splitting/main.py`의 `_entrypoint`와 `confidence.py`의 `_apply_workflow_review_metadata`가 채우는 `confidence`, `confidenceComponents`, `splitReason`, `memberCount`, `coverageShare`, cluster의 `label_score`, `label_evidence_coverage`, `flow_split_key`를 활용한다.
+
+## Scope
+
+### 후보 수집
+
+- cannot_link(WORKFLOW_BOUNDARY) 후보: 기존처럼 같은 source cluster에서 갈라진 entrypoint pair. 단, pair 폭발 방지를 위해 source당 후보 pair 생성 수를 상한(질문 한도 기반)으로 제한하고, 인접 confidence 조합부터 대각선 순서로 생성해 한 entrypoint가 후보 풀을 독식하지 않게 한다.
+- must_link(INTENT_BOUNDARY) 후보: 기존처럼 낮은 workflow confidence cluster의 대표 caselet pair.
+
+### 품질 가드 (weak 후보 분류)
+
+다음 중 하나라도 해당하면 weak 후보로 분류한다:
+
+- splitReason/flow_split_key가 mixed 계열 (`mixed_flow`, `mixed_residual`, `…|mixed_residual` compound 포함 — flow_splitting `_is_mixed_residual_reason`과 동일 판정)
+- label 신뢰도 < 0.40 (flow_splitting `WORKFLOW_LABEL_BLOCKING_CONFIDENCE_THRESHOLD`와 동일 기준; entrypoint는 `confidenceComponents.label`, cluster는 `label_score`)
+- label evidence coverage ≤ 0 (`label_evidence_coverage`)
+
+weak 후보는 strong 후보가 예산을 채우지 못할 때만 fallback으로 선택하고, `priority`를 `LOW`로 강등하며 출력 순서도 strong 후보 뒤에 둔다.
+
+### 점수화
+
+- impact: 후보가 커버하는 멤버 규모 (pair: 양쪽 entrypoint `memberCount` 합 정규화, cluster: `cluster_size` 정규화)
+- uncertainty: workflow confidence가 human review 임계(0.60) 부근일수록 높은 점수
+- score = uncertainty와 impact의 가중 합. 동률은 entrypoint/cluster id 순으로 결정적 정렬.
+- diversity는 정적 점수가 아니라 선별 단계의 상한(아래)으로 반영한다.
+
+### 예산과 다양성 상한
+
+- 질문 한도: 기존 `MAX_QUESTIONS = 12`, `PIPELINE_FEEDBACK_QUESTION_LIMIT` 유지.
+- must_link 예약 예산: must_link 후보가 존재할 때 `limit // 3` (기본 12 → 4). cannot_link 예산은 나머지. 한쪽 후보가 부족하면 남은 예산은 다른 쪽으로 이월한다.
+- source cluster별 선택 상한: `max(1, ceil(limit / 4))` (기본 12 → 3).
+- caselet 노출 상한: 동일 caselet은 최대 2개 질문까지만 등장.
+
+### Selection metric artifact
+
+- 신규 artifact `feedback_selection_metrics.json`을 stage 출력 디렉터리에 기록한다.
+- 내용: 한도/예산/상한 값, 타입별 후보 수(considered/strong/weak), 타입별 선택 수, 제외·강등 사유별 수, source cluster별 선택 분포, caselet 최대 노출 수.
+- manifest payload의 `reportPath`로 참조한다 (`ml/src/pipeline/common/artifacts.py` `_output_refs`가 이미 지원하는 key). manifest `metrics`에 선별 요약을 추가한다.
+
+## Non-goals
+
+- `feedback_review_questions.json`의 질문 필드 계약을 깨지 않는다. 변경은 additive(`priority`에 `LOW` 값 추가 수준)로 제한한다. backend는 payload를 raw `JsonNode`로 보존하고 frontend `pipelineReviewApi.ts`는 `priority: string`이라 호환된다.
+- PR #793이 추가한 `qualityKpis` 계측 동작을 변경하지 않는다. 선별된 최종 질문 집합에 대해 그대로 계산한다.
+- flow_splitting의 confidence/review 산정 로직을 변경하지 않는다.
+- backend/frontend 코드는 변경하지 않는다.
+- 질문 한도 외 신규 환경 변수를 추가하지 않는다. 상한·예산은 한도에서 유도한다.
+
+## Acceptance Criteria
+
+- 기본 12개 질문에서 하나의 source cluster가 전체 슬롯을 독식하지 않는다 (source당 최대 3개).
+- 동일 caselet이 3개 이상의 질문에 노출되지 않는다.
+- 사용 가능한 must_link 후보가 있으면 cannot_link 후보에 완전히 밀려나지 않고 예약 예산만큼 포함된다.
+- mixed_residual·label 신뢰도 0.40 미만·evidence coverage 0 후보는 strong 후보보다 상위 질문으로 올라오지 않으며, 선택되면 `priority`가 `LOW`다.
+- strong 후보만으로 한도를 채울 수 없으면 weak 후보로 잔여 슬롯을 채운다. 단 다양성 상한은 유지하므로 적격 후보가 부족하면 질문 수가 한도보다 적을 수 있다.
+- `feedback_selection_metrics.json`이 생성되고 manifest에서 참조된다.
+- job 42 증상(단일 source cluster 독식, caselet 반복, must_link 0건, weak 후보 다수)을 축소 재현한 fixture 회귀 테스트가 추가된다. 원본 job 42 artifact는 저장소에 없으므로 이슈에 보고된 분포를 합성한 fixture를 사용한다.
+- 기존 질문 schema 테스트(`test_feedback_candidate_generation_main.py`)가 계속 통과한다.
+
+## Validation Plan
+
+- `cd ml && uv run pytest tests/stages/test_feedback_candidate_selection.py tests/stages/test_feedback_candidate_generation_main.py`
+- `cd ml && uv run ruff check . && uv run ruff format --check . && uv run mypy .`
+
+## Open Questions
+
+- label 신뢰도 임계 0.40과 caselet 노출 상한 2회는 job 42 증상 기준의 초기값이다. 운영 데이터가 쌓이면 selection metric artifact를 근거로 조정한다.

--- a/ml/src/pipeline/stages/feedback_candidate_generation/main.py
+++ b/ml/src/pipeline/stages/feedback_candidate_generation/main.py
@@ -15,6 +15,15 @@ from pipeline.stages.feedback_candidate_generation.review_question_enrichment im
 from pipeline.stages.flow_splitting.constants import CLUSTERS_ARTIFACT, WORKFLOW_ENTRYPOINTS_ARTIFACT
 from pipeline.stages.preprocessing.io import read_stage_context
 
+from .selection import (
+    CANNOT_LINK_KIND,
+    SELECTION_METRICS_ARTIFACT,
+    QuestionCandidate,
+    SelectionResult,
+    collect_candidates,
+    select_candidates,
+)
+
 ARTIFACT_NAME = "feedback_review_questions.json"
 MAX_QUESTIONS = 12
 QUESTION_TYPE_INTENT_BOUNDARY = "INTENT_BOUNDARY"
@@ -66,7 +75,7 @@ def run(upstream_manifest_path: str | None = None) -> dict[str, object]:
     clusters_payload = _read_json(flow_dir / CLUSTERS_ARTIFACT)
     entrypoints_payload = _read_json(flow_dir / WORKFLOW_ENTRYPOINTS_ARTIFACT)
     preprocessed_index = _read_preprocessed_index(runtime_config, stage_context)
-    questions = _build_questions(
+    questions, selection = _build_questions(
         clusters_payload,
         entrypoints_payload,
         preprocessed_index,
@@ -88,12 +97,18 @@ def run(upstream_manifest_path: str | None = None) -> dict[str, object]:
     }
     artifact_path = output_dir / ARTIFACT_NAME
     artifact_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+    selection_metrics_path = output_dir / SELECTION_METRICS_ARTIFACT
+    selection_metrics_path.write_text(
+        json.dumps(selection.metrics, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
     manifest_path = write_stage_manifest(
         stage_context,
         runtime_config,
         {
             "upstream_manifest_path": upstream_manifest_path,
             "feedbackQuestionsPath": artifact_path.name,
+            "reportPath": selection_metrics_path.name,
             "recordCount": len(questions),
             "metrics": {
                 "feedbackQuestionCount": len(questions),
@@ -106,6 +121,7 @@ def run(upstream_manifest_path: str | None = None) -> dict[str, object]:
                     enrichment_summary.get("groundingFailureCount", 0)
                 ),
                 "qualityKpis": quality_kpis,
+                "selection": selection.metrics,
             },
         },
     )
@@ -118,101 +134,57 @@ def _build_questions(
     preprocessed_index: dict[str, dict[str, Any]],
     *,
     limit: int,
-) -> list[dict[str, object]]:
-    questions: list[dict[str, object]] = []
+) -> tuple[list[dict[str, object]], SelectionResult]:
     entrypoints = [item for item in entrypoints_payload.get("workflowEntryPoints", []) if isinstance(item, dict)]
     clusters = [item for item in clusters_payload.get("clusters", []) if isinstance(item, dict)]
-    questions.extend(_cannot_link_questions(entrypoints, preprocessed_index, limit=limit))
-    if len(questions) < limit:
-        questions.extend(_must_link_questions(clusters, preprocessed_index, limit=limit - len(questions)))
-    return questions[:limit]
+    candidates = collect_candidates(entrypoints, clusters, limit=limit)
+    selection = select_candidates(candidates, limit=limit)
+    return _questions_from_selection(selection.selected, preprocessed_index), selection
 
 
-def _cannot_link_questions(
-    entrypoints: list[dict[str, Any]],
+def _questions_from_selection(
+    selected: list[QuestionCandidate],
     preprocessed_index: dict[str, dict[str, Any]],
-    *,
-    limit: int,
 ) -> list[dict[str, object]]:
-    output: list[dict[str, object]] = []
-    for source, items in _entrypoints_by_source(entrypoints).items():
-        if len(items) < 2:
-            continue
-        output.extend(_cannot_link_questions_for_source(source, items, preprocessed_index, limit - len(output)))
-        if len(output) >= limit:
-            return output[:limit]
-    return output
-
-
-def _entrypoints_by_source(entrypoints: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
-    by_source: dict[str, list[dict[str, Any]]] = {}
-    for entrypoint in entrypoints:
-        source = _text_id(entrypoint.get("sourceClusterId"))
-        if source:
-            by_source.setdefault(source, []).append(entrypoint)
-    return by_source
-
-
-def _cannot_link_questions_for_source(
-    source: str,
-    items: list[dict[str, Any]],
-    preprocessed_index: dict[str, dict[str, Any]],
-    limit: int,
-) -> list[dict[str, object]]:
-    output: list[dict[str, object]] = []
-    ordered = sorted(items, key=lambda item: float(item.get("confidence") or 0.0))
-    for index, left in enumerate(ordered):
-        for right in ordered[index + 1 :]:
-            pair = _representative_pair(left, right)
-            if pair is None:
-                continue
-            output.append(
+    questions: list[dict[str, object]] = []
+    cannot_link_sequence: Counter[str] = Counter()
+    must_link_count = 0
+    for candidate in selected:
+        if candidate.kind == CANNOT_LINK_KIND:
+            cannot_link_sequence[candidate.source_cluster_id] += 1
+            questions.append(
                 _question(
-                    question_id=f"workflow-boundary-{source}-{len(output) + 1}",
-                    source_id=pair[0],
-                    target_id=pair[1],
+                    question_id=(
+                        f"workflow-boundary-{candidate.source_cluster_id}"
+                        f"-{cannot_link_sequence[candidate.source_cluster_id]}"
+                    ),
+                    source_id=candidate.source_id,
+                    target_id=candidate.target_id,
                     preprocessed_index=preprocessed_index,
                     question_type=QUESTION_TYPE_WORKFLOW_BOUNDARY,
                     decision_scope=DECISION_SCOPE_WORKFLOW,
                     reason="same_source_cluster_split",
-                    priority="HIGH",
-                    source_cluster_id=source,
+                    priority="LOW" if candidate.is_weak else "HIGH",
+                    source_cluster_id=candidate.source_cluster_id,
                 )
             )
-            if len(output) >= limit:
-                return output
-    return output
-
-
-def _must_link_questions(
-    clusters: list[dict[str, Any]],
-    preprocessed_index: dict[str, dict[str, Any]],
-    *,
-    limit: int,
-) -> list[dict[str, object]]:
-    output: list[dict[str, object]] = []
-    ordered = sorted(clusters, key=lambda item: float(item.get("workflow_confidence") or item.get("confidence") or 0.0))
-    for cluster in ordered:
-        member_ids = _string_list(cluster.get("exemplar_conv_ids")) or _string_list(cluster.get("member_conv_ids"))
-        if len(member_ids) < 2:
             continue
-        source_cluster_id = _text_id(cluster.get("cluster_id")) or _text_id(cluster.get("source_cluster_id"))
-        output.append(
+        must_link_count += 1
+        cluster_key = candidate.cluster_id or candidate.source_cluster_id or str(must_link_count - 1)
+        questions.append(
             _question(
-                question_id=f"must-link-{cluster.get('cluster_id', len(output))}-{len(output) + 1}",
-                source_id=member_ids[0],
-                target_id=member_ids[1],
+                question_id=f"must-link-{cluster_key}-{must_link_count}",
+                source_id=candidate.source_id,
+                target_id=candidate.target_id,
                 preprocessed_index=preprocessed_index,
                 question_type=QUESTION_TYPE_INTENT_BOUNDARY,
                 decision_scope=DECISION_SCOPE_INTENT,
                 reason="low_confidence_cluster_boundary",
-                priority="NORMAL",
-                source_cluster_id=source_cluster_id,
+                priority="LOW" if candidate.is_weak else "NORMAL",
+                source_cluster_id=candidate.source_cluster_id,
             )
         )
-        if len(output) >= limit:
-            break
-    return output
+    return questions
 
 
 def _question(
@@ -416,14 +388,6 @@ def _reason_label(reason: str) -> str:
         "same_source_cluster_split": "같은 클러스터에서 서로 다른 workflow 후보로 갈라졌습니다.",
         "low_confidence_cluster_boundary": "같은 클러스터로 묶였지만 경계 신뢰도가 낮습니다.",
     }.get(reason, "클러스터 경계 판단이 필요합니다.")
-
-
-def _representative_pair(left: dict[str, Any], right: dict[str, Any]) -> tuple[str, str] | None:
-    left_ids = _string_list(left.get("exemplarConversationIds")) or _string_list(left.get("memberConversationIds"))
-    right_ids = _string_list(right.get("exemplarConversationIds")) or _string_list(right.get("memberConversationIds"))
-    if not left_ids or not right_ids:
-        return None
-    return left_ids[0], right_ids[0]
 
 
 def _read_preprocessed_index(

--- a/ml/src/pipeline/stages/feedback_candidate_generation/selection.py
+++ b/ml/src/pipeline/stages/feedback_candidate_generation/selection.py
@@ -1,0 +1,389 @@
+from __future__ import annotations
+
+import math
+from collections import Counter
+from dataclasses import dataclass
+from typing import Any
+
+from pipeline.stages.flow_splitting.constants import (
+    COMPOUND_SPLIT_SEPARATOR,
+    WORKFLOW_HUMAN_REVIEW_CONFIDENCE_THRESHOLD,
+    WORKFLOW_LABEL_BLOCKING_CONFIDENCE_THRESHOLD,
+)
+
+SELECTION_METRICS_ARTIFACT = "feedback_selection_metrics.json"
+CANNOT_LINK_KIND = "cannot_link"
+MUST_LINK_KIND = "must_link"
+CASELET_EXPOSURE_CAP = 2
+MUST_LINK_BUDGET_RATIO = 3
+SOURCE_CLUSTER_CAP_RATIO = 4
+PAIR_POOL_MULTIPLIER = 4
+WEAK_MIXED_SPLIT_REASON = "mixed_split_reason"
+WEAK_LOW_LABEL_CONFIDENCE = "low_label_confidence"
+WEAK_ZERO_LABEL_EVIDENCE_COVERAGE = "zero_label_evidence_coverage"
+_MIXED_SPLIT_REASONS = {"mixed_flow", "mixed_residual"}
+
+
+@dataclass(frozen=True)
+class QuestionCandidate:
+    kind: str
+    source_cluster_id: str
+    cluster_id: str
+    source_id: str
+    target_id: str
+    member_total: int
+    confidence: float
+    score: float
+    weak_reasons: tuple[str, ...]
+
+    @property
+    def is_weak(self) -> bool:
+        return bool(self.weak_reasons)
+
+
+@dataclass
+class SelectionResult:
+    selected: list[QuestionCandidate]
+    metrics: dict[str, Any]
+
+
+def source_cluster_cap(limit: int) -> int:
+    return max(1, math.ceil(limit / SOURCE_CLUSTER_CAP_RATIO))
+
+
+def collect_candidates(
+    entrypoints: list[dict[str, Any]],
+    clusters: list[dict[str, Any]],
+    *,
+    limit: int,
+) -> list[QuestionCandidate]:
+    cluster_by_entrypoint = {
+        entrypoint_id: cluster
+        for cluster in clusters
+        if (entrypoint_id := _text_id(cluster.get("workflow_entrypoint_id")))
+    }
+    raw = _cannot_link_raw(entrypoints, cluster_by_entrypoint, limit=limit)
+    raw.extend(_must_link_raw(clusters))
+    return _finalized(raw)
+
+
+def select_candidates(candidates: list[QuestionCandidate], *, limit: int) -> SelectionResult:
+    source_cap = source_cluster_cap(limit)
+    strong = sorted((candidate for candidate in candidates if not candidate.is_weak), key=_order_key)
+    weak = sorted((candidate for candidate in candidates if candidate.is_weak), key=_order_key)
+    has_must_link = any(candidate.kind == MUST_LINK_KIND for candidate in candidates)
+    must_link_budget = (limit // MUST_LINK_BUDGET_RATIO) if has_must_link else 0
+    budgets = {MUST_LINK_KIND: must_link_budget, CANNOT_LINK_KIND: limit - must_link_budget}
+    selected: list[QuestionCandidate] = []
+    selected_set: set[QuestionCandidate] = set()
+    per_source: Counter[str] = Counter()
+    per_caselet: Counter[str] = Counter()
+    kind_counts: Counter[str] = Counter()
+
+    def cap_block_reason(candidate: QuestionCandidate) -> str | None:
+        if candidate.source_cluster_id and per_source[candidate.source_cluster_id] >= source_cap:
+            return "sourceClusterCap"
+        if per_caselet[candidate.source_id] >= CASELET_EXPOSURE_CAP:
+            return "caseletExposureCap"
+        if per_caselet[candidate.target_id] >= CASELET_EXPOSURE_CAP:
+            return "caseletExposureCap"
+        return None
+
+    # weak 후보는 strong 후보가 예산을 채우지 못한 잔여 슬롯만 가져간다.
+    for pool, enforce_budget in ((strong, True), (strong, False), (weak, True), (weak, False)):
+        for candidate in pool:
+            if len(selected) >= limit:
+                break
+            if candidate in selected_set:
+                continue
+            if enforce_budget and kind_counts[candidate.kind] >= budgets[candidate.kind]:
+                continue
+            if cap_block_reason(candidate) is not None:
+                continue
+            selected.append(candidate)
+            selected_set.add(candidate)
+            per_source[candidate.source_cluster_id] += 1
+            per_caselet[candidate.source_id] += 1
+            per_caselet[candidate.target_id] += 1
+            kind_counts[candidate.kind] += 1
+
+    skipped: Counter[str] = Counter()
+    for candidate in candidates:
+        if candidate in selected_set:
+            continue
+        skipped[cap_block_reason(candidate) or "questionLimitReached"] += 1
+
+    metrics = _selection_metrics(
+        candidates,
+        selected,
+        limit=limit,
+        source_cap=source_cap,
+        budgets=budgets,
+        kind_counts=kind_counts,
+        per_source=per_source,
+        per_caselet=per_caselet,
+        skipped=skipped,
+    )
+    return SelectionResult(selected=selected, metrics=metrics)
+
+
+def _order_key(candidate: QuestionCandidate) -> tuple[float, str, str, str, str]:
+    return (-candidate.score, candidate.kind, candidate.source_cluster_id, candidate.source_id, candidate.target_id)
+
+
+def _cannot_link_raw(
+    entrypoints: list[dict[str, Any]],
+    cluster_by_entrypoint: dict[str, dict[str, Any]],
+    *,
+    limit: int,
+) -> list[dict[str, Any]]:
+    output: list[dict[str, Any]] = []
+    pair_pool_cap = source_cluster_cap(limit) * PAIR_POOL_MULTIPLIER
+    for source, items in _entrypoints_by_source(entrypoints).items():
+        if len(items) < 2:
+            continue
+        ordered = sorted(items, key=lambda item: _float_or_zero(item.get("confidence")))
+        for left, right in _diagonal_pairs(ordered, pair_pool_cap):
+            pair = _representative_pair(left, right)
+            if pair is None:
+                continue
+            output.append(
+                {
+                    "kind": CANNOT_LINK_KIND,
+                    "source_cluster_id": source,
+                    "cluster_id": "",
+                    "source_id": pair[0],
+                    "target_id": pair[1],
+                    "member_total": _entrypoint_member_count(left) + _entrypoint_member_count(right),
+                    "confidence": (_float_or_zero(left.get("confidence")) + _float_or_zero(right.get("confidence")))
+                    / 2,
+                    "weak_reasons": _pair_weak_reasons(left, right, cluster_by_entrypoint),
+                }
+            )
+    return output
+
+
+def _diagonal_pairs(
+    ordered: list[dict[str, Any]],
+    pair_pool_cap: int,
+) -> list[tuple[dict[str, Any], dict[str, Any]]]:
+    # 인접 confidence 조합부터 대각선 순서로 생성해 한 entrypoint가 후보 풀을 독식하지 않게 한다.
+    pairs: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    for offset in range(1, len(ordered)):
+        for index in range(len(ordered) - offset):
+            if len(pairs) >= pair_pool_cap:
+                return pairs
+            pairs.append((ordered[index], ordered[index + offset]))
+    return pairs
+
+
+def _must_link_raw(clusters: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    output: list[dict[str, Any]] = []
+    for cluster in clusters:
+        member_ids = _string_list(cluster.get("exemplar_conv_ids")) or _string_list(cluster.get("member_conv_ids"))
+        if len(member_ids) < 2:
+            continue
+        cluster_id = _text_id(cluster.get("cluster_id"))
+        output.append(
+            {
+                "kind": MUST_LINK_KIND,
+                "source_cluster_id": cluster_id or _text_id(cluster.get("source_cluster_id")),
+                "cluster_id": cluster_id,
+                "source_id": member_ids[0],
+                "target_id": member_ids[1],
+                "member_total": _cluster_member_count(cluster, fallback=len(member_ids)),
+                "confidence": _float_or_zero(cluster.get("workflow_confidence") or cluster.get("confidence")),
+                "weak_reasons": _cluster_weak_reasons(cluster),
+            }
+        )
+    return output
+
+
+def _finalized(raw: list[dict[str, Any]]) -> list[QuestionCandidate]:
+    max_member_total = max((int(item["member_total"]) for item in raw), default=0)
+    candidates: list[QuestionCandidate] = []
+    for item in raw:
+        impact = (int(item["member_total"]) / max_member_total) if max_member_total > 0 else 0.0
+        score = round((0.5 * _uncertainty(float(item["confidence"]))) + (0.5 * impact), 6)
+        candidates.append(
+            QuestionCandidate(
+                kind=str(item["kind"]),
+                source_cluster_id=str(item["source_cluster_id"]),
+                cluster_id=str(item["cluster_id"]),
+                source_id=str(item["source_id"]),
+                target_id=str(item["target_id"]),
+                member_total=int(item["member_total"]),
+                confidence=float(item["confidence"]),
+                score=score,
+                weak_reasons=tuple(item["weak_reasons"]),
+            )
+        )
+    return candidates
+
+
+def _uncertainty(confidence: float) -> float:
+    center = WORKFLOW_HUMAN_REVIEW_CONFIDENCE_THRESHOLD
+    return max(0.0, 1.0 - (abs(confidence - center) / center))
+
+
+def _pair_weak_reasons(
+    left: dict[str, Any],
+    right: dict[str, Any],
+    cluster_by_entrypoint: dict[str, dict[str, Any]],
+) -> tuple[str, ...]:
+    reasons: list[str] = []
+    for entrypoint in (left, right):
+        cluster = cluster_by_entrypoint.get(_text_id(entrypoint.get("entryPointId")), {})
+        reasons.extend(_endpoint_weak_reasons(entrypoint, cluster))
+    return _deduped(reasons)
+
+
+def _endpoint_weak_reasons(entrypoint: dict[str, Any], cluster: dict[str, Any]) -> list[str]:
+    reasons: list[str] = []
+    split_reason = _text_id(entrypoint.get("splitReason")) or _text_id(cluster.get("flow_split_key"))
+    if _is_mixed_split_reason(split_reason):
+        reasons.append(WEAK_MIXED_SPLIT_REASON)
+    label_confidence = _label_confidence(entrypoint, cluster)
+    if label_confidence is not None and label_confidence < WORKFLOW_LABEL_BLOCKING_CONFIDENCE_THRESHOLD:
+        reasons.append(WEAK_LOW_LABEL_CONFIDENCE)
+    evidence_coverage = _float_or_none(cluster.get("label_evidence_coverage"))
+    if evidence_coverage is not None and evidence_coverage <= 0.0:
+        reasons.append(WEAK_ZERO_LABEL_EVIDENCE_COVERAGE)
+    return reasons
+
+
+def _cluster_weak_reasons(cluster: dict[str, Any]) -> tuple[str, ...]:
+    return _deduped(_endpoint_weak_reasons({}, cluster))
+
+
+def _label_confidence(entrypoint: dict[str, Any], cluster: dict[str, Any]) -> float | None:
+    components = entrypoint.get("confidenceComponents")
+    if isinstance(components, dict):
+        value = _float_or_none(components.get("label"))
+        if value is not None:
+            return value
+    return _float_or_none(cluster.get("label_score"))
+
+
+def _is_mixed_split_reason(split_reason: str) -> bool:
+    return split_reason in _MIXED_SPLIT_REASONS or split_reason.endswith(f"{COMPOUND_SPLIT_SEPARATOR}mixed_residual")
+
+
+def _selection_metrics(
+    candidates: list[QuestionCandidate],
+    selected: list[QuestionCandidate],
+    *,
+    limit: int,
+    source_cap: int,
+    budgets: dict[str, int],
+    kind_counts: Counter[str],
+    per_source: Counter[str],
+    per_caselet: Counter[str],
+    skipped: Counter[str],
+) -> dict[str, Any]:
+    weak_reason_counts = Counter(reason for candidate in candidates for reason in candidate.weak_reasons)
+    return {
+        "schemaVersion": "feedback-selection-metrics.v1",
+        "questionLimit": limit,
+        "sourceClusterCap": source_cap,
+        "caseletExposureCap": CASELET_EXPOSURE_CAP,
+        "budgets": {"mustLink": budgets[MUST_LINK_KIND], "cannotLink": budgets[CANNOT_LINK_KIND]},
+        "candidateCounts": {
+            "cannotLink": _kind_candidate_counts(candidates, CANNOT_LINK_KIND),
+            "mustLink": _kind_candidate_counts(candidates, MUST_LINK_KIND),
+        },
+        "selectedCounts": {
+            "total": len(selected),
+            "cannotLink": kind_counts[CANNOT_LINK_KIND],
+            "mustLink": kind_counts[MUST_LINK_KIND],
+            "weak": sum(1 for candidate in selected if candidate.is_weak),
+        },
+        "skippedCounts": dict(sorted(skipped.items())),
+        "weakReasonCounts": dict(sorted(weak_reason_counts.items())),
+        "selectedPerSourceCluster": {key: value for key, value in sorted(per_source.items()) if key},
+        "maxCaseletExposure": max(per_caselet.values(), default=0),
+    }
+
+
+def _kind_candidate_counts(candidates: list[QuestionCandidate], kind: str) -> dict[str, int]:
+    kind_candidates = [candidate for candidate in candidates if candidate.kind == kind]
+    weak_count = sum(1 for candidate in kind_candidates if candidate.is_weak)
+    return {
+        "considered": len(kind_candidates),
+        "strong": len(kind_candidates) - weak_count,
+        "weak": weak_count,
+    }
+
+
+def _entrypoints_by_source(entrypoints: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    by_source: dict[str, list[dict[str, Any]]] = {}
+    for entrypoint in entrypoints:
+        source = _text_id(entrypoint.get("sourceClusterId"))
+        if source:
+            by_source.setdefault(source, []).append(entrypoint)
+    return by_source
+
+
+def _representative_pair(left: dict[str, Any], right: dict[str, Any]) -> tuple[str, str] | None:
+    left_ids = _string_list(left.get("exemplarConversationIds")) or _string_list(left.get("memberConversationIds"))
+    right_ids = _string_list(right.get("exemplarConversationIds")) or _string_list(right.get("memberConversationIds"))
+    if not left_ids or not right_ids:
+        return None
+    return left_ids[0], right_ids[0]
+
+
+def _entrypoint_member_count(entrypoint: dict[str, Any]) -> int:
+    member_count = entrypoint.get("memberCount")
+    if isinstance(member_count, int) and not isinstance(member_count, bool):
+        return max(0, member_count)
+    return len(_string_list(entrypoint.get("memberConversationIds")))
+
+
+def _cluster_member_count(cluster: dict[str, Any], *, fallback: int) -> int:
+    cluster_size = cluster.get("cluster_size")
+    if isinstance(cluster_size, int) and not isinstance(cluster_size, bool):
+        return max(0, cluster_size)
+    member_count = len(_string_list(cluster.get("member_conv_ids")))
+    return member_count if member_count > 0 else fallback
+
+
+def _deduped(values: list[str]) -> tuple[str, ...]:
+    output: list[str] = []
+    for value in values:
+        if value not in output:
+            output.append(value)
+    return tuple(output)
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [text for item in value if (text := str(item).strip())]
+
+
+def _text_id(value: object) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _float_or_zero(value: object) -> float:
+    return _float_or_none(value) or 0.0
+
+
+def _float_or_none(value: object) -> float | None:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    return None
+
+
+__all__ = [
+    "CANNOT_LINK_KIND",
+    "MUST_LINK_KIND",
+    "SELECTION_METRICS_ARTIFACT",
+    "QuestionCandidate",
+    "SelectionResult",
+    "collect_candidates",
+    "select_candidates",
+    "source_cluster_cap",
+]

--- a/ml/tests/stages/test_feedback_candidate_selection.py
+++ b/ml/tests/stages/test_feedback_candidate_selection.py
@@ -1,0 +1,341 @@
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any, cast
+
+from pipeline.stages.feedback_candidate_generation.main import run
+from pipeline.stages.feedback_candidate_generation.selection import (
+    QuestionCandidate,
+    collect_candidates,
+    select_candidates,
+)
+
+
+def _entrypoint(
+    entrypoint_id: str,
+    source: str,
+    confidence: float,
+    exemplar: str,
+    *,
+    split_reason: str = "action:변경",
+    label: float = 0.7,
+    member_count: int = 8,
+) -> dict[str, Any]:
+    return {
+        "entryPointId": entrypoint_id,
+        "sourceClusterId": source,
+        "confidence": confidence,
+        "splitReason": split_reason,
+        "memberCount": member_count,
+        "exemplarConversationIds": [exemplar],
+        "confidenceComponents": {"label": label},
+    }
+
+
+def _must_link_cluster(
+    cluster_id: int,
+    confidence: float,
+    exemplars: list[str],
+    *,
+    label_score: float = 0.65,
+    evidence_coverage: float = 0.4,
+    split_key: str = "action:변경",
+) -> dict[str, Any]:
+    return {
+        "cluster_id": cluster_id,
+        "source_cluster_id": cluster_id,
+        "workflow_entrypoint_id": f"entrypoint-{cluster_id}",
+        "workflow_confidence": confidence,
+        "label_score": label_score,
+        "label_evidence_coverage": evidence_coverage,
+        "flow_split_key": split_key,
+        "cluster_size": 8,
+        "exemplar_conv_ids": exemplars,
+    }
+
+
+def _write_run_fixture(
+    artifact_root: Path,
+    *,
+    entrypoints: list[dict[str, Any]],
+    clusters: list[dict[str, Any]],
+) -> Path:
+    base_dir = artifact_root / "domain_pack_generation" / "manual__run"
+    flow_dir = base_dir / "flow_splitting"
+    preprocessing_dir = base_dir / "preprocessing"
+    flow_dir.mkdir(parents=True)
+    preprocessing_dir.mkdir(parents=True)
+    (flow_dir / "clusters.json").write_text(json.dumps({"clusters": clusters}), encoding="utf-8")
+    (flow_dir / "workflow_entrypoints.json").write_text(
+        json.dumps({"workflowEntryPoints": entrypoints}),
+        encoding="utf-8",
+    )
+    caselet_ids = {
+        caselet_id for entrypoint in entrypoints for caselet_id in entrypoint.get("exemplarConversationIds", [])
+    } | {caselet_id for cluster in clusters for caselet_id in cluster.get("exemplar_conv_ids", [])}
+    (preprocessing_dir / "preprocessed_data.json").write_text(
+        json.dumps(
+            {
+                "issueCaselets": [
+                    {"caseletId": caselet_id, "customerIssueText": f"{caselet_id} 문의"}
+                    for caselet_id in sorted(caselet_ids)
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    upstream_manifest = flow_dir / "manifest.json"
+    upstream_manifest.write_text(
+        json.dumps(
+            {
+                "dag_id": "domain_pack_generation",
+                "run_id": "manual__run",
+                "workspace_id": "3",
+                "dataset_id": "5",
+                "pipeline_job_id": "42",
+            }
+        ),
+        encoding="utf-8",
+    )
+    return upstream_manifest
+
+
+def _run_stage(monkeypatch, tmp_path: Path, entrypoints, clusters) -> tuple[dict[str, Any], dict[str, Any], Path]:
+    artifact_root = tmp_path / "artifacts"
+    monkeypatch.setenv("PIPELINE_ARTIFACT_ROOT", str(artifact_root))
+    monkeypatch.setenv("PIPELINE_BACKEND_BASE_URL", "http://backend:8080")
+    upstream_manifest = _write_run_fixture(artifact_root, entrypoints=entrypoints, clusters=clusters)
+
+    result = run(str(upstream_manifest))
+
+    output_dir = Path(cast(str, result["artifact_manifest_path"])).parent
+    questions_payload = json.loads((output_dir / "feedback_review_questions.json").read_text(encoding="utf-8"))
+    manifest = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
+    return questions_payload, manifest, output_dir
+
+
+def test_one_source_cluster_cannot_monopolize_default_question_slots(monkeypatch, tmp_path: Path) -> None:
+    """job 42 증상 축소 재현: 큰 source cluster 하나가 12개 질문 슬롯을 독식하던 분포."""
+    entrypoints = [
+        _entrypoint("entrypoint-0", "1", 0.40, "90100#issue-01"),
+        _entrypoint("entrypoint-1", "1", 0.45, "90101#issue-01"),
+        _entrypoint("entrypoint-2", "1", 0.50, "90102#issue-01"),
+        _entrypoint("entrypoint-3", "1", 0.55, "90103#issue-01"),
+        _entrypoint("entrypoint-4", "1", 0.58, "90104#issue-01"),
+        _entrypoint("entrypoint-5", "2", 0.52, "90200#issue-01"),
+        _entrypoint("entrypoint-6", "2", 0.60, "90201#issue-01"),
+        _entrypoint("entrypoint-7", "2", 0.65, "90202#issue-01"),
+        _entrypoint("entrypoint-8", "3", 0.55, "90300#issue-01", split_reason="mixed_residual"),
+        _entrypoint("entrypoint-9", "3", 0.57, "90301#issue-01", split_reason="mixed_residual"),
+    ]
+    clusters = [
+        _must_link_cluster(20, 0.42, ["90400#issue-01", "90401#issue-01"]),
+        _must_link_cluster(21, 0.46, ["90402#issue-01", "90403#issue-01"]),
+        _must_link_cluster(22, 0.50, ["90404#issue-01", "90405#issue-01"]),
+        _must_link_cluster(23, 0.54, ["90406#issue-01", "90407#issue-01"]),
+    ]
+
+    questions_payload, manifest, output_dir = _run_stage(monkeypatch, tmp_path, entrypoints, clusters)
+    questions = questions_payload["questions"]
+
+    workflow_questions = [question for question in questions if question["questionType"] == "WORKFLOW_BOUNDARY"]
+    intent_questions = [question for question in questions if question["questionType"] == "INTENT_BOUNDARY"]
+    source_counts = Counter(question["sourceClusterId"] for question in workflow_questions)
+    assert max(source_counts.values()) <= 3
+    assert len(source_counts) >= 2
+
+    caselet_counts = Counter(
+        caselet_id for question in questions for caselet_id in (question["sourceId"], question["targetId"])
+    )
+    assert max(caselet_counts.values()) <= 2
+
+    assert len(intent_questions) == 4
+    assert all(question["priority"] == "NORMAL" for question in intent_questions)
+
+    low_priority_indexes = [index for index, question in enumerate(questions) if question["priority"] == "LOW"]
+    assert low_priority_indexes
+    assert all(question["sourceClusterId"] == "3" for question in (questions[index] for index in low_priority_indexes))
+    assert min(low_priority_indexes) > max(
+        index for index, question in enumerate(questions) if question["priority"] != "LOW"
+    )
+
+    selection_metrics = json.loads((output_dir / "feedback_selection_metrics.json").read_text(encoding="utf-8"))
+    assert selection_metrics["schemaVersion"] == "feedback-selection-metrics.v1"
+    assert selection_metrics["budgets"] == {"mustLink": 4, "cannotLink": 8}
+    assert selection_metrics["selectedCounts"]["total"] == len(questions)
+    assert selection_metrics["selectedCounts"]["mustLink"] == 4
+    assert selection_metrics["selectedCounts"]["weak"] == len(low_priority_indexes)
+    assert selection_metrics["weakReasonCounts"]["mixed_split_reason"] >= 1
+    assert manifest["payload"]["reportPath"] == "feedback_selection_metrics.json"
+    assert manifest["payload"]["metrics"]["selection"]["selectedCounts"]["total"] == len(questions)
+
+
+def test_weak_only_candidates_still_fill_questions_with_low_priority(monkeypatch, tmp_path: Path) -> None:
+    entrypoints = [
+        _entrypoint("entrypoint-0", "9", 0.50, "90900#issue-01", split_reason="mixed_residual"),
+        _entrypoint("entrypoint-1", "9", 0.55, "90901#issue-01", split_reason="mixed_residual"),
+        _entrypoint("entrypoint-2", "9", 0.60, "90902#issue-01", split_reason="mixed_residual"),
+    ]
+
+    questions_payload, _manifest, output_dir = _run_stage(monkeypatch, tmp_path, entrypoints, clusters=[])
+    questions = questions_payload["questions"]
+
+    assert len(questions) == 3
+    assert all(question["priority"] == "LOW" for question in questions)
+    assert all(question["questionType"] == "WORKFLOW_BOUNDARY" for question in questions)
+
+    selection_metrics = json.loads((output_dir / "feedback_selection_metrics.json").read_text(encoding="utf-8"))
+    assert selection_metrics["selectedCounts"]["weak"] == 3
+    assert selection_metrics["budgets"]["mustLink"] == 0
+
+
+def _candidate(
+    *,
+    kind: str = "cannot_link",
+    source: str = "1",
+    cluster_id: str = "",
+    source_id: str = "a",
+    target_id: str = "b",
+    score: float = 0.5,
+    weak: tuple[str, ...] = (),
+) -> QuestionCandidate:
+    return QuestionCandidate(
+        kind=kind,
+        source_cluster_id=source,
+        cluster_id=cluster_id,
+        source_id=source_id,
+        target_id=target_id,
+        member_total=10,
+        confidence=0.5,
+        score=score,
+        weak_reasons=weak,
+    )
+
+
+def test_select_uses_full_limit_when_no_must_link_candidates() -> None:
+    candidates = [
+        _candidate(source=str(source), source_id=f"s-{source}-{index}", target_id=f"t-{source}-{index}", score=0.9)
+        for source in range(4)
+        for index in range(3)
+    ]
+
+    result = select_candidates(candidates, limit=12)
+
+    assert len(result.selected) == 12
+    assert result.metrics["budgets"]["mustLink"] == 0
+
+
+def test_select_reserves_must_link_budget_against_higher_scoring_cannot_link() -> None:
+    cannot_link = [
+        _candidate(source=str(source), source_id=f"s-{source}-{index}", target_id=f"t-{source}-{index}", score=0.9)
+        for source in range(3)
+        for index in range(3)
+    ]
+    must_link = [
+        _candidate(
+            kind="must_link",
+            source=f"m-{index}",
+            cluster_id=f"m-{index}",
+            source_id=f"ms-{index}",
+            target_id=f"mt-{index}",
+            score=0.1,
+        )
+        for index in range(4)
+    ]
+
+    result = select_candidates(cannot_link + must_link, limit=12)
+
+    kind_counts = Counter(candidate.kind for candidate in result.selected)
+    assert kind_counts["must_link"] == 4
+    assert kind_counts["cannot_link"] == 8
+
+
+def test_select_lets_must_link_exceed_reserved_budget_when_no_cannot_link() -> None:
+    must_link = [
+        _candidate(
+            kind="must_link",
+            source=f"m-{index}",
+            cluster_id=f"m-{index}",
+            source_id=f"ms-{index}",
+            target_id=f"mt-{index}",
+            score=0.5,
+        )
+        for index in range(6)
+    ]
+
+    result = select_candidates(must_link, limit=12)
+
+    assert len(result.selected) == 6
+    assert result.metrics["budgets"]["mustLink"] == 4
+
+
+def test_select_caps_repeated_caselet_exposure() -> None:
+    candidates = [
+        _candidate(source=str(source), source_id="repeated", target_id=f"t-{source}", score=0.9) for source in range(3)
+    ]
+
+    result = select_candidates(candidates, limit=12)
+
+    assert len(result.selected) == 2
+    assert result.metrics["skippedCounts"]["caseletExposureCap"] == 1
+    assert result.metrics["maxCaseletExposure"] == 2
+
+
+def test_select_orders_weak_candidates_after_strong_ones() -> None:
+    strong = _candidate(source="1", source_id="s1", target_id="t1", score=0.1)
+    weak = _candidate(source="2", source_id="s2", target_id="t2", score=0.9, weak=("mixed_split_reason",))
+
+    result = select_candidates([weak, strong], limit=12)
+
+    assert [candidate.is_weak for candidate in result.selected] == [False, True]
+
+
+def test_select_is_deterministic_for_reversed_input_order() -> None:
+    candidates = [
+        _candidate(source=str(source), source_id=f"s-{source}-{index}", target_id=f"t-{source}-{index}", score=0.5)
+        for source in range(4)
+        for index in range(3)
+    ]
+
+    forward = select_candidates(list(candidates), limit=6)
+    reversed_input = select_candidates(list(reversed(candidates)), limit=6)
+
+    assert forward.selected == reversed_input.selected
+
+
+def test_diagonal_pair_pool_reaches_source_cap_despite_caselet_cap() -> None:
+    entrypoints = [
+        _entrypoint(f"entrypoint-{index}", "1", 0.3 + 0.1 * index, f"e{index}#issue-01") for index in range(6)
+    ]
+
+    candidates = collect_candidates(entrypoints, [], limit=12)
+    result = select_candidates(candidates, limit=12)
+
+    assert len(result.selected) == 3
+
+
+def test_collect_marks_low_label_confidence_and_zero_evidence_as_weak() -> None:
+    entrypoints = [
+        _entrypoint("entrypoint-0", "1", 0.50, "a#issue-01", label=0.2),
+        _entrypoint("entrypoint-1", "1", 0.55, "b#issue-01"),
+    ]
+    clusters = [
+        {
+            "cluster_id": 1,
+            "workflow_entrypoint_id": "entrypoint-1",
+            "flow_split_key": "action:변경",
+            "label_score": 0.7,
+            "label_evidence_coverage": 0.0,
+        },
+        _must_link_cluster(7, 0.45, ["c#issue-01", "d#issue-01"], label_score=0.2),
+    ]
+
+    candidates = collect_candidates(entrypoints, clusters, limit=12)
+
+    pair = next(candidate for candidate in candidates if candidate.kind == "cannot_link")
+    assert "low_label_confidence" in pair.weak_reasons
+    assert "zero_label_evidence_coverage" in pair.weak_reasons
+    must = next(candidate for candidate in candidates if candidate.kind == "must_link")
+    assert must.weak_reasons == ("low_label_confidence",)


### PR DESCRIPTION
Closes #773

## 변경 사항

- 이슈 773 요구사항과 acceptance criteria를 `.agent/specs/773.md`에 정리했습니다.
- `feedback_candidate_generation`에 후보 선별 모듈(`selection.py`)을 추가해 단순 nested loop 순서 대신 점수 기반 greedy 선별을 적용했습니다.
  - **다양성 상한**: source cluster당 질문 `max(1, ceil(limit/4))`개(기본 12 → 3), 동일 caselet 노출 최대 2회.
  - **예산 분리**: must_link 후보가 있으면 `limit // 3`(기본 4)을 예약하고, 한쪽 후보가 부족하면 남은 예산을 다른 쪽으로 이월합니다.
  - **품질 가드**: mixed_flow/mixed_residual split, label 신뢰도 < 0.40(flow_splitting `WORKFLOW_LABEL_BLOCKING_CONFIDENCE_THRESHOLD` 동일 기준), label evidence coverage ≤ 0 후보는 weak로 분류해 strong이 못 채운 잔여 슬롯만 `priority=LOW`로 가져가고 출력 순서도 strong 뒤에 둡니다.
  - **점수**: human review 임계(0.60) 부근 confidence일수록 높은 uncertainty + 멤버 규모 기반 impact의 가중 합. 동률은 id 기준 결정적 정렬.
  - **pair 풀 편향 방지**: source당 pair 생성을 한도 기반 상한으로 제한하되, 인접 confidence 조합부터 대각선 순서로 생성해 한 entrypoint의 exemplar가 풀과 caselet 상한을 독식하지 않게 했습니다.
- 선별 근거를 `feedback_selection_metrics.json` artifact(예산/상한, 후보·선택·제외 수, source별 분포, caselet 최대 노출)로 남기고 manifest `reportPath`와 `metrics.selection`에서 참조합니다.
- 질문 schema는 additive 변경만 있습니다(`priority`에 `LOW` 추가). backend는 payload를 raw JsonNode로 보존하고 frontend `pipelineReviewApi.ts`는 `priority: string`이라 호환됩니다. PR #793의 `qualityKpis` 계측은 선별된 최종 질문 집합에 그대로 적용됩니다.
- job 42 증상(한 source cluster의 12개 질문 독식, caselet 반복, must_link 0건)을 축소 재현한 회귀 테스트를 포함해 11개 테스트를 추가했습니다. 원본 job 42 artifact는 저장소에 없어 이슈에 보고된 분포를 합성한 fixture를 사용했습니다.

## 검증

- `cd ml && uv run pytest tests/stages/test_feedback_candidate_selection.py tests/stages/test_feedback_candidate_generation_main.py` (13 passed)
- `cd ml && uv run pytest` (687 passed, 2 skipped)
- `cd ml && uv run ruff check .` / `uv run ruff format --check .` / `uv run mypy .` 전부 통과
- pre-commit hook(lint:ml / format:ml:check / typecheck:ml) 통과 상태로 커밋했습니다(우회 없음).

## 참고

- 구현 전 flow_splitting 산출물 계약(`_entrypoint`, `_apply_workflow_review_metadata`가 채우는 confidence/label/splitReason 필드), PR #793의 KPI 계측, backend checkpoint callback과 frontend review payload 계약을 확인했습니다.
- 스펙 리뷰 2회: 이슈의 제안 6개 항목·확인 포인트 5개를 Scope/AC에 매핑했고, 참조 경로 실재와 파일명/브랜치 규칙을 확인했습니다.
- self-review 3회: Round 1에서 pair 생성이 confidence 순 nested loop라 큰 cluster에서 첫 entrypoint가 풀을 독식하는 편향을 발견해 대각선 생성으로 수정하고 회귀 테스트를 추가했습니다. Round 2에서 artifact/manifest/DAG/S3 통합과 schema additive 여부를 점검했습니다. Round 3에서 must_link 예산 초과 이월 단위 테스트를 보강하고 staged diff 범위와 whitespace를 확인했습니다.
- 이 PR 전에 머지된 #795(ML ruff/mypy 기준선 복구), #796(pre-commit ml 검사 수정)이 hook 통과의 전제입니다.
- 다양성 상한 때문에 적격 후보가 부족하면 질문 수가 한도(12)보다 적을 수 있습니다. 임계값(label 0.40, caselet 2회)은 job 42 기준 초기값이며 selection metric을 근거로 조정할 수 있습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 피드백 질문 선택 로직을 점수 기반 선별 방식으로 개선하여 질문의 다양성과 품질을 보장합니다.
  * 단일 소스의 질문 독점을 방지하고 중복 노출을 제한하는 선택 메커니즘을 도입했습니다.

* **Tests**
  * 개선된 질문 선택 메커니즘의 통합 및 단위 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->