### PR TITLE
refactor(frontend): 업로드 후 파이프라인 상태별 다음 행동을 보장

### DIFF
--- a/.agent/specs/785.md
+++ b/.agent/specs/785.md
@@ -1,0 +1,137 @@
+# Frontend Spec: 업로드 후 파이프라인 진행 상태와 CTA를 일관되게 표시한다
+
+## Goal
+
+상담 로그 업로드 성공 이후 화면을 단일 view state 기반으로 정리하여, 사용자가 기다려야 하는지, 검토해야 하는지, 생성 요청을 다시 보내야 하는지를 상태별 하나의 primary CTA로 바로 이해하게 한다.
+
+## Problem
+
+- 업로드 성공 후 자동 ingestion job 패널, 수동 생성 fallback 패널, 생성 요청 진행/실패/완료 패널이 한 화면에 동시에 섞여 보일 수 있다.
+- `PipelineJobStatusPanel`은 최대 3개의 버튼을 렌더링하고, `reviewPath` 유무에 따라 "상태 새로고침" 버튼의 primary/secondary variant가 뒤바뀌어 상태별 primary CTA가 고정되지 않는다.
+- `CANCELLED` 상태 문구는 "다시 업로드하거나 생성 요청을 다시 보낼 수 있습니다"라고 안내하지만, 수동 생성 요청 버튼은 job이 아예 없을 때만 노출되어 문구와 실제 가능한 행동이 어긋난다.
+- 자동 파이프라인 패널과 수동 생성 fallback 패널이 별도 블록으로 나란히 렌더링되어 두 흐름의 관계(자동이 기본, 수동은 예외 복구 경로)가 드러나지 않는다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A[업로드 성공] --> B{수동 생성 흐름 진행 중?}
+    B -->|요청 중| C[generation_requesting 패널]
+    B -->|요청 실패| D[generation_failed 패널: primary 다시 생성 요청]
+    B -->|요청 완료| E[generation_requested 패널: primary 검토 화면으로 이동]
+    B -->|아니오| F{자동 ingestion job 조회}
+    F -->|조회 중| G[uploaded: 상태 확인 중]
+    F -->|조회 실패| H[status_unavailable: primary 상태 새로고침]
+    F -->|job 없음/QUEUED| I[pipeline_pending: primary 상태 새로고침·이동, 수동 fallback 안내]
+    F -->|RUNNING 등| J[running: primary 상태 화면으로 이동]
+    F -->|WAITING_DOMAIN_CONFIRMATION / WAITING_HUMAN_FEEDBACK| K[review_required: primary 검토 화면으로 이동]
+    F -->|SUCCEEDED| L[succeeded: primary 도메인팩 관리로 이동]
+    F -->|FAILED| M[failed: primary 초안 생성 다시 요청]
+    F -->|CANCELLED| N[cancelled: primary 초안 생성 다시 요청]
+    I -->|fallback 클릭| C
+    M -->|다시 요청 클릭| C
+    N -->|다시 요청 클릭| C
+```
+
+## Design Diff
+
+| 영역 | As-is | To-be | 변경 내용 |
+| ---- | ----- | ----- | --------- |
+| 상태 모델 | 업로드 상태, 생성 요청 상태, job 조회 상태가 각각 조건부 렌더링으로 분기 | `derivePipelineJobViewState`가 job 조회 결과를 단일 view state로 환원하고, 수동 생성 흐름이 활성화되면 자동 파이프라인 패널 대신 생성 패널만 렌더링 | 한 시점에 패널 하나만 표시 |
+| primary CTA | `reviewPath` 유무로 새로고침 버튼 variant가 뒤바뀜 | 상태별 primary CTA 1개 고정, 나머지는 secondary/ghost | CTA 일관성 |
+| 수동 fallback | job이 없을 때만 별도 패널로 노출 | `pipeline_pending`(job 없음)·`failed`·`cancelled` 상태 안에서 복구 경로로 노출, 자동/수동 관계 문구 명시 | 문구와 행동 일치 |
+| 실패/취소 복구 | 문구만 있고 생성 재요청 버튼 없음 | "도메인팩 초안 생성 다시 요청" 버튼 제공 | 실패 복구 경로 제공 |
+
+## View State 정의
+
+`frontend/src/features/log-upload/model/useLatestDatasetPipelineJob.ts`에 pure 함수로 추가한다.
+
+| view state | 조건 (jobType=INGESTION 최신 job 기준) | primary CTA | 보조 액션 |
+| ---------- | -------------------------------------- | ----------- | --------- |
+| `uploaded` | 조회 isLoading | 없음 (자동 확인 진행 안내) | 없음 |
+| `status_unavailable` | 조회 isError | 상태 새로고침 | 다른 파일 업로드 |
+| `pipeline_pending` | job 없음 또는 status `QUEUED` | job 있으면 상태 화면으로 이동, 없으면 상태 새로고침 | job 없으면 도메인팩 초안 생성 시작(fallback), 다른 파일 업로드 |
+| `running` | status `RUNNING`, `WAITING_INTENT_CALLBACK`, `WAITING_WORKFLOW_CALLBACK`, 미지정 상태 | 상태 화면으로 이동 | 상태 새로고침, 다른 파일 업로드 |
+| `review_required` | status `WAITING_DOMAIN_CONFIRMATION`, `WAITING_HUMAN_FEEDBACK` | 검토 화면으로 이동 | 상태 새로고침, 다른 파일 업로드 |
+| `succeeded` | status `SUCCEEDED` | 도메인팩 관리로 이동 | 상태 화면으로 이동, 다른 파일 업로드 |
+| `failed` | status `FAILED` | 도메인팩 초안 생성 다시 요청 | 상태 화면으로 이동, 다른 파일 업로드 |
+| `cancelled` | status `CANCELLED` | 도메인팩 초안 생성 다시 요청 | 상태 화면으로 이동, 다른 파일 업로드 |
+
+상태 값 출처: `backend/src/main/java/com/init/pipelinejob/domain/model/PipelineJob.java`의 STATUS 상수.
+
+수동 생성 흐름이 idle이 아니면 (`triggering`/`error`/`success` 또는 mutation pending) 위 표 대신 기존 생성 패널 3종 중 하나만 렌더링한다.
+
+| 생성 흐름 상태 | primary CTA | 보조 액션 |
+| -------------- | ----------- | --------- |
+| `generation_requesting` | 없음 (대기 안내) | 다른 파일 업로드 (pending 중 disabled) |
+| `generation_failed` | 다시 생성 요청 | 다른 파일 업로드 |
+| `generation_requested` | 검토 화면으로 이동 (pipelineJobId 없으면 도메인팩 관리로 이동) | 도메인팩 관리로 이동, 다른 파일 업로드 |
+
+## Component Tree
+
+```text
+LogUploadForm
+├─ onboardingStatus (변경 없음)
+├─ FileUploader (변경 없음)
+├─ filePreview (변경 없음)
+└─ afterUpload (status === "success")
+   ├─ uploadSummary (변경 없음)
+   └─ 단일 패널 (한 시점에 하나만)
+      ├─ 생성 흐름 활성 시: generation_requesting | generation_failed | generation_requested
+      └─ 생성 흐름 idle 시: PipelineJobStatusPanel
+         └─ view state별 statusLabel + 안내 문구 + primary CTA 1개 + 보조 액션
+```
+
+## API Integration
+
+신규 API, generated client, query key 변경 없음. 기존 `useLatestDatasetPipelineJob` (polling 포함)과 `useTriggerDomainPackGeneration`을 그대로 사용한다.
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+| ---- | --------- | ---- |
+| `frontend/src/features/log-upload/model/useLatestDatasetPipelineJob.ts` | update | `PipelineJobViewState` 타입과 `derivePipelineJobViewState` pure 함수 추가 |
+| `frontend/src/features/log-upload/ui/PipelineJobStatusPanel.tsx` | update | view state 기반 단일 패널 렌더링, 상태별 primary CTA 1개 고정, 수동 fallback 복구 액션 통합 |
+| `frontend/src/features/log-upload/ui/LogUploadForm.tsx` | update | 생성 흐름 활성 시 자동 파이프라인 패널 숨김, 별도 수동 fallback 블록 제거, 생성 콜백을 패널에 전달 |
+| `frontend/src/features/log-upload/model/useLatestDatasetPipelineJob.test.tsx` | update | `derivePipelineJobViewState` 상태 매핑 테스트 추가 |
+| `frontend/src/features/log-upload/ui/PipelineJobStatusPanel.test.tsx` | new | view state별 렌더링·primary CTA·fallback 액션 테스트 |
+| `frontend/src/features/log-upload/ui/LogUploadForm.test.tsx` | update | 단일 패널 배타 렌더링, 실패/취소 복구 CTA, 기존 시나리오 회귀 유지 |
+
+## State Management
+
+- `LogUploadForm`의 기존 local state(`status`, `uploadedDataset`, `generationStatus`)와 중복 클릭 가드는 유지한다.
+- `derivePipelineJobViewState(queryState, job)`는 부수효과 없는 pure 함수로 두고, polling 판단(`shouldPollPipelineJob`)과 같은 파일에서 관리한다.
+- `PipelineJobStatusPanel`은 `onStartGeneration`, `canStartGeneration`, `isGenerationPending` props를 추가로 받아 fallback/복구 CTA를 렌더링한다.
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+| ---- | ---- | ---- | ---- |
+| view state 매핑 | pure 함수 단위 테스트 | Vitest | 상태 9종(생성 3종 포함) 분기 |
+| 패널 렌더링 | 컴포넌트 테스트 | Vitest + React Testing Library | 상태별 문구·primary CTA 1개·fallback 노출 |
+| 폼 통합 | 기존 테스트 갱신 + 추가 | Vitest + React Testing Library | 패널 배타 렌더링, 복구 흐름 |
+| 정적 검증 | lint/test/build | pnpm scripts | frontend 범위 |
+
+### Acceptance Criteria
+
+| # | 기준 | 기대 결과 |
+| - | ---- | --------- |
+| 1 | 업로드 후 화면 상태 | `uploaded`/`pipeline_pending`/`review_required`/`running`/`succeeded`/`failed`/`cancelled`/`status_unavailable` view state로 환원 |
+| 2 | primary CTA | 사용자 행동이 가능한 모든 view state에서 primary variant 버튼이 정확히 1개. 진행 중 상태(`uploaded`, `generation_requesting`)는 primary CTA 없이 대기 안내만 표시 |
+| 3 | 자동/수동 관계 | `pipeline_pending`(job 없음)·`failed`·`cancelled` 문구에 자동 파이프라인 대비 수동 요청의 역할이 명시되고 같은 패널에서 실행 가능 |
+| 4 | 문구-행동 일치 | 실패/취소/검토 대기/성공 문구가 해당 패널의 실제 버튼과 일치 |
+| 5 | 배타 렌더링 | 자동 파이프라인 패널과 생성 흐름 패널이 동시에 보이지 않음 |
+| 6 | 테스트 | view state별 렌더링 테스트 추가, 기존 시나리오 회귀 없음 |
+
+### Non-goals
+
+- `useLatestDatasetPipelineJob`의 polling 주기·query key·API 계약 변경은 하지 않는다.
+- 업로드 자격(무료 온보딩/구독/쿨다운) 차단 로직과 문구는 변경하지 않는다.
+- 파이프라인 상세/검토 화면 자체의 동작 변경은 하지 않는다.
+- 신규 CSS 디자인 도입 없이 기존 `log-upload-form.module.css` 클래스를 재사용한다.
+
+### Open Questions
+
+- 없음. 이슈 본문, 기존 코드의 상태 상수, CTA 단일 출처(`shared/lib/ctaLabels.ts`) 기준으로 범위를 확정한다.

--- a/frontend/e2e/upload-domain-pack-generation.spec.ts
+++ b/frontend/e2e/upload-domain-pack-generation.spec.ts
@@ -173,7 +173,7 @@ test.describe("Upload completed Domain Pack draft generation", () => {
     await expect(page.getByText("업로드 완료").first()).toBeVisible();
     await expect(page.getByText("refund-log.zip")).toBeVisible();
     await expect(page.getByText("dataset 77")).toBeVisible();
-    await expect(page.getByText("파이프라인 준비 중")).toBeVisible();
+    await expect(page.getByText("자동 파이프라인 대기 중")).toBeVisible();
 
     return page.getByRole("button", {
       name: "도메인팩 초안 생성 시작",

--- a/frontend/e2e/workspace-core.spec.ts
+++ b/frontend/e2e/workspace-core.spec.ts
@@ -469,7 +469,7 @@ test.describe("Workspace core operator screens", () => {
 
         await startButton.click();
         await expect(page.getByText("업로드 완료").first()).toBeVisible();
-        await expect(page.getByText("자동 생성 파이프라인")).toBeVisible();
+        await expect(page.getByText("검토 대기 중")).toBeVisible();
         expect(seen).toContain("POST /workspaces/1/datasets/uploads:init");
         expect(seen).toContain("PUT /e2e-upload/raw-log.zip");
         expect(seen).toContain("POST /workspaces/1/datasets/uploads/77:complete");
@@ -491,7 +491,7 @@ test.describe("Workspace core operator screens", () => {
         });
         await page.getByRole("button", { name: "처리 시작" }).click();
         await expect(page.getByText("업로드 완료").first()).toBeVisible();
-        await expect(page.getByText("자동 생성 파이프라인")).toBeVisible();
+        await expect(page.getByText("검토 대기 중")).toBeVisible();
         await page.getByRole("button", { name: "검토 화면으로 이동" }).click();
 
         await expect(page).toHaveURL(/\/workspaces\/1\/pipeline-jobs\/900\/review/);

--- a/frontend/src/features/log-upload/model/useLatestDatasetPipelineJob.test.tsx
+++ b/frontend/src/features/log-upload/model/useLatestDatasetPipelineJob.test.tsx
@@ -17,6 +17,7 @@ vi.mock("../api/pipelineJobStatusApi", async () => {
 
 import { getLatestDatasetPipelineJob } from "../api/pipelineJobStatusApi";
 import {
+  derivePipelineJobViewState,
   latestDatasetPipelineJobKeys,
   shouldPollPipelineJob,
   useLatestDatasetPipelineJob,
@@ -104,5 +105,93 @@ describe("useLatestDatasetPipelineJob", () => {
     expect(shouldPollPipelineJob({ ...runningJob, status: "CANCELLED" })).toBe(
       false,
     );
+  });
+});
+
+describe("derivePipelineJobViewState", () => {
+  const settledQuery = { isLoading: false, isError: false };
+
+  it("조회 중에는 uploaded 상태로 둔다", () => {
+    expect(
+      derivePipelineJobViewState({ isLoading: true, isError: false }, null),
+    ).toBe("uploaded");
+  });
+
+  it("조회 실패는 status_unavailable로 구분한다", () => {
+    expect(
+      derivePipelineJobViewState({ isLoading: false, isError: true }, null),
+    ).toBe("status_unavailable");
+  });
+
+  it("job이 없거나 QUEUED면 pipeline_pending이다", () => {
+    expect(derivePipelineJobViewState(settledQuery, null)).toBe(
+      "pipeline_pending",
+    );
+    expect(
+      derivePipelineJobViewState(settledQuery, {
+        ...runningJob,
+        status: "QUEUED",
+      }),
+    ).toBe("pipeline_pending");
+  });
+
+  it("검토 입력 대기 상태는 review_required로 묶는다", () => {
+    expect(
+      derivePipelineJobViewState(settledQuery, {
+        ...runningJob,
+        status: "WAITING_DOMAIN_CONFIRMATION",
+      }),
+    ).toBe("review_required");
+    expect(
+      derivePipelineJobViewState(settledQuery, {
+        ...runningJob,
+        status: "WAITING_HUMAN_FEEDBACK",
+      }),
+    ).toBe("review_required");
+  });
+
+  it("종료 상태는 succeeded/failed/cancelled로 구분한다", () => {
+    expect(
+      derivePipelineJobViewState(settledQuery, {
+        ...runningJob,
+        status: "SUCCEEDED",
+      }),
+    ).toBe("succeeded");
+    expect(
+      derivePipelineJobViewState(settledQuery, {
+        ...runningJob,
+        status: "FAILED",
+      }),
+    ).toBe("failed");
+    expect(
+      derivePipelineJobViewState(settledQuery, {
+        ...runningJob,
+        status: "CANCELLED",
+      }),
+    ).toBe("cancelled");
+  });
+
+  it("실행과 내부 콜백 대기, 미지정 상태는 running으로 본다", () => {
+    expect(derivePipelineJobViewState(settledQuery, runningJob)).toBe(
+      "running",
+    );
+    expect(
+      derivePipelineJobViewState(settledQuery, {
+        ...runningJob,
+        status: "WAITING_INTENT_CALLBACK",
+      }),
+    ).toBe("running");
+    expect(
+      derivePipelineJobViewState(settledQuery, {
+        ...runningJob,
+        status: "WAITING_WORKFLOW_CALLBACK",
+      }),
+    ).toBe("running");
+    expect(
+      derivePipelineJobViewState(settledQuery, {
+        ...runningJob,
+        status: "UNKNOWN_FUTURE_STATUS",
+      }),
+    ).toBe("running");
   });
 });

--- a/frontend/src/features/log-upload/model/useLatestDatasetPipelineJob.ts
+++ b/frontend/src/features/log-upload/model/useLatestDatasetPipelineJob.ts
@@ -6,6 +6,54 @@ import {
 
 const FINAL_PIPELINE_STATUSES = new Set(["SUCCEEDED", "FAILED", "CANCELLED"]);
 
+const REVIEW_REQUIRED_PIPELINE_STATUSES = new Set([
+  "WAITING_DOMAIN_CONFIRMATION",
+  "WAITING_HUMAN_FEEDBACK",
+]);
+
+export type PipelineJobViewState =
+  | "uploaded"
+  | "status_unavailable"
+  | "pipeline_pending"
+  | "running"
+  | "review_required"
+  | "succeeded"
+  | "failed"
+  | "cancelled";
+
+export interface PipelineJobQueryState {
+  readonly isLoading: boolean;
+  readonly isError: boolean;
+}
+
+export function derivePipelineJobViewState(
+  queryState: PipelineJobQueryState,
+  job: LatestPipelineJob | null,
+): PipelineJobViewState {
+  if (queryState.isLoading) {
+    return "uploaded";
+  }
+  if (queryState.isError) {
+    return "status_unavailable";
+  }
+  if (!job || job.status === "QUEUED") {
+    return "pipeline_pending";
+  }
+  if (REVIEW_REQUIRED_PIPELINE_STATUSES.has(job.status)) {
+    return "review_required";
+  }
+  if (job.status === "SUCCEEDED") {
+    return "succeeded";
+  }
+  if (job.status === "FAILED") {
+    return "failed";
+  }
+  if (job.status === "CANCELLED") {
+    return "cancelled";
+  }
+  return "running";
+}
+
 export const latestDatasetPipelineJobKeys = {
   all: ["dataset-pipeline-job"] as const,
   latest: (workspaceId?: number, datasetId?: number, jobType = "INGESTION") =>

--- a/frontend/src/features/log-upload/ui/LogUploadForm.test.tsx
+++ b/frontend/src/features/log-upload/ui/LogUploadForm.test.tsx
@@ -87,12 +87,19 @@ vi.mock("../model/useRawFileUpload", () => ({
   }),
 }));
 
-vi.mock("../model/useLatestDatasetPipelineJob", () => ({
-  useLatestDatasetPipelineJob: () => ({
-    ...mockIngestionQuery,
-    refetch: mockIngestionRefetch,
-  }),
-}));
+vi.mock("../model/useLatestDatasetPipelineJob", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("../model/useLatestDatasetPipelineJob")
+    >();
+  return {
+    ...actual,
+    useLatestDatasetPipelineJob: () => ({
+      ...mockIngestionQuery,
+      refetch: mockIngestionRefetch,
+    }),
+  };
+});
 
 vi.mock(
   "../../../shared/api/generated/endpoints/domain-pack-generation-trigger-controller/domain-pack-generation-trigger-controller",
@@ -412,7 +419,7 @@ describe("LogUploadForm", () => {
     fireEvent.change(input, { target: { files: [file] } });
     fireEvent.click(screen.getByText("처리 시작"));
     expect(screen.getByText("다른 파일 업로드")).toBeInTheDocument();
-    expect(screen.getByText("파이프라인 준비 중")).toBeInTheDocument();
+    expect(screen.getByText("자동 파이프라인 대기 중")).toBeInTheDocument();
     expect(screen.getByText("도메인팩 초안 생성 시작")).toBeInTheDocument();
     expect(screen.getByText(/dataset 42/)).toBeInTheDocument();
     expect(screen.queryByText("도메인팩 관리로 이동")).not.toBeInTheDocument();
@@ -528,10 +535,13 @@ describe("LogUploadForm", () => {
     });
     fireEvent.click(screen.getByText("처리 시작"));
 
-    expect(screen.getByText("자동 생성 파이프라인")).toBeInTheDocument();
+    expect(screen.getByText("자동 파이프라인 실행 중")).toBeInTheDocument();
     expect(screen.getByText(/job 77 · pipeline_job_77/)).toBeInTheDocument();
     expect(screen.getByText("DAG domain_pack_generation")).toBeInTheDocument();
     expect(screen.getByText("실행 1분 35초")).toBeInTheDocument();
+    expect(
+      screen.queryByText("도메인팩 초안 생성 시작"),
+    ).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByText("상태 화면으로 이동"));
     expect(mockNavigate).toHaveBeenCalledWith(
@@ -577,6 +587,61 @@ describe("LogUploadForm", () => {
     expect(mockNavigate).toHaveBeenCalledWith(
       "/workspaces/1/pipeline-jobs/42/review",
     );
+  });
+
+  it("offers generation retry as the next action when the automatic pipeline fails", () => {
+    mockIngestionQuery = {
+      data: {
+        pipelineJob: {
+          pipelineJobId: 78,
+          workspaceId: 1,
+          datasetId: 42,
+          domainPackId: null,
+          jobType: "INGESTION",
+          status: "FAILED",
+          airflowDagId: "domain_pack_generation",
+          airflowRunId: "pipeline_job_78",
+          requestedAt: "2026-06-05T01:00:00Z",
+          startedAt: "2026-06-05T01:00:10Z",
+          finishedAt: "2026-06-05T01:02:00Z",
+          runningDurationSeconds: null,
+          lastErrorMessage: "ingestion artifact 누락",
+        },
+      },
+      isLoading: false,
+      isError: false,
+      isFetching: false,
+    };
+
+    render(<LogUploadForm workspaceId={1} />, { wrapper: MemoryRouter });
+    const file = new File(["data"], "data.zip", { type: "application/zip" });
+    fireEvent.change(screen.getByTestId("file-input"), {
+      target: { files: [file] },
+    });
+    fireEvent.click(screen.getByText("처리 시작"));
+
+    expect(screen.getByText("파이프라인 실패")).toBeInTheDocument();
+    expect(screen.getByText("ingestion artifact 누락")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("도메인팩 초안 생성 다시 요청"));
+
+    expect(mockTriggerMutate).toHaveBeenCalledWith({
+      workspaceId: 1,
+      datasetId: 42,
+    });
+    expect(screen.getByText("생성 요청 중")).toBeInTheDocument();
+    expect(screen.queryByText("파이프라인 실패")).not.toBeInTheDocument();
+
+    act(() => {
+      callTriggerOnSuccess?.(
+        { pipelineJobId: 11, status: "REQUESTED" },
+        { workspaceId: 1, datasetId: 42 },
+      );
+    });
+
+    expect(screen.getByText("생성 요청 완료")).toBeInTheDocument();
+    expect(screen.queryByText("파이프라인 실패")).not.toBeInTheDocument();
+    expect(screen.queryByText("생성 요청 중")).not.toBeInTheDocument();
   });
 
   it("shows upload failure toast with retry action", () => {
@@ -629,7 +694,7 @@ describe("LogUploadForm", () => {
     expect(screen.getByText("생성 요청 중")).toBeInTheDocument();
   });
 
-  it("disables generation CTA while mutation is pending", () => {
+  it("replaces the generation CTA with request progress while mutation is pending", () => {
     mockTriggerIsPending = true;
 
     render(<LogUploadForm workspaceId={1} />, { wrapper: MemoryRouter });
@@ -638,8 +703,12 @@ describe("LogUploadForm", () => {
     fireEvent.change(input, { target: { files: [file] } });
     fireEvent.click(screen.getByText("처리 시작"));
 
+    expect(screen.getByText("생성 요청 중")).toBeInTheDocument();
     expect(
-      screen.getByText("도메인팩 초안 생성 시작").closest("button"),
+      screen.queryByText("도메인팩 초안 생성 시작"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText("다른 파일 업로드").closest("button"),
     ).toBeDisabled();
   });
 

--- a/frontend/src/features/log-upload/ui/LogUploadForm.tsx
+++ b/frontend/src/features/log-upload/ui/LogUploadForm.tsx
@@ -23,7 +23,10 @@ import { useRawFileUpload } from "../model/useRawFileUpload";
 import { useLatestDatasetPipelineJob } from "../model/useLatestDatasetPipelineJob";
 
 import styles from "./log-upload-form.module.css";
-import { PipelineJobStatusPanel } from "./PipelineJobStatusPanel";
+import {
+  CTA_START_GENERATION,
+  PipelineJobStatusPanel,
+} from "./PipelineJobStatusPanel";
 
 type UploadStatus = "idle" | "uploading" | "success";
 
@@ -355,12 +358,119 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({
     generationStatus.kind === "triggering" || generationMutation.isPending;
   const isDashboardGenerationTarget =
     queryGenerationDataset !== null && uploadedDataset === null;
-  const shouldShowManualGenerationFallback =
-    generationStatus.kind === "idle" &&
-    (isDashboardGenerationTarget ||
-      (!ingestionJob && !ingestionJobQuery.isLoading && !ingestionJobQuery.isError));
   const handleIngestionRefresh = () => {
     ingestionJobQuery.refetch();
+  };
+
+  // 업로드 이후에는 한 시점에 패널 하나만 보여 다음 행동이 겹치지 않게 한다.
+  const renderAfterUploadPanel = () => {
+    if (generationStatus.kind === "success") {
+      return (
+        <div className={styles.generationPanel}>
+          <span className={styles.statusLabel}>생성 요청 완료</span>
+          <p>
+            도메인팩 초안 생성 파이프라인이 등록되었습니다.
+            {generationStatus.pipelineJobId
+              ? ` job ${generationStatus.pipelineJobId}`
+              : ""}
+            {generationStatus.status ? ` · ${generationStatus.status}` : ""}
+          </p>
+          <div className={styles.successActions}>
+            {pipelineReviewPath && (
+              <Button onClick={() => navigate(pipelineReviewPath)}>
+                {CTA_GO_REVIEW}
+              </Button>
+            )}
+            <Button
+              variant={pipelineReviewPath ? "secondary" : "primary"}
+              onClick={() => navigate(domainPacksPath)}
+            >
+              {CTA_GO_DOMAIN_PACK}
+            </Button>
+            <Button variant="ghost" onClick={handleReset}>
+              {CTA_UPLOAD_AGAIN}
+            </Button>
+          </div>
+        </div>
+      );
+    }
+
+    if (generationStatus.kind === "error") {
+      return (
+        <div className={styles.generationPanel}>
+          <span className={styles.statusLabel}>생성 요청 실패</span>
+          <p>{generationStatus.message}</p>
+          <div className={styles.successActions}>
+            <Button variant="secondary" onClick={handleReset}>
+              {CTA_UPLOAD_AGAIN}
+            </Button>
+            <Button
+              onClick={handleStartGeneration}
+              disabled={!canStartGeneration || isGenerationPending}
+            >
+              다시 생성 요청
+            </Button>
+          </div>
+        </div>
+      );
+    }
+
+    if (isGenerationPending) {
+      return (
+        <div className={styles.generationPanel}>
+          <span className={styles.statusLabel}>생성 요청 중</span>
+          <p>파이프라인 생성 요청을 보내고 있습니다. 잠시만 기다려 주세요.</p>
+          <Button
+            variant="secondary"
+            onClick={handleReset}
+            disabled={generationMutation.isPending}
+          >
+            {CTA_UPLOAD_AGAIN}
+          </Button>
+        </div>
+      );
+    }
+
+    if (isDashboardGenerationTarget) {
+      return (
+        <div className={styles.generationPanel}>
+          <p>
+            자동 파이프라인이 생성되지 않았거나 별도 재실행이 필요한 경우,
+            업로드한 데이터셋으로 도메인팩 초안 생성을 직접 요청할 수 있습니다.
+          </p>
+          <div className={styles.successActions}>
+            <Button variant="secondary" onClick={handleReset}>
+              {CTA_UPLOAD_AGAIN}
+            </Button>
+            <Button
+              onClick={handleStartGeneration}
+              disabled={!canStartGeneration || isGenerationPending}
+            >
+              {CTA_START_GENERATION}
+            </Button>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <PipelineJobStatusPanel
+        queryState={{
+          isLoading: ingestionJobQuery.isLoading,
+          isError: ingestionJobQuery.isError,
+          isFetching: ingestionJobQuery.isFetching,
+        }}
+        job={ingestionJob}
+        reviewPath={ingestionReviewPath}
+        domainPacksPath={domainPacksPath}
+        canStartGeneration={canStartGeneration}
+        isGenerationPending={isGenerationPending}
+        onStartGeneration={handleStartGeneration}
+        onRefresh={handleIngestionRefresh}
+        onReset={handleReset}
+        onNavigate={navigate}
+      />
+    );
   };
 
   return (
@@ -461,104 +571,7 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({
             </span>
           </div>
 
-          {!isDashboardGenerationTarget && (
-            <PipelineJobStatusPanel
-              queryState={{
-                isLoading: ingestionJobQuery.isLoading,
-                isError: ingestionJobQuery.isError,
-                isFetching: ingestionJobQuery.isFetching,
-              }}
-              job={ingestionJob}
-              reviewPath={ingestionReviewPath}
-              onRefresh={handleIngestionRefresh}
-              onReset={handleReset}
-              onNavigate={navigate}
-            />
-          )}
-
-          {shouldShowManualGenerationFallback && (
-            <div className={styles.generationPanel}>
-              <p>
-                자동 파이프라인이 생성되지 않았거나 별도 재실행이 필요한 경우,
-                업로드한 데이터셋으로 도메인팩 초안 생성을 직접 요청할 수
-                있습니다.
-              </p>
-              <div className={styles.successActions}>
-                <Button variant="secondary" onClick={handleReset}>
-                  {CTA_UPLOAD_AGAIN}
-                </Button>
-                <Button
-                  onClick={handleStartGeneration}
-                  disabled={!canStartGeneration || isGenerationPending}
-                >
-                  도메인팩 초안 생성 시작
-                </Button>
-              </div>
-            </div>
-          )}
-
-          {isGenerationPending && (
-            <div className={styles.generationPanel}>
-              <span className={styles.statusLabel}>생성 요청 중</span>
-              <p>
-                파이프라인 생성 요청을 보내고 있습니다. 잠시만 기다려 주세요.
-              </p>
-              <Button
-                variant="secondary"
-                onClick={handleReset}
-                disabled={generationMutation.isPending}
-              >
-                {CTA_UPLOAD_AGAIN}
-              </Button>
-            </div>
-          )}
-
-          {generationStatus.kind === "error" && (
-            <div className={styles.generationPanel}>
-              <span className={styles.statusLabel}>생성 요청 실패</span>
-              <p>{generationStatus.message}</p>
-              <div className={styles.successActions}>
-                <Button variant="secondary" onClick={handleReset}>
-                  {CTA_UPLOAD_AGAIN}
-                </Button>
-                <Button
-                  onClick={handleStartGeneration}
-                  disabled={!canStartGeneration || isGenerationPending}
-                >
-                  다시 생성 요청
-                </Button>
-              </div>
-            </div>
-          )}
-
-          {generationStatus.kind === "success" && (
-            <div className={styles.generationPanel}>
-              <span className={styles.statusLabel}>생성 요청 완료</span>
-              <p>
-                도메인팩 초안 생성 파이프라인이 등록되었습니다.
-                {generationStatus.pipelineJobId
-                  ? ` job ${generationStatus.pipelineJobId}`
-                  : ""}
-                {generationStatus.status ? ` · ${generationStatus.status}` : ""}
-              </p>
-              <div className={styles.successActions}>
-                {pipelineReviewPath && (
-                  <Button onClick={() => navigate(pipelineReviewPath)}>
-                    {CTA_GO_REVIEW}
-                  </Button>
-                )}
-                <Button
-                  variant={pipelineReviewPath ? "secondary" : "primary"}
-                  onClick={() => navigate(domainPacksPath)}
-                >
-                  {CTA_GO_DOMAIN_PACK}
-                </Button>
-                <Button variant="ghost" onClick={handleReset}>
-                  {CTA_UPLOAD_AGAIN}
-                </Button>
-              </div>
-            </div>
-          )}
+          {renderAfterUploadPanel()}
         </div>
       )}
     </div>

--- a/frontend/src/features/log-upload/ui/PipelineJobStatusPanel.test.tsx
+++ b/frontend/src/features/log-upload/ui/PipelineJobStatusPanel.test.tsx
@@ -1,0 +1,222 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import buttonStyles from "../../../shared/ui/button/button.module.css";
+import type { LatestPipelineJob } from "../api/pipelineJobStatusApi";
+
+import { PipelineJobStatusPanel } from "./PipelineJobStatusPanel";
+
+const onStartGeneration = vi.fn();
+const onRefresh = vi.fn();
+const onReset = vi.fn();
+const onNavigate = vi.fn();
+
+const baseJob: LatestPipelineJob = {
+  pipelineJobId: 77,
+  workspaceId: 1,
+  datasetId: 42,
+  domainPackId: null,
+  jobType: "INGESTION",
+  status: "RUNNING",
+  airflowDagId: "domain_pack_generation",
+  airflowRunId: "pipeline_job_77",
+  requestedAt: "2026-06-05T01:00:00Z",
+  startedAt: "2026-06-05T01:00:10Z",
+  finishedAt: null,
+  runningDurationSeconds: 95,
+  lastErrorMessage: null,
+};
+
+type PanelProps = Parameters<typeof PipelineJobStatusPanel>[0];
+
+function renderPanel(overrides: Partial<PanelProps> = {}) {
+  const props: PanelProps = {
+    queryState: { isLoading: false, isError: false, isFetching: false },
+    job: baseJob,
+    reviewPath: "/workspaces/1/pipeline-jobs/77/review",
+    domainPacksPath: "/workspaces/1/domain-packs",
+    canStartGeneration: true,
+    isGenerationPending: false,
+    onStartGeneration,
+    onRefresh,
+    onReset,
+    onNavigate,
+    ...overrides,
+  };
+  return render(<PipelineJobStatusPanel {...props} />);
+}
+
+function primaryButtons(container: HTMLElement) {
+  return container.querySelectorAll(`button.${buttonStyles.primary}`);
+}
+
+describe("PipelineJobStatusPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("업로드 직후 상태 확인 중에는 행동 버튼 없이 대기 안내만 보여준다", () => {
+    renderPanel({
+      queryState: { isLoading: true, isError: false, isFetching: true },
+      job: null,
+      reviewPath: null,
+    });
+
+    expect(screen.getByText("파이프라인 상태 확인 중")).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("상태 조회 실패 시 상태 새로고침을 primary CTA로 보여준다", () => {
+    const { container } = renderPanel({
+      queryState: { isLoading: false, isError: true, isFetching: false },
+      job: null,
+      reviewPath: null,
+    });
+
+    expect(screen.getByText("파이프라인 상태 조회 실패")).toBeInTheDocument();
+    expect(primaryButtons(container)).toHaveLength(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "상태 새로고침" }));
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "다른 파일 업로드" }));
+    expect(onReset).toHaveBeenCalledTimes(1);
+  });
+
+  it("자동 job이 아직 없으면 수동 생성 fallback을 함께 안내한다", () => {
+    const { container } = renderPanel({ job: null, reviewPath: null });
+
+    expect(screen.getByText("자동 파이프라인 대기 중")).toBeInTheDocument();
+    expect(
+      screen.getByText(/도메인팩 초안 생성을 직접 요청할 수 있습니다/),
+    ).toBeInTheDocument();
+    expect(primaryButtons(container)).toHaveLength(1);
+    expect(screen.getByRole("button", { name: "상태 새로고침" })).toHaveClass(
+      buttonStyles.primary,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "도메인팩 초안 생성 시작" }),
+    );
+    expect(onStartGeneration).toHaveBeenCalledTimes(1);
+  });
+
+  it("생성 요청이 불가능하면 fallback 버튼을 비활성화한다", () => {
+    renderPanel({ job: null, reviewPath: null, canStartGeneration: false });
+
+    expect(
+      screen.getByRole("button", { name: "도메인팩 초안 생성 시작" }),
+    ).toBeDisabled();
+  });
+
+  it("QUEUED job은 대기 안내와 상태 화면 이동 primary CTA를 보여준다", () => {
+    const { container } = renderPanel({
+      job: { ...baseJob, status: "QUEUED", runningDurationSeconds: null },
+    });
+
+    expect(screen.getByText("자동 파이프라인 대기 중")).toBeInTheDocument();
+    expect(screen.getByText(/대기열에 등록되어/)).toBeInTheDocument();
+    expect(primaryButtons(container)).toHaveLength(1);
+    expect(
+      screen.queryByRole("button", { name: "도메인팩 초안 생성 시작" }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "상태 화면으로 이동" }),
+    );
+    expect(onNavigate).toHaveBeenCalledWith(
+      "/workspaces/1/pipeline-jobs/77/review",
+    );
+  });
+
+  it("실행 중 상태는 job 정보와 상태 화면 이동 primary CTA를 보여준다", () => {
+    const { container } = renderPanel();
+
+    expect(screen.getByText("자동 파이프라인 실행 중")).toBeInTheDocument();
+    expect(screen.getByText(/job 77 · pipeline_job_77/)).toBeInTheDocument();
+    expect(screen.getByText("DAG domain_pack_generation")).toBeInTheDocument();
+    expect(screen.getByText("실행 1분 35초")).toBeInTheDocument();
+    expect(primaryButtons(container)).toHaveLength(1);
+    expect(
+      screen.getByRole("button", { name: "상태 화면으로 이동" }),
+    ).toHaveClass(buttonStyles.primary);
+  });
+
+  it.each([
+    ["WAITING_DOMAIN_CONFIRMATION", /후보 도메인을 선택해 주세요/],
+    ["WAITING_HUMAN_FEEDBACK", /애매한 경계를 확정해 주세요/],
+  ])("%s 상태는 검토 화면 이동을 primary CTA로 보여준다", (status, copy) => {
+    const { container } = renderPanel({ job: { ...baseJob, status } });
+
+    expect(screen.getByText("검토 대기 중")).toBeInTheDocument();
+    expect(screen.getByText(copy)).toBeInTheDocument();
+    expect(primaryButtons(container)).toHaveLength(1);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "검토 화면으로 이동" }),
+    );
+    expect(onNavigate).toHaveBeenCalledWith(
+      "/workspaces/1/pipeline-jobs/77/review",
+    );
+  });
+
+  it("완료 상태는 도메인팩 관리 이동을 primary CTA로 보여준다", () => {
+    const { container } = renderPanel({
+      job: { ...baseJob, status: "SUCCEEDED" },
+    });
+
+    expect(screen.getByText("파이프라인 완료")).toBeInTheDocument();
+    expect(primaryButtons(container)).toHaveLength(1);
+    expect(
+      screen.getByRole("button", { name: "도메인팩 관리로 이동" }),
+    ).toHaveClass(buttonStyles.primary);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "도메인팩 관리로 이동" }),
+    );
+    expect(onNavigate).toHaveBeenCalledWith("/workspaces/1/domain-packs");
+  });
+
+  it.each([
+    ["FAILED", "파이프라인 실패"],
+    ["CANCELLED", "파이프라인 취소됨"],
+  ])(
+    "%s 상태는 초안 생성 다시 요청을 primary CTA로 보여준다",
+    (status, label) => {
+      const { container } = renderPanel({ job: { ...baseJob, status } });
+
+      expect(screen.getByText(label)).toBeInTheDocument();
+      expect(
+        screen.getByText(/도메인팩 초안 생성을 다시 요청하거나/),
+      ).toBeInTheDocument();
+      expect(primaryButtons(container)).toHaveLength(1);
+
+      fireEvent.click(
+        screen.getByRole("button", { name: "도메인팩 초안 생성 다시 요청" }),
+      );
+      expect(onStartGeneration).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("실패 상태는 마지막 에러 메시지를 함께 보여준다", () => {
+    renderPanel({
+      job: {
+        ...baseJob,
+        status: "FAILED",
+        lastErrorMessage: "ingestion artifact 누락",
+      },
+    });
+
+    expect(screen.getByText("ingestion artifact 누락")).toBeInTheDocument();
+  });
+
+  it("새로고침 중에는 상태 새로고침 버튼을 비활성화한다", () => {
+    renderPanel({
+      queryState: { isLoading: false, isError: false, isFetching: true },
+    });
+
+    expect(
+      screen.getByRole("button", { name: "상태 새로고침" }),
+    ).toBeDisabled();
+  });
+});

--- a/frontend/src/features/log-upload/ui/PipelineJobStatusPanel.tsx
+++ b/frontend/src/features/log-upload/ui/PipelineJobStatusPanel.tsx
@@ -1,153 +1,216 @@
 import { Button } from "../../../shared/ui/button/Button";
+import {
+  CTA_GO_DOMAIN_PACK,
+  CTA_GO_REVIEW,
+  CTA_UPLOAD_AGAIN,
+} from "../../../shared/lib/ctaLabels";
 import type { LatestPipelineJob } from "../api/pipelineJobStatusApi";
+import {
+  derivePipelineJobViewState,
+  type PipelineJobViewState,
+} from "../model/useLatestDatasetPipelineJob";
 
 import styles from "./log-upload-form.module.css";
 
-interface PipelineStatusMeta {
-  title: string;
-  detail: string;
-  primaryActionLabel: string;
+export const CTA_START_GENERATION = "도메인팩 초안 생성 시작";
+
+const CTA_REFRESH_PIPELINE_STATUS = "상태 새로고침";
+const CTA_GO_PIPELINE_STATUS = "상태 화면으로 이동";
+const CTA_RETRY_GENERATION = "도메인팩 초안 생성 다시 요청";
+
+interface PanelAction {
+  readonly label: string;
+  readonly onClick: () => void;
+  readonly disabled?: boolean;
 }
 
 type PipelineJobStatusPanelProps = Readonly<{
   queryState: { isLoading: boolean; isError: boolean; isFetching: boolean };
   job: LatestPipelineJob | null;
   reviewPath: string | null;
+  domainPacksPath: string;
+  canStartGeneration: boolean;
+  isGenerationPending: boolean;
+  onStartGeneration: () => void;
   onRefresh: () => void;
   onReset: () => void;
   onNavigate: (path: string) => void;
 }>;
 
-export function PipelineJobStatusPanel({
-  queryState,
-  job,
-  reviewPath,
-  onRefresh,
-  onReset,
-  onNavigate,
-}: PipelineJobStatusPanelProps) {
-  const statusMeta = pipelineStatusMeta(job?.status);
-
-  if (queryState.isLoading) {
-    return (
-      <div className={styles.generationPanel}>
-        <span className={styles.statusLabel}>파이프라인 상태 확인 중</span>
-        <p>업로드 완료 후 자동 생성된 Airflow job을 찾고 있습니다.</p>
-      </div>
-    );
-  }
-
-  if (queryState.isError) {
-    return (
-      <div className={styles.generationPanel}>
-        <span className={styles.statusLabel}>파이프라인 상태 조회 실패</span>
-        <p>자동 생성된 Airflow job 상태를 불러오지 못했습니다.</p>
-        <div className={styles.successActions}>
-          <Button variant="secondary" onClick={onReset}>
-            다른 파일 업로드
-          </Button>
-          <Button onClick={onRefresh} disabled={queryState.isFetching}>
-            상태 새로고침
-          </Button>
-        </div>
-      </div>
-    );
-  }
-
-  if (!job) {
-    return (
-      <div className={styles.generationPanel}>
-        <span className={styles.statusLabel}>파이프라인 준비 중</span>
-        <p>업로드 완료 후 자동 생성될 Airflow job을 기다리고 있습니다.</p>
-        <div className={styles.successActions}>
-          <Button onClick={onRefresh} disabled={queryState.isFetching}>
-            상태 새로고침
-          </Button>
-        </div>
-      </div>
-    );
-  }
+export function PipelineJobStatusPanel(props: PipelineJobStatusPanelProps) {
+  const { queryState, job } = props;
+  const viewState = derivePipelineJobViewState(queryState, job);
+  const content = panelContent(viewState, job);
+  const actions = panelActions(viewState, props);
 
   return (
     <div className={styles.generationPanel}>
-      <span className={styles.statusLabel}>자동 생성 파이프라인</span>
-      <p>
-        {statusMeta.title} · job {job.pipelineJobId}
-        {job.airflowRunId ? ` · ${job.airflowRunId}` : ""}
-      </p>
-      <div className={styles.pipelineMeta}>
-        <span>DAG {job.airflowDagId ?? "-"}</span>
-        <span>
-          {job.runningDurationSeconds == null
-            ? statusMeta.detail
-            : `실행 ${formatDuration(job.runningDurationSeconds)}`}
-        </span>
-      </div>
-      {job.lastErrorMessage && <p>{job.lastErrorMessage}</p>}
-      <div className={styles.successActions}>
-        <Button variant="secondary" onClick={onReset}>
-          다른 파일 업로드
-        </Button>
-        {reviewPath && (
-          <Button onClick={() => onNavigate(reviewPath)}>
-            {statusMeta.primaryActionLabel}
-          </Button>
-        )}
-        <Button
-          variant={reviewPath ? "secondary" : "primary"}
-          onClick={onRefresh}
-          disabled={queryState.isFetching}
-        >
-          상태 새로고침
-        </Button>
-      </div>
+      <span className={styles.statusLabel}>{content.label}</span>
+      <p>{content.body}</p>
+      {job && viewState !== "uploaded" && (
+        <div className={styles.pipelineMeta}>
+          <span>
+            job {job.pipelineJobId}
+            {job.airflowRunId ? ` · ${job.airflowRunId}` : ""}
+          </span>
+          <span>DAG {job.airflowDagId ?? "-"}</span>
+          {job.runningDurationSeconds != null && (
+            <span>실행 {formatDuration(job.runningDurationSeconds)}</span>
+          )}
+        </div>
+      )}
+      {viewState === "failed" && job?.lastErrorMessage && (
+        <p>{job.lastErrorMessage}</p>
+      )}
+      {actions.length > 0 && (
+        <div className={styles.successActions}>
+          {actions.map((action, index) => (
+            <Button
+              key={action.label}
+              variant={index === 0 ? "primary" : "secondary"}
+              onClick={action.onClick}
+              disabled={action.disabled}
+            >
+              {action.label}
+            </Button>
+          ))}
+        </div>
+      )}
     </div>
   );
 }
 
-const DEFAULT_PIPELINE_STATUS_META: PipelineStatusMeta = {
-  title: "파이프라인이 실행 중입니다.",
-  detail: "Airflow가 상담 로그를 분석하고 있습니다.",
-  primaryActionLabel: "상태 화면으로 이동",
-};
+interface PanelContent {
+  readonly label: string;
+  readonly body: string;
+}
 
-const PIPELINE_STATUS_META: Record<string, PipelineStatusMeta> = {
-  WAITING_DOMAIN_CONFIRMATION: {
-    title: "도메인 확정 입력을 기다리고 있습니다.",
-    detail: "검토 화면에서 후보 도메인을 선택할 수 있습니다.",
-    primaryActionLabel: "검토 화면으로 이동",
-  },
-  WAITING_HUMAN_FEEDBACK: {
-    title: "클러스터 피드백 입력을 기다리고 있습니다.",
-    detail: "검토 화면에서 애매한 경계를 확정할 수 있습니다.",
-    primaryActionLabel: "검토 화면으로 이동",
-  },
-  SUCCEEDED: {
-    title: "파이프라인이 완료되었습니다.",
-    detail: "생성된 도메인팩 초안을 확인할 수 있습니다.",
-    primaryActionLabel: "상태 화면으로 이동",
-  },
-  FAILED: {
-    title: "파이프라인이 실패했습니다.",
-    detail: "실패 원인을 확인한 뒤 다시 시도할 수 있습니다.",
-    primaryActionLabel: "상태 화면으로 이동",
-  },
-  CANCELLED: {
-    title: "파이프라인이 취소되었습니다.",
-    detail: "필요하면 다시 업로드하거나 생성 요청을 다시 보낼 수 있습니다.",
-    primaryActionLabel: "상태 화면으로 이동",
-  },
-  QUEUED: {
-    title: "파이프라인이 대기열에 등록되었습니다.",
-    detail: "Airflow 실행 시작을 기다리고 있습니다.",
-    primaryActionLabel: "상태 화면으로 이동",
-  },
-};
+function panelContent(
+  viewState: PipelineJobViewState,
+  job: LatestPipelineJob | null,
+): PanelContent {
+  switch (viewState) {
+    case "uploaded":
+      return {
+        label: "파이프라인 상태 확인 중",
+        body: "업로드 완료 후 자동 생성된 Airflow job을 찾고 있습니다.",
+      };
+    case "status_unavailable":
+      return {
+        label: "파이프라인 상태 조회 실패",
+        body: "자동 생성된 Airflow job 상태를 불러오지 못했습니다. 상태 새로고침으로 다시 시도해 주세요.",
+      };
+    case "pipeline_pending":
+      return job
+        ? {
+            label: "자동 파이프라인 대기 중",
+            body: "파이프라인이 대기열에 등록되어 Airflow 실행 시작을 기다리고 있습니다.",
+          }
+        : {
+            label: "자동 파이프라인 대기 중",
+            body: "업로드 완료 후 자동 생성될 Airflow job을 기다리고 있습니다. 자동 파이프라인이 시작되지 않으면 같은 데이터셋으로 도메인팩 초안 생성을 직접 요청할 수 있습니다.",
+          };
+    case "running":
+      return {
+        label: "자동 파이프라인 실행 중",
+        body: "Airflow가 상담 로그를 분석하고 있습니다. 완료되면 검토 또는 도메인팩 확인으로 안내합니다.",
+      };
+    case "review_required":
+      return {
+        label: "검토 대기 중",
+        body:
+          job?.status === "WAITING_HUMAN_FEEDBACK"
+            ? "클러스터 피드백 입력을 기다리고 있습니다. 검토 화면에서 애매한 경계를 확정해 주세요."
+            : "도메인 확정 입력을 기다리고 있습니다. 검토 화면에서 후보 도메인을 선택해 주세요.",
+      };
+    case "succeeded":
+      return {
+        label: "파이프라인 완료",
+        body: "자동 파이프라인이 완료되었습니다. 생성된 도메인팩 초안을 도메인팩 관리에서 확인해 주세요.",
+      };
+    case "failed":
+      return {
+        label: "파이프라인 실패",
+        body: "자동 파이프라인이 실패했습니다. 같은 데이터셋으로 도메인팩 초안 생성을 다시 요청하거나 다른 파일을 업로드할 수 있습니다.",
+      };
+    case "cancelled":
+      return {
+        label: "파이프라인 취소됨",
+        body: "자동 파이프라인이 취소되었습니다. 같은 데이터셋으로 도메인팩 초안 생성을 다시 요청하거나 다른 파일을 업로드할 수 있습니다.",
+      };
+  }
+}
 
-function pipelineStatusMeta(status?: string): PipelineStatusMeta {
-  return status
-    ? (PIPELINE_STATUS_META[status] ?? DEFAULT_PIPELINE_STATUS_META)
-    : DEFAULT_PIPELINE_STATUS_META;
+function panelActions(
+  viewState: PipelineJobViewState,
+  props: PipelineJobStatusPanelProps,
+): PanelAction[] {
+  const {
+    queryState,
+    job,
+    reviewPath,
+    domainPacksPath,
+    canStartGeneration,
+    isGenerationPending,
+    onStartGeneration,
+    onRefresh,
+    onReset,
+    onNavigate,
+  } = props;
+
+  const refresh: PanelAction = {
+    label: CTA_REFRESH_PIPELINE_STATUS,
+    onClick: onRefresh,
+    disabled: queryState.isFetching,
+  };
+  const uploadAgain: PanelAction = {
+    label: CTA_UPLOAD_AGAIN,
+    onClick: onReset,
+  };
+  const goStatus: PanelAction | null = reviewPath
+    ? { label: CTA_GO_PIPELINE_STATUS, onClick: () => onNavigate(reviewPath) }
+    : null;
+  const goReview: PanelAction | null = reviewPath
+    ? { label: CTA_GO_REVIEW, onClick: () => onNavigate(reviewPath) }
+    : null;
+  const goDomainPacks: PanelAction = {
+    label: CTA_GO_DOMAIN_PACK,
+    onClick: () => onNavigate(domainPacksPath),
+  };
+  const startGeneration: PanelAction = {
+    label: CTA_START_GENERATION,
+    onClick: onStartGeneration,
+    disabled: !canStartGeneration || isGenerationPending,
+  };
+  const retryGeneration: PanelAction = {
+    label: CTA_RETRY_GENERATION,
+    onClick: onStartGeneration,
+    disabled: !canStartGeneration || isGenerationPending,
+  };
+
+  switch (viewState) {
+    case "uploaded":
+      return [];
+    case "status_unavailable":
+      return [refresh, uploadAgain];
+    case "pipeline_pending":
+      return job
+        ? compact([goStatus, refresh, uploadAgain])
+        : [refresh, startGeneration, uploadAgain];
+    case "running":
+      return compact([goStatus, refresh, uploadAgain]);
+    case "review_required":
+      return compact([goReview, refresh, uploadAgain]);
+    case "succeeded":
+      return compact([goDomainPacks, goStatus, uploadAgain]);
+    case "failed":
+    case "cancelled":
+      return compact([retryGeneration, goStatus, uploadAgain]);
+  }
+}
+
+function compact(actions: Array<PanelAction | null>): PanelAction[] {
+  return actions.filter((action): action is PanelAction => action !== null);
 }
 
 function formatDuration(seconds: number): string {


### PR DESCRIPTION
Closes #785

## 변경 사항

- 이슈 785 요구사항과 acceptance criteria를 `.agent/specs/785.md`에 정리했습니다.
- `useLatestDatasetPipelineJob`에 `derivePipelineJobViewState` pure 함수를 추가해 업로드 후 화면을 `uploaded`/`status_unavailable`/`pipeline_pending`/`running`/`review_required`/`succeeded`/`failed`/`cancelled` view state로 환원했습니다.
- `PipelineJobStatusPanel`을 view state 기반 단일 패널로 재구성해 상태마다 primary CTA를 정확히 1개로 고정했습니다. 기존에는 `reviewPath` 유무에 따라 상태 새로고침 버튼의 variant가 뒤바뀌었습니다.
- 자동 파이프라인 `FAILED`/`CANCELLED` 상태에서 "도메인팩 초안 생성 다시 요청" 복구 CTA를 제공해, "다시 시도할 수 있습니다" 문구와 실제 가능한 행동을 일치시켰습니다. 수동 생성 fallback은 자동 job이 없을 때 같은 패널 안에서 관계 설명과 함께 노출됩니다.
- `LogUploadForm`이 업로드 이후 한 시점에 패널 하나만 렌더링하도록 정리했습니다. 수동 생성 흐름(요청 중/실패/완료)이 활성화되면 자동 파이프라인 패널을 대체하고, 기존 dashboard 진입(`?datasetId=`) 흐름은 유지합니다.
- view state 매핑 단위 테스트, 패널 상태별 렌더링·primary CTA 단일성 테스트(신규 `PipelineJobStatusPanel.test.tsx`), 폼 레벨 실패 복구·배타 렌더링 테스트를 추가했고, 바뀐 패널 라벨에 맞춰 E2E 문구 단언을 갱신했습니다.

## 검증

- `pnpm --dir frontend exec vp test --run src/features/log-upload` (6 files, 78 tests)
- `pnpm --dir frontend exec vp test --run` (284 files, 2213 tests)
- `pnpm --dir frontend exec tsc -b`
- `pnpm --dir frontend exec eslint src/features/log-upload e2e/upload-domain-pack-generation.spec.ts e2e/workspace-core.spec.ts`
- `pnpm --dir frontend build` (기존 chunk-size warning만 표시)
- 로컬 Playwright E2E는 3000 포트를 점유한 별개 서버를 `reuseExistingServer`가 재사용해 실행하지 못했습니다. 바뀐 라벨은 동일 문자열을 단위 테스트로 검증했고, mocked E2E는 CI에서 확인합니다.

## 참고

- 구현 전 issue 785, `LogUploadForm`/`PipelineJobStatusPanel`/`useLatestDatasetPipelineJob`과 기존 테스트, backend `PipelineJob` 상태 상수, `shared/lib/ctaLabels.ts`, 영향받는 E2E 시나리오, frontend FSD/test rules를 확인했습니다.
- spec review 2회 수행: issue fidelity 관점에서 view state 명세·primary CTA 단일성·자동/수동 관계·문구-행동 일치·상태별 테스트 요구를 매핑했고, repository compliance 관점에서 파일명/브랜치/FSD 경계/참조 경로를 확인했습니다.
- self-review 3회 수행: Round 1에서 AC 매핑과 dashboard 모드·datasetId 부재·reviewPath 부재 엣지를 확인했고, Round 2에서 FSD import 방향, generated client·query 계약 불변, CTA 라벨 단일 출처화(미사용 export 축소 포함)를 수정·확인했으며, Round 3에서 primary CTA 단언 방식, 구버전에서 실패하는 FAILED 복구 회귀 테스트, 의도 외 파일·포맷 churn 제거를 확인했습니다.
- `pnpm run lint:frontend`는 이번 변경과 무관한 기존 frontend ESLint baseline 45건으로 실패합니다(변경 파일 대상 ESLint는 통과). hook 실패가 repository-wide baseline 때문이라 변경 파일 대상 검증을 근거로 hook을 우회해 커밋했습니다.