### PR TITLE
feat(frontend): 시뮬레이션 검증 대상 맥락 유지를 보장

### DIFF
--- a/.agent/specs/784.md
+++ b/.agent/specs/784.md
@@ -1,0 +1,176 @@
+# Frontend Spec: 시뮬레이션 검증 대상 워크플로우 맥락 유지
+
+## Goal
+
+시뮬레이션 화면이 URL query 또는 route state로 전달된 `packId`, `versionId`, `workflowId`를 검증 대상 맥락으로 유지하고, 피드백과 개선 후보 생성 흐름에서 대상 워크플로우를 명확히 연결한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["워크플로우 상세 또는 대시보드 추천 액션"] --> B["시뮬레이션 이동"]
+    B --> C{"packId/versionId/workflowId 존재?"}
+    C -->|Yes| D["상단 검증 대상 표시"]
+    D --> E["시작 workflow 기본 선택"]
+    E --> F["시뮬레이션 세션 생성"]
+    F --> G["피드백 작성"]
+    G --> H["개선 후보 생성 시 workflow target 연결"]
+    C -->|No| I["기존 workspace 기본 시뮬레이션"]
+    I --> F
+```
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+|------|-------|-------|----------|
+| 시뮬레이션 진입 | `feedbackStatus`, `candidateStatus` 중심 query만 처리 | `packId`, `versionId`, `workflowId` query와 route state를 함께 처리 | 검증 대상 워크플로우를 URL/state에서 해석 |
+| 상단 맥락 | 페이지 제목과 선택 workflow만 표시 | pack/version/workflow 대상 요약 표시 | 대상이 있으면 상단에 검증 대상, 코드, 버전 정보를 노출 |
+| workflow 상세 진입 | 상세 화면에서 시뮬레이션 직접 진입 없음 | 현재 workflow 맥락을 가진 시뮬레이션 링크 제공 | 상세 검증 흐름 연결 |
+| 대시보드 추천 액션 | backend 제공 `targetPath`를 그대로 링크 | workflow 상세 추천은 시뮬레이션 URL로 맥락을 함께 전달 | 추천에서 검증 맥락 보존 |
+| 개선 후보 생성 | feedback id만으로 후보 생성 | 선택/매칭 workflow 정보를 target payload로 전달 | 후보가 workflow 개선으로 연결되도록 target 정보 포함 |
+| 기본 흐름 | workspace 시뮬레이션은 자동 매칭 가능 | 대상 맥락이 없어도 기존 자동 매칭 유지 | 기존 진입/생성/피드백 플로우 보존 |
+
+## Component Tree
+
+```text
+WorkspaceSimulationPage
+├─ PageHeader
+│    └─ VerificationTargetBanner
+├─ CreateSimulationPanel
+│    └─ StartWorkflowSelect
+├─ SessionPane
+├─ ChatPane
+└─ StatePane
+     ├─ RuntimeState
+     ├─ FeedbackPanel
+     └─ ImprovementCandidatePanel
+
+WorkflowDraftReadPage
+└─ HeaderActions
+     └─ SimulationLink
+
+WorkspaceDashboardPage
+└─ ActionRecommendationsPanel
+     └─ ActionRecommendationCard
+```
+
+## API Integration
+
+### Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/v1/workspaces/:workspaceId/simulation/sessions` | 선택 workflow 기반 시뮬레이션 세션 생성 |
+| POST | `/api/v1/workspaces/:workspaceId/simulation/improvement-candidates/from-feedback/:feedbackId` | feedback에서 개선 후보 생성, workflow target payload 전달 |
+
+### Existing Contract Use
+
+- `frontend/src/features/simulation/api/simulationApi.ts`의 `CreateSimulationSessionPayload.workflowDefinitionId`를 유지한다.
+- `CreateSimulationImprovementCandidatePayload.targetElementType`, `targetElementId`, `targetElementKey`, `beforeSummary`, `afterSummary`를 사용해 workflow 후보 맥락을 전달한다.
+- generated API 변경 또는 backend schema 변경은 포함하지 않는다.
+
+## Data Flow
+
+```text
+WorkflowDraftReadPage
+  -> buildWorkspaceSimulationPath(wsId, { packId, versionId, workflowId })
+  -> WorkspaceSimulationPage query/state parsing
+  -> useListAllWorkspaceWorkflows entries lookup
+  -> selected verification target banner + default workflow select
+  -> createSession(workflowDefinitionId)
+  -> createImprovementCandidate(feedbackId, workflow target payload)
+```
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `frontend/src/shared/lib/demoRoutes.ts` | modify | 시뮬레이션 경로에 검증 대상 query builder 추가 |
+| `frontend/src/shared/lib/demoRoutes.test.ts` | modify | query 생성 회귀 테스트 |
+| `frontend/src/pages/workspace/ui/WorkspaceSimulationPage.tsx` | modify | query/state 해석, 대상 배너, 기본 workflow 선택, 후보 target payload |
+| `frontend/src/pages/workspace/ui/simulation/workspace-simulation-page.module.css` | modify | 대상 배너와 반응형 스타일 |
+| `frontend/src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx` | modify | URL query 기반 맥락 표시와 후보 payload 테스트 |
+| `frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx` | modify | workflow 상세에서 시뮬레이션 링크 추가 |
+| `frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.test.tsx` | modify | 상세 링크 href 테스트 |
+| `frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx` | modify | workflow 추천 링크를 시뮬레이션 맥락 URL로 보강 |
+| `frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx` | modify | 추천 액션 href 테스트 |
+
+## State Management
+
+### URL/Route State
+
+- Query: `packId`, `versionId`, `workflowId`
+- Route state: `{ simulationTarget: { packId, versionId, workflowId } }`
+- 둘 다 있으면 query를 우선한다. query는 새로고침과 공유 URL에 남기기 위함이다.
+
+### Client State
+
+- 기존 `workflowDefinitionId` state는 유지한다.
+- 검증 대상 workflow가 현재 workspace workflow 목록에서 확인되면 `workflowDefinitionId` 기본값으로 동기화한다.
+- 사용자가 직접 workflow select를 변경한 경우 해당 선택을 우선한다.
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+|------|------|------|------|
+| 유틸 테스트 | path builder query 검증 | Vitest | `demoRoutes.test.ts` |
+| 페이지 테스트 | URL query 기반 대상 표시와 세션 생성 payload | RTL + Vitest | `WorkspaceSimulationPage.test.tsx` |
+| 페이지 테스트 | workflow 상세 시뮬레이션 링크 | RTL + Vitest | `WorkflowDraftReadPage.test.tsx` |
+| 페이지 테스트 | 대시보드 추천 액션 링크 | RTL + Vitest | `WorkspaceDashboardPage.test.tsx` |
+
+### Happy Path
+
+| # | 시나리오 | 사전 조건 | 조작 | 기대 결과 |
+|---|---------|---------|------|----------|
+| 1 | 상세에서 시뮬레이션 이동 | workflow 상세 URL에 `versionId` 존재 | 검증 버튼 확인 | `/simulation?packId=...&versionId=...&workflowId=...` 링크 표시 |
+| 2 | query 대상 표시 | workflow 목록에서 target workflow 조회 가능 | 시뮬레이션 진입 | 상단에 pack/version/workflow 대상 표시, 시작 workflow 기본 선택 |
+| 3 | route state 대상 표시 | 상세 화면 Link state로 target 전달 | 시뮬레이션 진입 | query가 없어도 상단 대상과 시작 workflow 기본 선택 |
+| 4 | 개선 후보 생성 | target workflow가 선택됨 | 피드백에서 후보 생성 클릭 | `targetElementType: "WORKFLOW"`, workflow id/key가 payload에 포함 |
+
+### Error & Edge Cases
+
+| # | 시나리오 | 조작 | 기대 결과 |
+|---|---------|------|----------|
+| 1 | 대상 query 없음 | `/simulation` 진입 | 기존 자동 매칭 기본 흐름 유지 |
+| 2 | target workflow를 목록에서 찾지 못함 | 알 수 없는 `workflowId` query | 대상 id를 표시하되 workflow select는 자동 매칭 유지 |
+| 3 | user가 workflow select 변경 | query target과 다른 workflow 선택 | 사용자가 선택한 workflow로 세션 생성 |
+| 4 | user가 자동 매칭 선택 | query target 기본값을 자동 매칭으로 변경 | target workflow를 payload에 강제하지 않음 |
+
+## Non-goals
+
+- backend API 또는 DB schema 변경은 하지 않는다.
+- generated OpenAPI client 재생성은 하지 않는다.
+- 기존 세션 목록을 target별로 서버 필터링하지 않는다.
+- 대시보드 추천 액션 backend 응답 구조를 변경하지 않는다.
+
+## Implementation Quality Brief
+
+- 기존 패턴: `buildWorkspaceSimulationPath`, `useListAllWorkspaceWorkflows`, `CreateSimulationSessionPayload.workflowDefinitionId`, `CreateSimulationImprovementCandidatePayload`를 재사용한다.
+- 최소 diff: URL builder와 세 페이지의 링크/표시/전달 로직만 변경한다.
+- 위험 표면: FSD import 방향, 기존 자동 매칭 유지, query 변경 시 사용자 선택 덮어쓰기, 후보 payload가 backend 허용 필드와 맞는지 여부, 모바일 레이아웃 overflow.
+- 검증 명령: 관련 Vitest 파일과 frontend lint/type/build 범위에서 가능한 명령을 실행한다.
+
+## Self-review Passes
+
+### Pass 1: Issue Fidelity
+
+- Acceptance Criteria의 `packId`, `versionId`, `workflowId` 수신, 상단 표시, 상세/대시보드 진입 보존, 후보 workflow 연결, 무맥락 기본 흐름 보존을 모두 spec에 매핑했다.
+- 이슈에 없는 backend/schema 변경은 non-goal로 제한했다.
+- 대시보드 추천 액션의 target 정보가 backend에서 항상 충분하지 않을 수 있으므로, 확인 가능한 workflow detail path에서만 simulation target query를 보강하는 것으로 범위를 명확히 했다.
+
+### Pass 2: Ostone Compliance
+
+- Frontend 템플릿을 사용했고 파일명은 `.agent/specs/784.md`다.
+- final branch는 `feature/784-simulation-workflow-context`다.
+- 참조한 production/test 파일 경로는 repository에서 존재를 확인했다.
+- FSD 방향은 pages -> features/entities/shared, shared 내부 유틸만 유지한다.
+
+### Pass 3: Regression Review
+
+- query target 자동 선택 후 사용자가 `자동 매칭`으로 되돌리는 경우 target workflow id를 session 생성 payload에 강제하지 않도록 했다.
+- route state만 전달된 진입도 별도 테스트로 고정했다.
+- workflow id만 fallback으로 찾은 경우 pack/version까지 확인된 것으로 표시하지 않도록 banner badge를 보수적으로 유지했다.

--- a/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.test.tsx
@@ -1,13 +1,7 @@
 import { useState } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import {
-  MemoryRouter,
-  Outlet,
-  Route,
-  Routes,
-  useLocation,
-} from "react-router-dom";
+import { MemoryRouter, Outlet, Route, Routes, useLocation } from "react-router-dom";
 import { ApiRequestError } from "@/shared/api";
 import { WorkflowDraftReadPage } from "./WorkflowDraftReadPage";
 
@@ -19,18 +13,13 @@ const mockGetWorkflowBottleneckAnalysis = vi.fn();
 const mockToastSuccess = vi.fn();
 const mockToastError = vi.fn();
 vi.mock("@/entities/workflow", () => ({
-  useGetWorkflowDefinition: (...args: unknown[]) =>
-    mockUseGetWorkflowDefinition(...args),
+  useGetWorkflowDefinition: (...args: unknown[]) => mockUseGetWorkflowDefinition(...args),
 }));
 
 vi.mock("@/features/domain-pack-summary-read", () => ({
   usePackDetail: (...args: unknown[]) => mockUsePackDetail(...args),
   formatLifecycleStatus: (status?: string | null) =>
-    status === "PUBLISHED"
-      ? "운영 가능"
-      : status === "DRAFT"
-        ? "검토 중"
-        : "상태 없음",
+    status === "PUBLISHED" ? "운영 가능" : status === "DRAFT" ? "검토 중" : "상태 없음",
   VersionSafetyBanner: () => null,
 }));
 
@@ -45,11 +34,7 @@ vi.mock("@/features/update-workflow", () => ({
   InlineWorkflowEditor: vi.fn(({ workflow, onClose, onDirtyChange }) => (
     <div data-testid="inline-editor">
       editing {workflow.workflowCode}
-      <button
-        type="button"
-        data-testid="editor-dirty"
-        onClick={() => onDirtyChange(true)}
-      >
+      <button type="button" data-testid="editor-dirty" onClick={() => onDirtyChange(true)}>
         dirty
       </button>
       <button type="button" data-testid="editor-close" onClick={onClose}>
@@ -67,8 +52,7 @@ vi.mock("@/features/workflow-viewer/ui/GraphViewer", () => ({
 
 vi.mock("@/features/intent-revision-draft", () => ({
   intentRevisionDraftApi: {
-    createRevisionDraft: (...args: unknown[]) =>
-      mockCreateRevisionDraft(...args),
+    createRevisionDraft: (...args: unknown[]) => mockCreateRevisionDraft(...args),
   },
 }));
 vi.mock(
@@ -86,9 +70,7 @@ vi.mock("sonner", () => ({
 
 function LocationProbe() {
   const location = useLocation();
-  return (
-    <div data-testid="location">{`${location.pathname}${location.search}`}</div>
-  );
+  return <div data-testid="location">{`${location.pathname}${location.search}`}</div>;
 }
 
 function ShellHost() {
@@ -98,9 +80,7 @@ function ShellHost() {
   return (
     <>
       <div data-testid="crumbs">
-        {crumbs
-          .map((crumb) => (typeof crumb === "string" ? crumb : crumb.label))
-          .join(" / ")}
+        {crumbs.map((crumb) => (typeof crumb === "string" ? crumb : crumb.label)).join(" / ")}
       </div>
       <div data-testid="shell-topbar">{topbarRight}</div>
       <Outlet context={{ setCrumbs, setTopbarRight, workspace: null }} />
@@ -120,10 +100,7 @@ function renderPage(path: string, state?: unknown) {
       ]}
     >
       <Routes>
-        <Route
-          path="/workspaces/:workspaceId/domain-packs/:packId"
-          element={<ShellHost />}
-        >
+        <Route path="/workspaces/:workspaceId/domain-packs/:packId" element={<ShellHost />}>
           <Route
             path="workflows/:workflowId?"
             element={
@@ -165,9 +142,7 @@ beforeEach(() => {
     policyHitTop: [],
     riskHitTop: [],
     humanInterventionPoints: [],
-    improvementHints: [
-      "선택 기간에 개선 우선순위를 판단할 병목 신호가 아직 충분하지 않습니다.",
-    ],
+    improvementHints: ["선택 기간에 개선 우선순위를 판단할 병목 신호가 아직 충분하지 않습니다."],
   });
   mockUsePackDetail.mockReturnValue({
     data: {
@@ -186,9 +161,7 @@ describe("WorkflowDraftReadPage", () => {
   it("유효하지 않은 URL 파라미터는 에러 메시지를 보여준다", () => {
     mockUseGetWorkflowDefinition.mockReturnValue({ isLoading: false });
     renderPage("/workspaces/abc/domain-packs/2/workflows?versionId=3");
-    expect(screen.getByRole("alert")).toHaveTextContent(
-      "잘못된 URL 파라미터입니다.",
-    );
+    expect(screen.getByRole("alert")).toHaveTextContent("잘못된 URL 파라미터입니다.");
   });
 
   it("workflowId가 없으면 좌측 사이드바에서 선택하라는 안내를 표시한다", () => {
@@ -232,13 +205,13 @@ describe("WorkflowDraftReadPage", () => {
       },
     });
     renderPage("/workspaces/1/domain-packs/2/workflows/10?versionId=3");
-    expect(screen.getByTestId("workflow-detail-title")).toHaveTextContent(
-      "환불 처리",
-    );
+    expect(screen.getByTestId("workflow-detail-title")).toHaveTextContent("환불 처리");
     expect(screen.queryByText("refund.standard")).not.toBeInTheDocument();
     expect(screen.getByText("노드 2개")).toBeInTheDocument();
-    expect(screen.getByTestId("graph-viewer")).toHaveTextContent(
-      "graph nodes: 2",
+    expect(screen.getByTestId("graph-viewer")).toHaveTextContent("graph nodes: 2");
+    expect(screen.getByTestId("workflow-simulation-link")).toHaveAttribute(
+      "href",
+      "/workspaces/1/simulation?packId=2&versionId=3&workflowId=10",
     );
   });
 
@@ -252,9 +225,7 @@ describe("WorkflowDraftReadPage", () => {
       completedCount: 1,
       failedCount: 1,
       runningCount: 1,
-      transitions: [
-        { stateFrom: "collect_slots", stateTo: "verify_policy", passCount: 2 },
-      ],
+      transitions: [{ stateFrom: "collect_slots", stateTo: "verify_policy", passCount: 2 }],
       longestDwellState: {
         stateName: "collect_slots",
         metricValue: 420,
@@ -285,9 +256,7 @@ describe("WorkflowDraftReadPage", () => {
           description: "상담사 개입 action이 자주 발생한 state",
         },
       ],
-      improvementHints: [
-        "order_id slot 수집 문구와 검증 규칙을 우선 점검하세요.",
-      ],
+      improvementHints: ["order_id slot 수집 문구와 검증 규칙을 우선 점검하세요."],
     });
     mockUseGetWorkflowDefinition.mockReturnValue({
       isLoading: false,
@@ -302,9 +271,9 @@ describe("WorkflowDraftReadPage", () => {
 
     renderPage("/workspaces/1/domain-packs/2/workflows/10?versionId=3");
 
-    expect(
-      await screen.findByTestId("workflow-analysis-panel"),
-    ).toHaveTextContent("운영 실행 병목 분석");
+    expect(await screen.findByTestId("workflow-analysis-panel")).toHaveTextContent(
+      "운영 실행 병목 분석",
+    );
     expect(screen.getByText("전체 실행")).toBeInTheDocument();
     expect(screen.getAllByText("collect_slots").length).toBeGreaterThan(0);
     expect(screen.getAllByText("verify_policy").length).toBeGreaterThan(0);
@@ -315,9 +284,7 @@ describe("WorkflowDraftReadPage", () => {
   });
 
   it("운영 실행 병목 분석 로딩 상태를 표시한다", async () => {
-    mockGetWorkflowBottleneckAnalysis.mockReturnValueOnce(
-      new Promise(() => undefined),
-    );
+    mockGetWorkflowBottleneckAnalysis.mockReturnValueOnce(new Promise(() => undefined));
     mockUseGetWorkflowDefinition.mockReturnValue({
       isLoading: false,
       isError: false,
@@ -331,9 +298,9 @@ describe("WorkflowDraftReadPage", () => {
 
     renderPage("/workspaces/1/domain-packs/2/workflows/10?versionId=3");
 
-    expect(
-      await screen.findByTestId("workflow-analysis-loading"),
-    ).toHaveTextContent("워크플로우 병목 분석을 불러오는 중입니다.");
+    expect(await screen.findByTestId("workflow-analysis-loading")).toHaveTextContent(
+      "워크플로우 병목 분석을 불러오는 중입니다.",
+    );
   });
 
   it("운영 실행 병목 분석 데이터가 없으면 빈 상태를 표시한다", async () => {
@@ -350,9 +317,9 @@ describe("WorkflowDraftReadPage", () => {
 
     renderPage("/workspaces/1/domain-packs/2/workflows/10?versionId=3");
 
-    expect(
-      await screen.findByTestId("workflow-analysis-empty"),
-    ).toHaveTextContent("선택 기간에 분석할 운영 실행 로그가 없습니다.");
+    expect(await screen.findByTestId("workflow-analysis-empty")).toHaveTextContent(
+      "선택 기간에 분석할 운영 실행 로그가 없습니다.",
+    );
   });
 
   it("운영 실행 병목 분석 실패 상태에서 다시 시도할 수 있다", async () => {
@@ -397,21 +364,17 @@ describe("WorkflowDraftReadPage", () => {
 
     renderPage("/workspaces/1/domain-packs/2/workflows/10?versionId=3");
 
-    expect(
-      await screen.findByTestId("workflow-analysis-error"),
-    ).toHaveTextContent("워크플로우 병목 분석을 불러오지 못했습니다.");
-    expect(mockToastError).toHaveBeenCalledWith(
+    expect(await screen.findByTestId("workflow-analysis-error")).toHaveTextContent(
       "워크플로우 병목 분석을 불러오지 못했습니다.",
     );
+    expect(mockToastError).toHaveBeenCalledWith("워크플로우 병목 분석을 불러오지 못했습니다.");
 
     fireEvent.click(screen.getByRole("button", { name: "다시 시도" }));
 
-    expect(
-      await screen.findByTestId("workflow-analysis-panel"),
-    ).toHaveTextContent("1분 15초 평균 체류");
-    expect(
-      screen.getByText("멈춘 실행이 관측되지 않았습니다."),
-    ).toBeInTheDocument();
+    expect(await screen.findByTestId("workflow-analysis-panel")).toHaveTextContent(
+      "1분 15초 평균 체류",
+    );
+    expect(screen.getByText("멈춘 실행이 관측되지 않았습니다.")).toBeInTheDocument();
     expect(mockGetWorkflowBottleneckAnalysis).toHaveBeenCalledTimes(2);
   });
 
@@ -454,9 +417,7 @@ describe("WorkflowDraftReadPage", () => {
     renderPage("/workspaces/1/domain-packs/2/workflows/10?versionId=3");
     expect(screen.queryByTestId("inline-editor")).not.toBeInTheDocument();
     fireEvent.click(screen.getByTestId("edit-toggle"));
-    expect(screen.getByTestId("inline-editor")).toHaveTextContent(
-      "editing refund.standard",
-    );
+    expect(screen.getByTestId("inline-editor")).toHaveTextContent("editing refund.standard");
     expect(mockCreateRevisionDraft).not.toHaveBeenCalled();
   });
 
@@ -464,9 +425,7 @@ describe("WorkflowDraftReadPage", () => {
     mockUsePackDetail.mockReturnValue({
       data: {
         name: "CS Pack",
-        versions: [
-          { versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" },
-        ],
+        versions: [{ versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" }],
       },
       refetch: vi.fn().mockResolvedValue({
         data: {
@@ -507,9 +466,7 @@ describe("WorkflowDraftReadPage", () => {
     mockUsePackDetail.mockReturnValue({
       data: {
         name: "CS Pack",
-        versions: [
-          { versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" },
-        ],
+        versions: [{ versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" }],
       },
       refetch: vi.fn(),
     });
@@ -540,9 +497,7 @@ describe("WorkflowDraftReadPage", () => {
     mockUsePackDetail.mockReturnValue({
       data: {
         name: "CS Pack",
-        versions: [
-          { versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" },
-        ],
+        versions: [{ versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" }],
       },
       refetch: vi.fn().mockResolvedValue({
         data: {
@@ -585,9 +540,7 @@ describe("WorkflowDraftReadPage", () => {
     mockUsePackDetail.mockReturnValue({
       data: {
         name: "CS Pack",
-        versions: [
-          { versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" },
-        ],
+        versions: [{ versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" }],
       },
       refetch: vi.fn().mockResolvedValue({
         data: {
@@ -618,12 +571,8 @@ describe("WorkflowDraftReadPage", () => {
     renderPage("/workspaces/1/domain-packs/2/workflows/10?versionId=3");
     fireEvent.click(screen.getByTestId("edit-toggle"));
 
-    expect(
-      await screen.findByText("진행 중인 검토본이 있습니다"),
-    ).toBeInTheDocument();
-    fireEvent.click(
-      screen.getByRole("button", { name: "기존 검토본으로 이동" }),
-    );
+    expect(await screen.findByText("진행 중인 검토본이 있습니다")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "기존 검토본으로 이동" }));
     await waitFor(() =>
       expect(screen.getByTestId("location")).toHaveTextContent(
         "/workspaces/1/domain-packs/2/workflows/55?versionId=5",
@@ -635,15 +584,11 @@ describe("WorkflowDraftReadPage", () => {
     mockUsePackDetail.mockReturnValue({
       data: {
         name: "CS Pack",
-        versions: [
-          { versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" },
-        ],
+        versions: [{ versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" }],
       },
       refetch: vi.fn().mockResolvedValue({
         data: {
-          versions: [
-            { versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" },
-          ],
+          versions: [{ versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" }],
         },
       }),
     });
@@ -669,18 +614,14 @@ describe("WorkflowDraftReadPage", () => {
         "진행 중인 검토본을 확인할 수 없습니다. 도메인팩 화면에서 상태를 확인해 주세요.",
       ),
     );
-    expect(
-      screen.queryByText("진행 중인 검토본이 있습니다"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText("진행 중인 검토본이 있습니다")).not.toBeInTheDocument();
   });
 
   it("기존 DRAFT 충돌 후 같은 workflow를 찾지 못하면 이동 dialog를 열지 않는다", async () => {
     mockUsePackDetail.mockReturnValue({
       data: {
         name: "CS Pack",
-        versions: [
-          { versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" },
-        ],
+        versions: [{ versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" }],
       },
       refetch: vi.fn().mockResolvedValue({
         data: {
@@ -716,22 +657,16 @@ describe("WorkflowDraftReadPage", () => {
         "기존 검토본에서 같은 워크플로우를 찾지 못했습니다.",
       ),
     );
-    expect(
-      screen.queryByText("진행 중인 검토본이 있습니다"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText("진행 중인 검토본이 있습니다")).not.toBeInTheDocument();
   });
 
   it("기존 DRAFT 충돌 후 pack refetch가 실패하면 에러를 안내하고 dialog를 열지 않는다", async () => {
-    const consoleError = vi
-      .spyOn(console, "error")
-      .mockImplementation(() => undefined);
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
     try {
       mockUsePackDetail.mockReturnValue({
         data: {
           name: "CS Pack",
-          versions: [
-            { versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" },
-          ],
+          versions: [{ versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" }],
         },
         refetch: vi.fn().mockRejectedValue(new Error("refetch failed")),
       });
@@ -752,32 +687,24 @@ describe("WorkflowDraftReadPage", () => {
       renderPage("/workspaces/1/domain-packs/2/workflows/10?versionId=3");
       fireEvent.click(screen.getByTestId("edit-toggle"));
 
-      await waitFor(() =>
-        expect(mockToastError).toHaveBeenCalledWith("refetch failed"),
-      );
+      await waitFor(() => expect(mockToastError).toHaveBeenCalledWith("refetch failed"));
       expect(consoleError).toHaveBeenCalledWith(
         "Failed to resolve existing workflow draft",
         expect.any(Error),
       );
-      expect(
-        screen.queryByText("진행 중인 검토본이 있습니다"),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByText("진행 중인 검토본이 있습니다")).not.toBeInTheDocument();
     } finally {
       consoleError.mockRestore();
     }
   });
 
   it("기존 DRAFT 충돌 후 workflow 목록 조회가 실패하면 에러를 안내한다", async () => {
-    const consoleError = vi
-      .spyOn(console, "error")
-      .mockImplementation(() => undefined);
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
     try {
       mockUsePackDetail.mockReturnValue({
         data: {
           name: "CS Pack",
-          versions: [
-            { versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" },
-          ],
+          versions: [{ versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" }],
         },
         refetch: vi.fn().mockResolvedValue({
           data: {
@@ -806,9 +733,7 @@ describe("WorkflowDraftReadPage", () => {
       renderPage("/workspaces/1/domain-packs/2/workflows/10?versionId=3");
       fireEvent.click(screen.getByTestId("edit-toggle"));
 
-      await waitFor(() =>
-        expect(mockToastError).toHaveBeenCalledWith("workflow list failed"),
-      );
+      await waitFor(() => expect(mockToastError).toHaveBeenCalledWith("workflow list failed"));
       expect(consoleError).toHaveBeenCalled();
     } finally {
       consoleError.mockRestore();
@@ -831,9 +756,7 @@ describe("WorkflowDraftReadPage", () => {
     fireEvent.click(screen.getByTestId("editor-dirty"));
     fireEvent.click(screen.getByTestId("editor-close"));
 
-    expect(
-      await screen.findByText("변경 내역을 버릴까요?"),
-    ).toBeInTheDocument();
+    expect(await screen.findByText("변경 내역을 버릴까요?")).toBeInTheDocument();
     expect(screen.getByTestId("inline-editor")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "계속 편집" }));
@@ -861,9 +784,7 @@ describe("WorkflowDraftReadPage", () => {
     fireEvent.click(screen.getByTestId("editor-dirty"));
     fireEvent.click(screen.getByRole("button", { name: "목록" }));
 
-    expect(
-      await screen.findByText("변경 내역을 버릴까요?"),
-    ).toBeInTheDocument();
+    expect(await screen.findByText("변경 내역을 버릴까요?")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "변경 내역 버리기" }));
 
     await waitFor(() =>
@@ -901,18 +822,12 @@ describe("WorkflowDraftReadPage", () => {
     mockUsePackDetail.mockReturnValue({
       data: {
         name: "CS Pack",
-        versions: [
-          { versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" },
-        ],
+        versions: [{ versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" }],
       },
       refetch: vi.fn(),
     });
     mockCreateRevisionDraft.mockRejectedValue(
-      new ApiRequestError(
-        400,
-        "DOMAIN_PACK_VERSION_NOT_CURRENT",
-        "현재 운영 버전이 아닙니다.",
-      ),
+      new ApiRequestError(400, "DOMAIN_PACK_VERSION_NOT_CURRENT", "현재 운영 버전이 아닙니다."),
     );
     mockUseGetWorkflowDefinition.mockReturnValue({
       isLoading: false,
@@ -928,9 +843,7 @@ describe("WorkflowDraftReadPage", () => {
     renderPage("/workspaces/1/domain-packs/2/workflows/10?versionId=3");
     fireEvent.click(screen.getByTestId("edit-toggle"));
 
-    await waitFor(() =>
-      expect(mockToastError).toHaveBeenCalledWith("현재 운영 버전이 아닙니다."),
-    );
+    await waitFor(() => expect(mockToastError).toHaveBeenCalledWith("현재 운영 버전이 아닙니다."));
   });
 
   it("편집 모드에서는 상단 보기 버튼을 렌더하지 않는다", () => {
@@ -989,9 +902,7 @@ describe("WorkflowDraftReadPage", () => {
     renderPage("/workspaces/1/domain-packs/2/workflows/10?versionId=3");
     // legacy panels gone
     expect(screen.queryByText(/검토 중 · v0\.4/)).not.toBeInTheDocument();
-    expect(
-      screen.queryByText("Card payment refund flow"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Card payment refund flow")).not.toBeInTheDocument();
     expect(screen.queryByText("Selected node")).not.toBeInTheDocument();
     expect(screen.queryByText(/Edit graph/)).not.toBeInTheDocument();
     // tab list gone

--- a/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx
@@ -1,10 +1,5 @@
 import { type ReactNode, useEffect, useMemo, useState } from "react";
-import {
-  useLocation,
-  useNavigate,
-  useParams,
-  useSearchParams,
-} from "react-router-dom";
+import { Link, useLocation, useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
 import {
   formatLifecycleStatus,
@@ -18,10 +13,8 @@ import type {
 } from "@/features/consultation/api/consultationApi";
 import { InlineWorkflowEditor } from "@/features/update-workflow";
 import { intentRevisionDraftApi } from "@/features/intent-revision-draft";
-import {
-  buildDomainPackCrumbs,
-  domainPackSectionPath,
-} from "@/shared/lib/domainPackRoutes";
+import { buildDomainPackCrumbs, domainPackSectionPath } from "@/shared/lib/domainPackRoutes";
+import { buildWorkspaceSimulationPath } from "@/shared/lib/demoRoutes";
 import { parseRouteId } from "@/shared/lib/parseRouteId";
 import { Pill, Mono, Icon } from "@/shared/ui/ostone/atoms";
 import type { Crumb } from "@/shared/ui/ostone/chrome";
@@ -91,13 +84,7 @@ function formatInclusivePeriodEnd(value: string): string {
   return date.toISOString().slice(0, 10);
 }
 
-function HitList({
-  title,
-  items,
-}: {
-  title: string;
-  items: WorkflowHitMetric[];
-}) {
+function HitList({ title, items }: { title: string; items: WorkflowHitMetric[] }) {
   return (
     <section className={styles.analysisListGroup} aria-label={title}>
       <h4>{title}</h4>
@@ -133,24 +120,16 @@ function WorkflowBottleneckAnalysisPanel({
 }) {
   if (state === "loading") {
     return (
-      <section
-        className={styles.analysisPanel}
-        data-testid="workflow-analysis-loading"
-      >
+      <section className={styles.analysisPanel} data-testid="workflow-analysis-loading">
         <LoadingSpinner />
-        <p className={styles.analysisEmptyText}>
-          워크플로우 병목 분석을 불러오는 중입니다.
-        </p>
+        <p className={styles.analysisEmptyText}>워크플로우 병목 분석을 불러오는 중입니다.</p>
       </section>
     );
   }
 
   if (state === "error") {
     return (
-      <section
-        className={styles.analysisPanel}
-        data-testid="workflow-analysis-error"
-      >
+      <section className={styles.analysisPanel} data-testid="workflow-analysis-error">
         <ErrorState
           message={error ?? "워크플로우 병목 분석을 불러오지 못했습니다."}
           onRetry={onRetry}
@@ -161,47 +140,34 @@ function WorkflowBottleneckAnalysisPanel({
 
   if (state === "empty" || !analysis) {
     return (
-      <section
-        className={styles.analysisPanel}
-        data-testid="workflow-analysis-empty"
-      >
+      <section className={styles.analysisPanel} data-testid="workflow-analysis-empty">
         <div className={styles.analysisHeader}>
           <div>
             <span className={styles.analysisEyebrow}>Bottleneck Analysis</span>
             <h3>운영 실행 병목 분석</h3>
           </div>
         </div>
-        <p className={styles.analysisEmptyText}>
-          선택 기간에 분석할 운영 실행 로그가 없습니다.
-        </p>
+        <p className={styles.analysisEmptyText}>선택 기간에 분석할 운영 실행 로그가 없습니다.</p>
       </section>
     );
   }
 
   return (
-    <section
-      className={styles.analysisPanel}
-      data-testid="workflow-analysis-panel"
-    >
+    <section className={styles.analysisPanel} data-testid="workflow-analysis-panel">
       <div className={styles.analysisHeader}>
         <div>
           <span className={styles.analysisEyebrow}>Bottleneck Analysis</span>
           <h3>운영 실행 병목 분석</h3>
           <p>
-            상태 전이와 runtime decision 로그를 기준으로 slot, policy, risk 개선
-            지점을 요약합니다.
+            상태 전이와 runtime decision 로그를 기준으로 slot, policy, risk 개선 지점을 요약합니다.
           </p>
         </div>
         <span className={styles.analysisPeriod}>
-          {analysis.periodStart.slice(0, 10)} ~{" "}
-          {formatInclusivePeriodEnd(analysis.periodEnd)}
+          {analysis.periodStart.slice(0, 10)} ~ {formatInclusivePeriodEnd(analysis.periodEnd)}
         </span>
       </div>
 
-      <div
-        className={styles.analysisMetricGrid}
-        aria-label="워크플로우 실행 상태 요약"
-      >
+      <div className={styles.analysisMetricGrid} aria-label="워크플로우 실행 상태 요약">
         <article>
           <span>전체 실행</span>
           <strong>{formatMetricCount(analysis.totalExecutionCount)}</strong>
@@ -256,9 +222,7 @@ function WorkflowBottleneckAnalysisPanel({
             </div>
           ))
         ) : (
-          <p className={styles.analysisEmptyText}>
-            표시할 상태 전이가 없습니다.
-          </p>
+          <p className={styles.analysisEmptyText}>표시할 상태 전이가 없습니다.</p>
         )}
       </div>
 
@@ -268,10 +232,7 @@ function WorkflowBottleneckAnalysisPanel({
         <HitList title="Risk Hit TOP 5" items={analysis.riskHitTop} />
       </div>
 
-      <section
-        className={styles.analysisListGroup}
-        aria-label="상담사 개입 발생 지점"
-      >
+      <section className={styles.analysisListGroup} aria-label="상담사 개입 발생 지점">
         <h4>상담사 개입 지점</h4>
         {analysis.humanInterventionPoints.length > 0 ? (
           <ol>
@@ -286,9 +247,7 @@ function WorkflowBottleneckAnalysisPanel({
             ))}
           </ol>
         ) : (
-          <p className={styles.analysisEmptyText}>
-            상담사 개입 지점이 관측되지 않았습니다.
-          </p>
+          <p className={styles.analysisEmptyText}>상담사 개입 지점이 관측되지 않았습니다.</p>
         )}
       </section>
 
@@ -314,8 +273,7 @@ export function WorkflowDraftReadPage() {
     versionId: number;
     workflowId: number;
   } | null>(null);
-  const [analysis, setAnalysis] =
-    useState<WorkspaceWorkflowBottleneckAnalysis | null>(null);
+  const [analysis, setAnalysis] = useState<WorkspaceWorkflowBottleneckAnalysis | null>(null);
   const [isAnalysisLoading, setIsAnalysisLoading] = useState(false);
   const [analysisError, setAnalysisError] = useState<string | null>(null);
 
@@ -324,17 +282,14 @@ export function WorkflowDraftReadPage() {
   const vId = parseRouteId(search.get("versionId") ?? undefined);
   const wfId = workflowId ? parseRouteId(workflowId) : null;
 
-  const enabled =
-    wsId !== null && pId !== null && vId !== null && wfId !== null;
+  const enabled = wsId !== null && pId !== null && vId !== null && wfId !== null;
 
   const packQuery = usePackDetail(wsId ?? 0, pId ?? 0, {
     enabled: wsId !== null && pId !== null && vId !== null && wfId !== null,
   });
   const packDetail = packQuery.data;
   const packName = packDetail?.name ?? `PACK · ${pId ?? "?"}`;
-  const selectedVersion = packDetail?.versions?.find(
-    (v) => v.versionId === vId,
-  );
+  const selectedVersion = packDetail?.versions?.find((v) => v.versionId === vId);
   const versionNo = selectedVersion?.versionNo ?? vId ?? 0;
   const lifecycleStatus = selectedVersion?.lifecycleStatus ?? null;
   const workflowReturnTo = readWorkflowReturnTo(location.state);
@@ -348,6 +303,14 @@ export function WorkflowDraftReadPage() {
   });
 
   const workflow = query.data;
+  const simulationPath =
+    wsId !== null && pId !== null && vId !== null && wfId !== null
+      ? buildWorkspaceSimulationPath(wsId, {
+          packId: pId,
+          versionId: vId,
+          workflowId: wfId,
+        })
+      : null;
   const graph = useMemo<WorkflowGraph | null>(
     () => parseGraphJson(workflow?.graphJson),
     [workflow?.graphJson],
@@ -383,10 +346,7 @@ export function WorkflowDraftReadPage() {
     setIsAnalysisLoading(true);
     setAnalysisError(null);
     try {
-      const data = await consultationApi.getWorkflowBottleneckAnalysis(
-        wsId,
-        wfId,
-      );
+      const data = await consultationApi.getWorkflowBottleneckAnalysis(wsId, wfId);
       setAnalysis(data);
     } catch (error) {
       console.error("Failed to load workflow bottleneck analysis:", error);
@@ -412,10 +372,7 @@ export function WorkflowDraftReadPage() {
       setIsAnalysisLoading(true);
       setAnalysisError(null);
       try {
-        const data = await consultationApi.getWorkflowBottleneckAnalysis(
-          wsId,
-          wfId,
-        );
+        const data = await consultationApi.getWorkflowBottleneckAnalysis(wsId, wfId);
         if (ignore) return;
         setAnalysis(data);
       } catch (error) {
@@ -450,8 +407,7 @@ export function WorkflowDraftReadPage() {
       packName,
       versionNo,
       section: { label: "워크플로우", path: "workflows" },
-      selectedLabel:
-        workflow?.workflowCode ?? (wfId !== null ? `#${wfId}` : null),
+      selectedLabel: workflow?.workflowCode ?? (wfId !== null ? `#${wfId}` : null),
     });
   }, [packName, pId, versionNo, vId, wfId, workflow?.workflowCode, wsId]);
 
@@ -483,32 +439,17 @@ export function WorkflowDraftReadPage() {
     setPendingClose(() => next);
   };
 
-  const navigateToWorkflow = (
-    versionId: number,
-    targetWorkflowId: number | null,
-  ) => {
+  const navigateToWorkflow = (versionId: number, targetWorkflowId: number | null) => {
     navigate(
-      domainPackSectionPath(
-        wsId,
-        pId,
-        versionId,
-        "workflows",
-        targetWorkflowId ?? undefined,
-      ),
+      domainPackSectionPath(wsId, pId, versionId, "workflows", targetWorkflowId ?? undefined),
       { replace: true },
     );
   };
 
-  const findWorkflowIdByCode = async (
-    versionId: number,
-    workflowCode: string,
-  ) => {
+  const findWorkflowIdByCode = async (versionId: number, workflowCode: string) => {
     const response = await listWorkflows(wsId, pId, versionId);
-    const workflows = (unwrapApiResponse(response) ??
-      []) as WorkflowDefinitionSummary[];
-    const target = workflows.find(
-      (entry) => entry.workflowCode === workflowCode,
-    );
+    const workflows = (unwrapApiResponse(response) ?? []) as WorkflowDefinitionSummary[];
+    const target = workflows.find((entry) => entry.workflowCode === workflowCode);
     return typeof target?.id === "number" ? target.id : null;
   };
 
@@ -516,8 +457,7 @@ export function WorkflowDraftReadPage() {
     try {
       const refetched = await packQuery.refetch();
       const drafts = (refetched.data?.versions ?? []).filter(
-        (version) =>
-          version.lifecycleStatus === "DRAFT" && version.versionId != null,
+        (version) => version.lifecycleStatus === "DRAFT" && version.versionId != null,
       );
 
       if (drafts.length !== 1 || drafts[0].versionId == null) {
@@ -528,10 +468,7 @@ export function WorkflowDraftReadPage() {
       }
 
       const draftVersionId = drafts[0].versionId;
-      const draftWorkflowId = await findWorkflowIdByCode(
-        draftVersionId,
-        workflowCode,
-      );
+      const draftWorkflowId = await findWorkflowIdByCode(draftVersionId, workflowCode);
 
       if (draftWorkflowId == null) {
         toast.error("기존 검토본에서 같은 워크플로우를 찾지 못했습니다.");
@@ -556,12 +493,9 @@ export function WorkflowDraftReadPage() {
   const handleBackToList = () => {
     guardEditorClose(() => {
       closeEditor();
-      navigate(
-        workflowReturnTo ?? domainPackSectionPath(wsId, pId, vId, "workflows"),
-        {
-          replace: true,
-        },
-      );
+      navigate(workflowReturnTo ?? domainPackSectionPath(wsId, pId, vId, "workflows"), {
+        replace: true,
+      });
     });
   };
 
@@ -573,21 +507,15 @@ export function WorkflowDraftReadPage() {
     }
 
     if (!workflow.workflowCode) {
-      toast.error(
-        "워크플로우 코드를 확인할 수 없어 수정 검토본을 만들 수 없습니다.",
-      );
+      toast.error("워크플로우 코드를 확인할 수 없어 수정 검토본을 만들 수 없습니다.");
       return;
     }
 
     setCreatingDraft(true);
     try {
-      const { draftVersionId } =
-        await intentRevisionDraftApi.createRevisionDraft(wsId, pId, vId);
+      const { draftVersionId } = await intentRevisionDraftApi.createRevisionDraft(wsId, pId, vId);
       await packQuery.refetch();
-      const draftWorkflowId = await findWorkflowIdByCode(
-        draftVersionId,
-        workflow.workflowCode,
-      );
+      const draftWorkflowId = await findWorkflowIdByCode(draftVersionId, workflow.workflowCode);
       if (draftWorkflowId === null) {
         toast.error("수정 검토본에서 같은 워크플로우를 찾지 못했습니다.");
         navigateToWorkflow(draftVersionId, null);
@@ -598,18 +526,12 @@ export function WorkflowDraftReadPage() {
       setEditDirty(false);
       toast.success("워크플로우 수정 검토본이 생성되었습니다.");
     } catch (error) {
-      if (
-        error instanceof ApiRequestError &&
-        error.code === "DOMAIN_PACK_DRAFT_ALREADY_EXISTS"
-      ) {
+      if (error instanceof ApiRequestError && error.code === "DOMAIN_PACK_DRAFT_ALREADY_EXISTS") {
         await resolveExistingDraft(workflow.workflowCode);
         return;
       }
       toast.error(
-        resolveWorkflowActionErrorMessage(
-          error,
-          "워크플로우 수정 검토본 생성에 실패했습니다.",
-        ),
+        resolveWorkflowActionErrorMessage(error, "워크플로우 수정 검토본 생성에 실패했습니다."),
       );
     } finally {
       setCreatingDraft(false);
@@ -646,10 +568,7 @@ export function WorkflowDraftReadPage() {
     );
   } else if (graph) {
     graphContent = (
-      <div
-        data-testid="workflow-graph-viewer"
-        style={{ width: "100%", height: "100%" }}
-      >
+      <div data-testid="workflow-graph-viewer" style={{ width: "100%", height: "100%" }}>
         <GraphViewer graph={graph} />
       </div>
     );
@@ -668,28 +587,18 @@ export function WorkflowDraftReadPage() {
         <div className={styles.detailHeader}>
           <div className={styles.titleGroup}>
             <div className={styles.titleStack}>
-              <h2
-                data-testid="workflow-detail-title"
-                className={styles.detailTitle}
-              >
-                {workflow?.name ||
-                  (query.isLoading ? "워크플로우 로드 중..." : "워크플로우")}
+              <h2 data-testid="workflow-detail-title" className={styles.detailTitle}>
+                {workflow?.name || (query.isLoading ? "워크플로우 로드 중..." : "워크플로우")}
               </h2>
               {workflow?.description && (
-                <p className={styles.detailDescription}>
-                  {workflow.description}
-                </p>
+                <p className={styles.detailDescription}>{workflow.description}</p>
               )}
             </div>
             {workflow && lifecycleStatus && lifecycleStatus !== "PUBLISHED" && (
-              <Pill tone="signal">
-                {formatLifecycleStatus(lifecycleStatus)}
-              </Pill>
+              <Pill tone="signal">{formatLifecycleStatus(lifecycleStatus)}</Pill>
             )}
             {workflow && isEditing && <Pill tone="ink">수정 중</Pill>}
-            {workflow && (
-              <Mono className={styles.nodeCount}>노드 {nodeCount}개</Mono>
-            )}
+            {workflow && <Mono className={styles.nodeCount}>노드 {nodeCount}개</Mono>}
           </div>
 
           <div className={styles.headerActions}>
@@ -704,6 +613,29 @@ export function WorkflowDraftReadPage() {
               <Icon name="chevron" size={14} />
               {workflowReturnTo ? "뒤로" : "목록"}
             </Button>
+            {workflow && simulationPath && (
+              <Button
+                asChild
+                variant="outline"
+                size="default"
+                data-testid="workflow-simulation-link"
+                className={`${styles.headerButton} ${styles.backAction}`}
+              >
+                <Link
+                  to={simulationPath}
+                  state={{
+                    simulationTarget: {
+                      packId: pId,
+                      versionId: vId,
+                      workflowId: wfId,
+                    },
+                  }}
+                >
+                  <Icon name="play" size={14} />
+                  검증
+                </Link>
+              </Button>
+            )}
             {workflow && !isEditing && (
               <Button
                 type="button"
@@ -720,15 +652,9 @@ export function WorkflowDraftReadPage() {
           </div>
         </div>
 
-        <div
-          className={styles.canvasFrame}
-          data-editing={isEditing ? "true" : "false"}
-        >
+        <div className={styles.canvasFrame} data-editing={isEditing ? "true" : "false"}>
           {!enabled && (
-            <div
-              data-testid="workflow-select-empty"
-              className={styles.centerState}
-            >
+            <div data-testid="workflow-select-empty" className={styles.centerState}>
               좌측 사이드바에서 워크플로우를 선택하세요.
             </div>
           )}
@@ -749,11 +675,7 @@ export function WorkflowDraftReadPage() {
             </div>
           )}
 
-          {enabled &&
-            !query.isLoading &&
-            !query.isError &&
-            workflow &&
-            graphContent}
+          {enabled && !query.isLoading && !query.isError && workflow && graphContent}
         </div>
         {enabled && !isEditing && (
           <WorkflowBottleneckAnalysisPanel
@@ -771,9 +693,7 @@ export function WorkflowDraftReadPage() {
         }}
       >
         <AlertDialogContent size="sm" className={styles.discardDialog}>
-          <AlertDialogTitle className={styles.discardTitle}>
-            변경 내역을 버릴까요?
-          </AlertDialogTitle>
+          <AlertDialogTitle className={styles.discardTitle}>변경 내역을 버릴까요?</AlertDialogTitle>
           <AlertDialogDescription className={styles.discardDescription}>
             저장하지 않고 이동하면 현재 편집 중인 변경 내역이 버려집니다.
           </AlertDialogDescription>
@@ -786,11 +706,7 @@ export function WorkflowDraftReadPage() {
             >
               계속 편집
             </Button>
-            <Button
-              type="button"
-              className={styles.discardButton}
-              onClick={confirmPendingClose}
-            >
+            <Button type="button" className={styles.discardButton} onClick={confirmPendingClose}>
               변경 내역 버리기
             </Button>
           </AlertDialogFooter>
@@ -805,15 +721,11 @@ export function WorkflowDraftReadPage() {
         <AlertDialogContent size="sm">
           <AlertDialogTitle>진행 중인 검토본이 있습니다</AlertDialogTitle>
           <AlertDialogDescription>
-            새 검토본을 만들 수 없습니다. 기존 검토본에서 계속 편집하거나,
-            도메인팩 화면에서 검토본을 적용 또는 폐기한 뒤 다시 시도하세요.
+            새 검토본을 만들 수 없습니다. 기존 검토본에서 계속 편집하거나, 도메인팩 화면에서
+            검토본을 적용 또는 폐기한 뒤 다시 시도하세요.
           </AlertDialogDescription>
           <AlertDialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => setExistingDraftTarget(null)}
-            >
+            <Button type="button" variant="outline" onClick={() => setExistingDraftTarget(null)}>
               취소
             </Button>
             <Button type="button" onClick={confirmExistingDraftNavigation}>
@@ -832,10 +744,7 @@ function readWorkflowReturnTo(state: unknown): string | null {
   return typeof value === "string" && value.startsWith("/") ? value : null;
 }
 
-function resolveWorkflowActionErrorMessage(
-  error: unknown,
-  fallback: string,
-): string {
+function resolveWorkflowActionErrorMessage(error: unknown, fallback: string): string {
   if (error instanceof ApiRequestError && error.message) {
     return error.message;
   }

--- a/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx
@@ -6,19 +6,12 @@ import { toast } from "sonner";
 import { consultationApi } from "@/features/consultation/api/consultationApi";
 import { fetchWorkspaceDashboardActionRecommendations } from "@/features/workspace-dashboard-health/api/workspaceDashboardHealthApi";
 
-import {
-  DashboardStatePanel,
-  WorkspaceDashboardPage,
-} from "./WorkspaceDashboardPage";
+import { DashboardStatePanel, WorkspaceDashboardPage } from "./WorkspaceDashboardPage";
 
 const setCrumbs = vi.fn();
 const mockedGetMetrics = vi.mocked(consultationApi.getMetrics);
-const mockedGetWorkflowRankings = vi.mocked(
-  consultationApi.getWorkflowRankings,
-);
-const mockedFetchActionRecommendations = vi.mocked(
-  fetchWorkspaceDashboardActionRecommendations,
-);
+const mockedGetWorkflowRankings = vi.mocked(consultationApi.getWorkflowRankings);
+const mockedFetchActionRecommendations = vi.mocked(fetchWorkspaceDashboardActionRecommendations);
 const mockedToastError = vi.mocked(toast.error);
 
 const metricsResponse = {
@@ -167,8 +160,7 @@ const actionRecommendationResponse = {
       priority: 95,
       sourceLabel: "시뮬레이션에서 발견됨",
       title: "개선 후보 생성",
-      description:
-        "미처리 시뮬레이션 피드백이 있어 지식팩 개선 후보로 정리할 수 있습니다.",
+      description: "미처리 시뮬레이션 피드백이 있어 지식팩 개선 후보로 정리할 수 있습니다.",
       evidenceLabel: "Open feedback",
       evidenceValue: "4건",
       targetPath: "/workspaces/1/simulation?feedbackStatus=OPEN",
@@ -181,24 +173,15 @@ function renderPage(path = "/workspaces/1/dashboard") {
   render(
     <MemoryRouter initialEntries={[path]}>
       <Routes>
-        <Route
-          path="/workspaces/:workspaceId/dashboard"
-          element={<WorkspaceDashboardPage />}
-        />
-        <Route
-          path="/workspaces"
-          element={<div data-testid="workspace-root" />}
-        />
+        <Route path="/workspaces/:workspaceId/dashboard" element={<WorkspaceDashboardPage />} />
+        <Route path="/workspaces" element={<div data-testid="workspace-root" />} />
       </Routes>
     </MemoryRouter>,
   );
 }
 
 vi.mock("react-router-dom", async () => {
-  const actual =
-    await vi.importActual<typeof import("react-router-dom")>(
-      "react-router-dom",
-    );
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
   return {
     ...actual,
     useOutletContext: () => ({
@@ -215,12 +198,9 @@ vi.mock("@/features/consultation/api/consultationApi", () => ({
   },
 }));
 
-vi.mock(
-  "@/features/workspace-dashboard-health/api/workspaceDashboardHealthApi",
-  () => ({
-    fetchWorkspaceDashboardActionRecommendations: vi.fn(),
-  }),
-);
+vi.mock("@/features/workspace-dashboard-health/api/workspaceDashboardHealthApi", () => ({
+  fetchWorkspaceDashboardActionRecommendations: vi.fn(),
+}));
 
 vi.mock("sonner", () => ({
   toast: {
@@ -230,9 +210,7 @@ vi.mock("sonner", () => ({
 
 vi.mock("@/features/workspace-dashboard-health", () => ({
   KnowledgePackHealthPanel: ({ workspaceId }: { workspaceId: number }) => (
-    <section data-testid="knowledge-health-panel">
-      workspace {workspaceId} health
-    </section>
+    <section data-testid="knowledge-health-panel">workspace {workspaceId} health</section>
   ),
 }));
 
@@ -244,9 +222,7 @@ describe("WorkspaceDashboardPage", () => {
     mockedFetchActionRecommendations.mockReset();
     mockedGetMetrics.mockResolvedValue(metricsResponse);
     mockedGetWorkflowRankings.mockResolvedValue(workflowRankingResponse);
-    mockedFetchActionRecommendations.mockResolvedValue(
-      actionRecommendationResponse,
-    );
+    mockedFetchActionRecommendations.mockResolvedValue(actionRecommendationResponse);
   });
 
   it("잘못된 workspaceId면 /workspaces로 리다이렉트한다", () => {
@@ -260,89 +236,58 @@ describe("WorkspaceDashboardPage", () => {
   it("기간 필터와 상담 처리 KPI, 추천 액션, 운영 지식팩 건강도, 핫패스 랭킹을 표시한다", async () => {
     renderPage();
 
-    expect(
-      screen.getByRole("heading", { name: "대시보드" }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "대시보드" })).toBeInTheDocument();
     expect(
       screen.getByText(
         "상담 처리 흐름, 자동화 커버리지, 운영 지식팩 상태를 한 화면에서 확인합니다.",
       ),
     ).toBeInTheDocument();
-    expect(
-      screen.queryByText(/필터와 배치 구조를 먼저 고정합니다/),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/필터와 배치 구조를 먼저 고정합니다/)).not.toBeInTheDocument();
     expect(screen.getByLabelText("기간 필터")).toBeInTheDocument();
-    expect(
-      screen.queryByLabelText("운영 지식팩 버전 필터"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("운영 지식팩 버전 필터")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("채널 필터")).not.toBeInTheDocument();
-    expect(
-      screen.queryByLabelText("워크플로우 상태 필터"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("워크플로우 상태 필터")).not.toBeInTheDocument();
     expect(screen.getByText("총 상담")).toBeInTheDocument();
     expect(await screen.findByText("120")).toBeInTheDocument();
     expect(screen.getByText("1분 15초")).toBeInTheDocument();
     expect(screen.getByText("전 기간 +20.0%")).toBeInTheDocument();
-    expect(
-      screen.getByRole("heading", { name: "자동화 커버리지" }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "자동화 커버리지" })).toBeInTheDocument();
     expect(screen.getByText("계측 확인")).toBeInTheDocument();
     expect(screen.getByText("60.0%")).toBeInTheDocument();
     expect(screen.getByText("21.7%")).toBeInTheDocument();
     expect(screen.getByText("72.9%")).toBeInTheDocument();
     expect(screen.getByText("2026-05-29")).toBeInTheDocument();
-    expect(
-      await screen.findByRole("heading", { name: "추천 액션" }),
-    ).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "추천 액션" })).toBeInTheDocument();
     expect(screen.getByText("환불 처리 workflow 점검")).toBeInTheDocument();
     expect(screen.getByText("+33.3%")).toBeInTheDocument();
     expect(screen.getByText("시뮬레이션에서 발견됨")).toBeInTheDocument();
     expect(screen.getByText("4건")).toBeInTheDocument();
-    expect(
-      screen.getByRole("link", { name: /환불 처리 workflow 점검/ }),
-    ).toHaveAttribute(
+    expect(screen.getByRole("link", { name: /환불 처리 workflow 점검/ })).toHaveAttribute(
       "href",
-      "/workspaces/1/domain-packs/11/workflows/100?versionId=22",
+      "/workspaces/1/simulation?packId=11&versionId=22&workflowId=100",
     );
-    expect(
-      screen.getByRole("link", { name: /개선 후보 생성/ }),
-    ).toHaveAttribute("href", "/workspaces/1/simulation?feedbackStatus=OPEN");
-    expect(screen.getByTestId("knowledge-health-panel")).toHaveTextContent(
-      "workspace 1 health",
+    expect(screen.getByRole("link", { name: /개선 후보 생성/ })).toHaveAttribute(
+      "href",
+      "/workspaces/1/simulation?feedbackStatus=OPEN",
     );
-    expect(
-      await screen.findByText("핫패스 워크플로우 랭킹"),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("knowledge-health-panel")).toHaveTextContent("workspace 1 health");
+    expect(await screen.findByText("핫패스 워크플로우 랭킹")).toBeInTheDocument();
     expect(screen.getByTestId("hotpath-top-1")).toHaveTextContent("환불 처리");
     expect(screen.getByTestId("hotpath-row-1")).toHaveTextContent("급증");
-    expect(
-      screen.getAllByRole("link", { name: /환불 처리/ })[0],
-    ).toHaveAttribute(
+    expect(screen.getByTestId("hotpath-top-1")).toHaveAttribute(
       "href",
       "/workspaces/1/domain-packs/11/workflows/100?versionId=22",
     );
-    expect(screen.getByTestId("hotpath-row-2")).toHaveTextContent(
-      "상세 준비 중",
-    );
-    expect(
-      screen.queryByLabelText("대시보드 카드와 차트 배치 영역"),
-    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("hotpath-row-2")).toHaveTextContent("상세 준비 중");
+    expect(screen.queryByLabelText("대시보드 카드와 차트 배치 영역")).not.toBeInTheDocument();
     expect(screen.queryByText(/연결될 자리입니다/)).not.toBeInTheDocument();
     expect(screen.queryByTestId("dashboard-partial")).not.toBeInTheDocument();
+    await waitFor(() => expect(mockedGetMetrics).toHaveBeenCalledWith(1, expect.any(Object)));
     await waitFor(() =>
-      expect(mockedGetMetrics).toHaveBeenCalledWith(1, expect.any(Object)),
+      expect(mockedGetWorkflowRankings).toHaveBeenCalledWith(1, expect.any(Object)),
     );
     await waitFor(() =>
-      expect(mockedGetWorkflowRankings).toHaveBeenCalledWith(
-        1,
-        expect.any(Object),
-      ),
-    );
-    await waitFor(() =>
-      expect(mockedFetchActionRecommendations).toHaveBeenCalledWith(
-        1,
-        expect.any(Object),
-      ),
+      expect(mockedFetchActionRecommendations).toHaveBeenCalledWith(1, expect.any(Object)),
     );
   });
 
@@ -444,28 +389,18 @@ describe("WorkspaceDashboardPage", () => {
       "href",
       "/workspaces/1/domain-packs",
     );
-    expect(
-      screen.getByRole("link", { name: /지식팩 검토/ }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /지식팩 검토/ })).toBeInTheDocument();
     expect(screen.getByTestId("dashboard-simulation-cta")).toHaveAttribute(
       "href",
       "/workspaces/1/simulation",
     );
-    expect(
-      screen.getByRole("link", { name: /시뮬레이션 시작/ }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("link", { name: /고객 화면 미리보기/ }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByTestId("dashboard-customer-preview-cta"),
-    ).toHaveAttribute(
+    expect(screen.getByRole("link", { name: /시뮬레이션 시작/ })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /고객 화면 미리보기/ })).toBeInTheDocument();
+    expect(screen.getByTestId("dashboard-customer-preview-cta")).toHaveAttribute(
       "href",
       "/demo/chat/1",
     );
-    expect(screen.getByTestId("recommendation-empty")).toHaveTextContent(
-      "현재 큰 이상 없음",
-    );
+    expect(screen.getByTestId("recommendation-empty")).toHaveTextContent("현재 큰 이상 없음");
   });
 
   it("상담 KPI가 실패해도 워크플로우 랭킹은 같은 화면에 남긴다", async () => {
@@ -473,9 +408,7 @@ describe("WorkspaceDashboardPage", () => {
 
     renderPage();
 
-    expect(
-      await screen.findByText("핫패스 워크플로우 랭킹"),
-    ).toBeInTheDocument();
+    expect(await screen.findByText("핫패스 워크플로우 랭킹")).toBeInTheDocument();
     expect(screen.getByTestId("hotpath-row-1")).toHaveTextContent("환불 처리");
     expect(screen.getByTestId("dashboard-partial")).toHaveTextContent(
       "일부 운영 데이터만 확인됩니다.",
@@ -485,18 +418,12 @@ describe("WorkspaceDashboardPage", () => {
 
   it("passive load 실패는 화면 상태로 표시하고 toast를 띄우지 않는다", async () => {
     mockedGetMetrics.mockRejectedValueOnce(new Error("metrics failed"));
-    mockedGetWorkflowRankings.mockRejectedValueOnce(
-      new Error("rankings failed"),
-    );
-    mockedFetchActionRecommendations.mockRejectedValueOnce(
-      new Error("recommendations failed"),
-    );
+    mockedGetWorkflowRankings.mockRejectedValueOnce(new Error("rankings failed"));
+    mockedFetchActionRecommendations.mockRejectedValueOnce(new Error("recommendations failed"));
 
     renderPage();
 
-    expect(
-      await screen.findByText("대시보드 데이터를 불러오지 못했습니다."),
-    ).toBeInTheDocument();
+    expect(await screen.findByText("대시보드 데이터를 불러오지 못했습니다.")).toBeInTheDocument();
     expect(screen.getByTestId("recommendation-error")).toHaveTextContent(
       "추천 액션을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.",
     );

--- a/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx
@@ -23,10 +23,7 @@ import {
   type WorkspaceDashboardActionRecommendations,
 } from "@/features/workspace-dashboard-health/api/workspaceDashboardHealthApi";
 import type { ShellContext } from "@/shared/ui/ostone/chrome";
-import {
-  buildDemoChatPath,
-  buildWorkspaceSimulationPath,
-} from "@/shared/lib/demoRoutes";
+import { buildDemoChatPath, buildWorkspaceSimulationPath } from "@/shared/lib/demoRoutes";
 import { parseRouteId } from "@/shared/lib/parseRouteId";
 import { Button } from "@/shared/ui/button";
 import { LoadingSpinner } from "@/shared/ui/ostone/atoms/LoadingSpinner";
@@ -141,10 +138,7 @@ function formatCount(value: MetricValue, state: DashboardDataState): string {
   return new Intl.NumberFormat("ko-KR").format(value);
 }
 
-function formatDuration(
-  seconds: MetricValue,
-  state: DashboardDataState,
-): string {
+function formatDuration(seconds: MetricValue, state: DashboardDataState): string {
   if (state === "loading") return "로딩중";
   if (state === "error") return "--";
   if (typeof seconds !== "number" || !Number.isFinite(seconds)) return "--";
@@ -154,16 +148,9 @@ function formatDuration(
   return remainder === 0 ? `${minutes}분` : `${minutes}분 ${remainder}초`;
 }
 
-function formatDelta(
-  delta: number | null | undefined,
-  state: DashboardDataState,
-): string {
+function formatDelta(delta: number | null | undefined, state: DashboardDataState): string {
   if (state === "loading") return "전 기간 계산 중";
-  if (
-    state === "error" ||
-    typeof delta !== "number" ||
-    !Number.isFinite(delta)
-  ) {
+  if (state === "error" || typeof delta !== "number" || !Number.isFinite(delta)) {
     return "전 기간 --";
   }
   const sign = delta > 0 ? "+" : "";
@@ -188,9 +175,7 @@ function hasMetricData(metrics: ConsultationMetrics | null): boolean {
   );
 }
 
-function hasWorkflowRankingData(
-  rankings: WorkspaceWorkflowRankingResponse | null,
-): boolean {
+function hasWorkflowRankingData(rankings: WorkspaceWorkflowRankingResponse | null): boolean {
   return (rankings?.rankings?.length ?? 0) > 0;
 }
 
@@ -352,10 +337,7 @@ function TopWorkflowCard({
   }
 
   return (
-    <article
-      className={styles.hotpathCard}
-      data-testid={`hotpath-top-${item.rank}`}
-    >
+    <article className={styles.hotpathCard} data-testid={`hotpath-top-${item.rank}`}>
       {body}
       <span className={styles.unavailableText}>상세 준비 중</span>
     </article>
@@ -369,8 +351,7 @@ function AutomationCoveragePanel({
   coverage: ConsultationCoverageMetrics | null | undefined;
   state: DashboardDataState;
 }) {
-  const needsInstrumentation =
-    coverage?.measurementStatus === "NEEDS_INSTRUMENTATION";
+  const needsInstrumentation = coverage?.measurementStatus === "NEEDS_INSTRUMENTATION";
   const measurementStatus =
     state === "loading" ? "LOADING" : (coverage?.measurementStatus ?? "EMPTY");
   const measurementLabel =
@@ -382,16 +363,10 @@ function AutomationCoveragePanel({
           ? "계측 확인"
           : "--";
   const trend = coverage?.trend ?? [];
-  const maxTrendTotal = Math.max(
-    1,
-    ...trend.map((point) => point.totalConsultationCount),
-  );
+  const maxTrendTotal = Math.max(1, ...trend.map((point) => point.totalConsultationCount));
 
   return (
-    <section
-      className={styles.coveragePanel}
-      aria-labelledby="automation-coverage-title"
-    >
+    <section className={styles.coveragePanel} aria-labelledby="automation-coverage-title">
       <div className={styles.coverageHeader}>
         <div>
           <span className={styles.panelEyebrow}>Automation Coverage</span>
@@ -402,10 +377,7 @@ function AutomationCoveragePanel({
             운영 지식팩이 실제 상담을 workflow로 얼마나 커버했는지 확인합니다.
           </p>
         </div>
-        <span
-          className={styles.measurementBadge}
-          data-status={measurementStatus}
-        >
+        <span className={styles.measurementBadge} data-status={measurementStatus}>
           {measurementLabel}
         </span>
       </div>
@@ -424,10 +396,7 @@ function AutomationCoveragePanel({
         />
         <CoverageMetricCard
           label="Intent Success"
-          value={formatPercent(
-            coverage?.intentClassificationSuccessRate,
-            state,
-          )}
+          value={formatPercent(coverage?.intentClassificationSuccessRate, state)}
           description={`${formatCount(coverage?.intentClassificationSuccessCount, state)}건의 intent 분류 성공`}
         />
         <CoverageMetricCard
@@ -519,10 +488,7 @@ function WorkflowRankingTable({
                 <td>#{item.rank}</td>
                 <td>
                   {item.detailPath ? (
-                    <Link
-                      to={item.detailPath}
-                      className={styles.workflowDetailLink}
-                    >
+                    <Link to={item.detailPath} className={styles.workflowDetailLink}>
                       {workflowName}
                     </Link>
                   ) : (
@@ -541,9 +507,7 @@ function WorkflowRankingTable({
                 <td>
                   <span className={styles.changeCell}>
                     {formatDelta(item.changeRate, state)}
-                    {item.surging ? (
-                      <span className={styles.surgeBadge}>급증</span>
-                    ) : null}
+                    {item.surging ? <span className={styles.surgeBadge}>급증</span> : null}
                   </span>
                 </td>
               </tr>
@@ -568,10 +532,7 @@ function HotpathWorkflowRankingPanel({
   const allRankings = rankings?.rankings ?? [];
 
   return (
-    <section
-      className={styles.hotpathPanel}
-      aria-labelledby="hotpath-ranking-title"
-    >
+    <section className={styles.hotpathPanel} aria-labelledby="hotpath-ranking-title">
       <div className={styles.panelHeader}>
         <div>
           <span className={styles.panelEyebrow}>HOTPATH</span>
@@ -579,8 +540,7 @@ function HotpathWorkflowRankingPanel({
             핫패스 워크플로우 랭킹
           </h2>
           <p className={styles.sectionDescription}>
-            선택 기간의 실행량과 전 기간 대비 증가율을 기준으로 우선 개선 대상을
-            확인합니다.
+            선택 기간의 실행량과 전 기간 대비 증가율을 기준으로 우선 개선 대상을 확인합니다.
           </p>
         </div>
         <span className={styles.totalBadge}>
@@ -597,17 +557,13 @@ function HotpathWorkflowRankingPanel({
       {!error && state === "loading" ? (
         <div className={styles.hotpathState} data-testid="hotpath-loading">
           <LoadingSpinner />
-          <p className={styles.stateText}>
-            워크플로우 랭킹을 불러오는 중입니다.
-          </p>
+          <p className={styles.stateText}>워크플로우 랭킹을 불러오는 중입니다.</p>
         </div>
       ) : null}
 
       {!error && state !== "loading" && allRankings.length === 0 ? (
         <div className={styles.hotpathState} data-testid="hotpath-empty">
-          <p className={styles.stateText}>
-            선택 기간에 집계할 워크플로우 실행이 없습니다.
-          </p>
+          <p className={styles.stateText}>선택 기간에 집계할 워크플로우 실행이 없습니다.</p>
         </div>
       ) : null}
 
@@ -629,18 +585,14 @@ function HotpathWorkflowRankingPanel({
   );
 }
 
-function ActionRecommendationCard({
-  item,
-}: {
-  item: WorkspaceDashboardActionRecommendation;
-}) {
+function ActionRecommendationCard({ item }: { item: WorkspaceDashboardActionRecommendation }) {
+  const targetPath = buildSimulationPathFromWorkflowDetailPath(item.targetPath) ?? item.targetPath;
+
   return (
-    <Link to={item.targetPath} className={styles.recommendationCard}>
+    <Link to={targetPath} className={styles.recommendationCard}>
       <span className={styles.recommendationMeta}>
         <span className={styles.sourceBadge}>{item.sourceLabel}</span>
-        <span className={styles.ruleBadge}>
-          {item.ruleCode.replaceAll("_", " ")}
-        </span>
+        <span className={styles.ruleBadge}>{item.ruleCode.replaceAll("_", " ")}</span>
       </span>
       <h3>{item.title}</h3>
       <p>{item.description}</p>
@@ -658,6 +610,28 @@ function ActionRecommendationCard({
   );
 }
 
+function buildSimulationPathFromWorkflowDetailPath(path: string): string | null {
+  const [pathname, rawSearch = ""] = path.split("?");
+  const match = pathname.match(
+    /^\/workspaces\/([^/]+)\/domain-packs\/([^/]+)\/workflows\/([^/]+)$/,
+  );
+  if (!match) return null;
+
+  const workspaceId = decodeURIComponent(match[1]);
+  const packId = parseRouteId(decodeURIComponent(match[2]));
+  const workflowId = parseRouteId(decodeURIComponent(match[3]));
+  const versionId = parseRouteId(new URLSearchParams(rawSearch).get("versionId") ?? undefined);
+  if (packId === null || versionId === null || workflowId === null) {
+    return null;
+  }
+
+  return buildWorkspaceSimulationPath(workspaceId, {
+    packId,
+    versionId,
+    workflowId,
+  });
+}
+
 function ActionRecommendationsPanel({
   recommendations,
   state,
@@ -670,10 +644,7 @@ function ActionRecommendationsPanel({
   const items = recommendations?.recommendations ?? [];
 
   return (
-    <section
-      className={styles.recommendationPanel}
-      aria-labelledby="action-recommendation-title"
-    >
+    <section className={styles.recommendationPanel} aria-labelledby="action-recommendation-title">
       <div className={styles.panelHeader}>
         <div>
           <span className={styles.panelEyebrow}>Next Actions</span>
@@ -687,29 +658,20 @@ function ActionRecommendationsPanel({
       </div>
 
       {error ? (
-        <div
-          className={styles.recommendationState}
-          data-testid="recommendation-error"
-        >
+        <div className={styles.recommendationState} data-testid="recommendation-error">
           <ErrorState message={error} />
         </div>
       ) : null}
 
       {!error && state === "loading" ? (
-        <div
-          className={styles.recommendationState}
-          data-testid="recommendation-loading"
-        >
+        <div className={styles.recommendationState} data-testid="recommendation-loading">
           <LoadingSpinner />
           <p className={styles.stateText}>추천 액션을 계산하는 중입니다.</p>
         </div>
       ) : null}
 
       {!error && state !== "loading" && items.length === 0 ? (
-        <div
-          className={styles.recommendationState}
-          data-testid="recommendation-empty"
-        >
+        <div className={styles.recommendationState} data-testid="recommendation-empty">
           <CheckCircle2Icon aria-hidden="true" className={styles.panelIcon} />
           <p className={styles.stateText}>현재 큰 이상 없음</p>
         </div>
@@ -733,18 +695,12 @@ function DashboardFilters({
   filters: DashboardFilters;
   onChange: (filters: DashboardFilters) => void;
 }) {
-  const updateFilter = <K extends keyof DashboardFilters>(
-    key: K,
-    value: DashboardFilters[K],
-  ) => {
+  const updateFilter = <K extends keyof DashboardFilters>(key: K, value: DashboardFilters[K]) => {
     onChange({ ...filters, [key]: value });
   };
 
   return (
-    <section
-      className={styles.filterBar}
-      aria-labelledby="dashboard-filter-title"
-    >
+    <section className={styles.filterBar} aria-labelledby="dashboard-filter-title">
       <div className={styles.filterHeader}>
         <div>
           <h2 id="dashboard-filter-title" className={styles.sectionTitle}>
@@ -780,9 +736,7 @@ function DashboardFilters({
             <input
               type="date"
               value={filters.customFrom}
-              onChange={(event) =>
-                updateFilter("customFrom", event.target.value)
-              }
+              onChange={(event) => updateFilter("customFrom", event.target.value)}
             />
           </label>
           <label className={styles.field}>
@@ -799,17 +753,10 @@ function DashboardFilters({
   );
 }
 
-export function DashboardStatePanel({
-  state,
-  workspaceId,
-}: DashboardStatePanelProps) {
+export function DashboardStatePanel({ state, workspaceId }: DashboardStatePanelProps) {
   if (state === "loading") {
     return (
-      <section
-        className={styles.statePanel}
-        data-testid="dashboard-loading"
-        aria-live="polite"
-      >
+      <section className={styles.statePanel} data-testid="dashboard-loading" aria-live="polite">
         <LoadingSpinner />
         <p className={styles.stateText}>대시보드 데이터를 불러오는 중입니다.</p>
       </section>
@@ -831,8 +778,8 @@ export function DashboardStatePanel({
           <span className={styles.panelEyebrow}>PARTIAL DATA</span>
           <h2>일부 운영 데이터만 확인됩니다.</h2>
           <p>
-            선택 기간에 수집된 상담 로그 기준으로 확인 가능한 지표를 먼저
-            표시합니다. 값이 없는 항목은 해당 운영 기록이 쌓이면 계산됩니다.
+            선택 기간에 수집된 상담 로그 기준으로 확인 가능한 지표를 먼저 표시합니다. 값이 없는
+            항목은 해당 운영 기록이 쌓이면 계산됩니다.
           </p>
         </div>
         <RefreshCwIcon aria-hidden="true" className={styles.panelIcon} />
@@ -846,25 +793,19 @@ export function DashboardStatePanel({
         <span className={styles.panelEyebrow}>GET STARTED</span>
         <h2>아직 대시보드에 표시할 운영 데이터가 없습니다.</h2>
         <p>
-          상담 로그를 업로드하고 운영 지식팩 검토를 마친 뒤, 시뮬레이션으로
-          워크플로우 흐름을 확인하세요.
+          상담 로그를 업로드하고 운영 지식팩 검토를 마친 뒤, 시뮬레이션으로 워크플로우 흐름을
+          확인하세요.
         </p>
       </div>
       <div className={styles.ctaGrid}>
         <Button asChild variant="default">
-          <Link
-            to={`/workspaces/${workspaceId}/upload`}
-            data-testid="dashboard-upload-cta"
-          >
+          <Link to={`/workspaces/${workspaceId}/upload`} data-testid="dashboard-upload-cta">
             <FileUpIcon aria-hidden="true" />
             상담 업로드
           </Link>
         </Button>
         <Button asChild variant="outline">
-          <Link
-            to={`/workspaces/${workspaceId}/domain-packs`}
-            data-testid="dashboard-pack-cta"
-          >
+          <Link to={`/workspaces/${workspaceId}/domain-packs`} data-testid="dashboard-pack-cta">
             <CheckCircle2Icon aria-hidden="true" />
             지식팩 검토
           </Link>
@@ -879,10 +820,7 @@ export function DashboardStatePanel({
           </Link>
         </Button>
         <Button asChild variant="outline">
-          <Link
-            to={buildDemoChatPath(workspaceId)}
-            data-testid="dashboard-customer-preview-cta"
-          >
+          <Link to={buildDemoChatPath(workspaceId)} data-testid="dashboard-customer-preview-cta">
             <MonitorSmartphoneIcon aria-hidden="true" />
             고객 화면 미리보기
           </Link>
@@ -900,24 +838,16 @@ export function WorkspaceDashboardPage() {
   const [metrics, setMetrics] = useState<ConsultationMetrics | null>(null);
   const [isMetricsLoading, setIsMetricsLoading] = useState(false);
   const [metricsError, setMetricsError] = useState<string | null>(null);
-  const [workflowRankings, setWorkflowRankings] =
-    useState<WorkspaceWorkflowRankingResponse | null>(null);
-  const [isWorkflowRankingsLoading, setIsWorkflowRankingsLoading] =
-    useState(false);
-  const [workflowRankingsError, setWorkflowRankingsError] = useState<
-    string | null
-  >(null);
+  const [workflowRankings, setWorkflowRankings] = useState<WorkspaceWorkflowRankingResponse | null>(
+    null,
+  );
+  const [isWorkflowRankingsLoading, setIsWorkflowRankingsLoading] = useState(false);
+  const [workflowRankingsError, setWorkflowRankingsError] = useState<string | null>(null);
   const [actionRecommendations, setActionRecommendations] =
     useState<WorkspaceDashboardActionRecommendations | null>(null);
-  const [isActionRecommendationsLoading, setIsActionRecommendationsLoading] =
-    useState(false);
-  const [actionRecommendationsError, setActionRecommendationsError] = useState<
-    string | null
-  >(null);
-  const metricDateRange = useMemo(
-    () => buildMetricDateRange(filters),
-    [filters],
-  );
+  const [isActionRecommendationsLoading, setIsActionRecommendationsLoading] = useState(false);
+  const [actionRecommendationsError, setActionRecommendationsError] = useState<string | null>(null);
+  const metricDateRange = useMemo(() => buildMetricDateRange(filters), [filters]);
   const metricsState = useMemo<DashboardDataState>(() => {
     if (isMetricsLoading) return "loading";
     if (metricsError) return "error";
@@ -935,30 +865,20 @@ export function WorkspaceDashboardPage() {
     if (actionRecommendationsError) return "error";
     if (hasActionRecommendationData(actionRecommendations)) return "partial";
     return "empty";
-  }, [
-    isActionRecommendationsLoading,
-    actionRecommendationsError,
-    actionRecommendations,
-  ]);
+  }, [isActionRecommendationsLoading, actionRecommendationsError, actionRecommendations]);
   const dataState = useMemo<DashboardDataState | null>(() => {
     const hasAnyData =
       hasMetricData(metrics) ||
       hasWorkflowRankingData(workflowRankings) ||
       hasActionRecommendationData(actionRecommendations);
     if (
-      (isMetricsLoading ||
-        isWorkflowRankingsLoading ||
-        isActionRecommendationsLoading) &&
+      (isMetricsLoading || isWorkflowRankingsLoading || isActionRecommendationsLoading) &&
       !hasAnyData
     ) {
       return "loading";
     }
-    if (metricsError && workflowRankingsError && actionRecommendationsError)
-      return "error";
-    if (
-      hasAnyData &&
-      (metricsError || workflowRankingsError || actionRecommendationsError)
-    ) {
+    if (metricsError && workflowRankingsError && actionRecommendationsError) return "error";
+    if (hasAnyData && (metricsError || workflowRankingsError || actionRecommendationsError)) {
       return "partial";
     }
     if (hasAnyData) return null;
@@ -1001,10 +921,7 @@ export function WorkspaceDashboardPage() {
       setIsMetricsLoading(true);
       setMetricsError(null);
       try {
-        const data = await consultationApi.getMetrics(
-          parsedWorkspaceId,
-          metricDateRange,
-        );
+        const data = await consultationApi.getMetrics(parsedWorkspaceId, metricDateRange);
         if (ignore) return;
         setMetrics(data);
       } catch (error) {
@@ -1055,10 +972,7 @@ export function WorkspaceDashboardPage() {
         setActionRecommendations(data);
       } catch (error) {
         if (ignore) return;
-        console.error(
-          "Failed to load dashboard action recommendations:",
-          error,
-        );
+        console.error("Failed to load dashboard action recommendations:", error);
         setActionRecommendations(null);
         setActionRecommendationsError(
           "추천 액션을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.",
@@ -1098,10 +1012,7 @@ export function WorkspaceDashboardPage() {
       setIsWorkflowRankingsLoading(true);
       setWorkflowRankingsError(null);
       try {
-        const data = await consultationApi.getWorkflowRankings(
-          parsedWorkspaceId,
-          metricDateRange,
-        );
+        const data = await consultationApi.getWorkflowRankings(parsedWorkspaceId, metricDateRange);
         if (ignore) return;
         setWorkflowRankings(data);
       } catch (error) {
@@ -1136,8 +1047,7 @@ export function WorkspaceDashboardPage() {
           <span className={styles.eyebrow}>Workspace Dashboard</span>
           <h1 className={styles.pageTitle}>대시보드</h1>
           <p className={styles.pageSubtitle}>
-            상담 처리 흐름, 자동화 커버리지, 운영 지식팩 상태를 한 화면에서
-            확인합니다.
+            상담 처리 흐름, 자동화 커버리지, 운영 지식팩 상태를 한 화면에서 확인합니다.
           </p>
         </div>
         <Button asChild variant="outline" size="sm">
@@ -1156,22 +1066,14 @@ export function WorkspaceDashboardPage() {
         error={actionRecommendationsError}
       />
       <DashboardMetricsGrid metrics={metrics} state={metricsState} />
-      <AutomationCoveragePanel
-        coverage={metrics?.coverage}
-        state={metricsState}
-      />
+      <AutomationCoveragePanel coverage={metrics?.coverage} state={metricsState} />
       <KnowledgePackHealthPanel workspaceId={parsedWorkspaceId} />
       <HotpathWorkflowRankingPanel
         rankings={workflowRankings}
         state={workflowRankingState}
         error={workflowRankingsError}
       />
-      {dataState ? (
-        <DashboardStatePanel
-          state={dataState}
-          workspaceId={parsedWorkspaceId}
-        />
-      ) : null}
+      {dataState ? <DashboardStatePanel state={dataState} workspaceId={parsedWorkspaceId} /> : null}
     </div>
   );
 }

--- a/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx
@@ -4,19 +4,13 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { toast } from "sonner";
 
 import { WorkspaceSimulationPage } from "./WorkspaceSimulationPage";
-import {
-  simulationApi,
-  type SimulationImprovementCandidate,
-} from "@/features/simulation";
+import { simulationApi, type SimulationImprovementCandidate } from "@/features/simulation";
 import { useListAllWorkspaceWorkflows } from "@/entities/workflow";
 
 const setCrumbs = vi.fn();
 
 vi.mock("react-router-dom", async () => {
-  const actual =
-    await vi.importActual<typeof import("react-router-dom")>(
-      "react-router-dom",
-    );
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
   return {
     ...actual,
     useOutletContext: () => ({
@@ -218,18 +212,12 @@ const otherDetail = {
   },
 };
 
-function renderPage(path = "/workspaces/1/simulation") {
+function renderPage(path = "/workspaces/1/simulation", state?: unknown) {
   render(
-    <MemoryRouter initialEntries={[path]}>
+    <MemoryRouter initialEntries={[state === undefined ? path : { pathname: path, state }]}>
       <Routes>
-        <Route
-          path="/workspaces/:workspaceId/simulation"
-          element={<WorkspaceSimulationPage />}
-        />
-        <Route
-          path="/workspaces"
-          element={<div data-testid="workspace-root" />}
-        />
+        <Route path="/workspaces/:workspaceId/simulation" element={<WorkspaceSimulationPage />} />
+        <Route path="/workspaces" element={<div data-testid="workspace-root" />} />
       </Routes>
     </MemoryRouter>,
   );
@@ -268,9 +256,8 @@ beforeEach(() => {
     totalElements: 1,
     totalPages: 1,
   });
-  mockedSimulationApi.getSession.mockImplementation(
-    async (_workspaceId, sessionId) =>
-      sessionId === otherSession.id ? otherDetail : detail,
+  mockedSimulationApi.getSession.mockImplementation(async (_workspaceId, sessionId) =>
+    sessionId === otherSession.id ? otherDetail : detail,
   );
   mockedSimulationApi.createSession.mockResolvedValue(detail);
   mockedSimulationApi.createFeedback.mockResolvedValue(detail);
@@ -338,9 +325,7 @@ describe("WorkspaceSimulationPage", () => {
   it("세션 목록과 runtime 상태를 표시한다", async () => {
     renderPage();
 
-    expect(
-      await screen.findByRole("heading", { name: "상담 시뮬레이션" }),
-    ).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "상담 시뮬레이션" })).toBeInTheDocument();
     expect(await screen.findByText("테스트 고객")).toBeInTheDocument();
     expect(await screen.findByText("환불하고 싶어요")).toBeInTheDocument();
     expect(screen.getByText("환불 문의")).toBeInTheDocument();
@@ -350,18 +335,12 @@ describe("WorkspaceSimulationPage", () => {
   });
 
   it("대시보드 추천 query로 피드백과 개선 후보 상태 필터를 초기화한다", async () => {
-    renderPage(
-      "/workspaces/1/simulation?feedbackStatus=RESOLVED&candidateStatus=READY_FOR_REVIEW",
-    );
+    renderPage("/workspaces/1/simulation?feedbackStatus=RESOLVED&candidateStatus=READY_FOR_REVIEW");
 
     await openFeedbackTab();
-    expect(await screen.findByLabelText("피드백 상태 필터")).toHaveValue(
-      "RESOLVED",
-    );
+    expect(await screen.findByLabelText("피드백 상태 필터")).toHaveValue("RESOLVED");
     await openCandidateTab();
-    expect(screen.getByLabelText("개선 후보 상태 필터")).toHaveValue(
-      "READY_FOR_REVIEW",
-    );
+    expect(screen.getByLabelText("개선 후보 상태 필터")).toHaveValue("READY_FOR_REVIEW");
     await waitFor(() => {
       expect(mockedSimulationApi.listFeedback).toHaveBeenCalledWith(1, {
         status: "RESOLVED",
@@ -370,12 +349,64 @@ describe("WorkspaceSimulationPage", () => {
       });
     });
     await waitFor(() => {
-      expect(
-        mockedSimulationApi.listImprovementCandidates,
-      ).toHaveBeenCalledWith(1, {
+      expect(mockedSimulationApi.listImprovementCandidates).toHaveBeenCalledWith(1, {
         status: "READY_FOR_REVIEW",
         page: 0,
         size: 20,
+      });
+    });
+  });
+
+  it("query 검증 대상을 상단에 표시하고 시작 workflow 기본값으로 사용한다", async () => {
+    renderPage("/workspaces/1/simulation?packId=11&versionId=22&workflowId=100");
+
+    expect(await screen.findByText("Verification Target")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "환불 처리" })).toBeInTheDocument();
+    expect(screen.getByText("CS Support · Version #22 · refund.standard")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByLabelText("시작 workflow 선택")).toHaveValue("100");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "세션 생성" }));
+
+    await waitFor(() => {
+      expect(mockedSimulationApi.createSession).toHaveBeenCalledWith(1, {
+        customerName: "시뮬레이션 고객",
+        workflowDefinitionId: 100,
+      });
+    });
+  });
+
+  it("route state 검증 대상도 상단 대상과 시작 workflow 기본값으로 사용한다", async () => {
+    renderPage("/workspaces/1/simulation", {
+      simulationTarget: {
+        packId: 11,
+        versionId: 22,
+        workflowId: 100,
+      },
+    });
+
+    expect(await screen.findByText("Verification Target")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "환불 처리" })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByLabelText("시작 workflow 선택")).toHaveValue("100");
+    });
+  });
+
+  it("query 검증 대상이 있어도 사용자가 자동 매칭을 선택하면 workflow를 고정하지 않는다", async () => {
+    renderPage("/workspaces/1/simulation?packId=11&versionId=22&workflowId=100");
+
+    const workflowSelect = await screen.findByLabelText("시작 workflow 선택");
+    await waitFor(() => {
+      expect(workflowSelect).toHaveValue("100");
+    });
+
+    fireEvent.change(workflowSelect, { target: { value: "" } });
+    fireEvent.click(screen.getByRole("button", { name: "세션 생성" }));
+
+    await waitFor(() => {
+      expect(mockedSimulationApi.createSession).toHaveBeenCalledWith(1, {
+        customerName: "시뮬레이션 고객",
       });
     });
   });
@@ -399,12 +430,9 @@ describe("WorkspaceSimulationPage", () => {
   it("고객 메시지를 전송하고 응답을 화면에 반영한다", async () => {
     renderPage();
 
-    fireEvent.change(
-      await screen.findByPlaceholderText("고객 역할 메시지 입력"),
-      {
-        target: { value: "A-100 주문 환불이요" },
-      },
-    );
+    fireEvent.change(await screen.findByPlaceholderText("고객 역할 메시지 입력"), {
+      target: { value: "A-100 주문 환불이요" },
+    });
     fireEvent.click(screen.getByRole("button", { name: "전송" }));
 
     await waitFor(() => {
@@ -412,19 +440,14 @@ describe("WorkspaceSimulationPage", () => {
         content: "A-100 주문 환불이요",
       });
     });
-    expect(
-      await screen.findByText("주문번호를 알려주세요."),
-    ).toBeInTheDocument();
+    expect(await screen.findByText("주문번호를 알려주세요.")).toBeInTheDocument();
   });
 
   it("turn 단위 피드백을 작성하고 session 상세를 갱신한다", async () => {
     renderPage();
 
     fireEvent.click(await screen.findByLabelText("Turn 1 피드백 대상 선택"));
-    expect(screen.getByRole("tab", { name: "피드백" })).toHaveAttribute(
-      "aria-selected",
-      "true",
-    );
+    expect(screen.getByRole("tab", { name: "피드백" })).toHaveAttribute("aria-selected", "true");
     expect(await screen.findByLabelText("피드백 대상 선택")).toHaveValue("1");
     fireEvent.change(screen.getByLabelText("피드백 유형 선택"), {
       target: { value: "MISSING_SLOT_QUESTION" },
@@ -483,9 +506,7 @@ describe("WorkspaceSimulationPage", () => {
     await waitFor(() => {
       expect(screen.getByLabelText("피드백 대상 선택")).toHaveValue("session");
     });
-    expect(screen.getByLabelText("피드백 유형 선택")).toHaveValue(
-      "INTENT_MISMATCH",
-    );
+    expect(screen.getByLabelText("피드백 유형 선택")).toHaveValue("INTENT_MISMATCH");
     expect(screen.getByLabelText("피드백 심각도 선택")).toHaveValue("MEDIUM");
     expect(screen.getByLabelText("설명")).toHaveValue("");
     expect(screen.getByLabelText("기대 응답/행동")).toHaveValue("");
@@ -502,69 +523,45 @@ describe("WorkspaceSimulationPage", () => {
     fireEvent.change(screen.getByLabelText("기대 응답/행동"), {
       target: { value: "주문번호를 먼저 요청합니다." },
     });
-    mockedSimulationApi.listFeedback.mockRejectedValueOnce(
-      new Error("refresh failed"),
-    );
+    mockedSimulationApi.listFeedback.mockRejectedValueOnce(new Error("refresh failed"));
     fireEvent.click(screen.getByRole("button", { name: "피드백 저장" }));
 
     await waitFor(() => {
       expect(mockedSimulationApi.createFeedback).toHaveBeenCalled();
     });
-    expect(toast.success).toHaveBeenCalledWith(
-      "시뮬레이션 피드백을 남겼습니다.",
-    );
+    expect(toast.success).toHaveBeenCalledWith("시뮬레이션 피드백을 남겼습니다.");
     await waitFor(() => {
-      expect(
-        screen.getByText("시뮬레이션 피드백 목록을 불러오지 못했습니다."),
-      ).toBeInTheDocument();
+      expect(screen.getByText("시뮬레이션 피드백 목록을 불러오지 못했습니다.")).toBeInTheDocument();
     });
-    expect(toast.error).not.toHaveBeenCalledWith(
-      "시뮬레이션 피드백 목록을 불러오지 못했습니다.",
-    );
-    expect(toast.error).not.toHaveBeenCalledWith(
-      "시뮬레이션 피드백을 저장하지 못했습니다.",
-    );
+    expect(toast.error).not.toHaveBeenCalledWith("시뮬레이션 피드백 목록을 불러오지 못했습니다.");
+    expect(toast.error).not.toHaveBeenCalledWith("시뮬레이션 피드백을 저장하지 못했습니다.");
   });
 
   it("피드백 목록 로드 실패는 패널 내부 오류와 재시도를 제공한다", async () => {
-    mockedSimulationApi.listFeedback.mockRejectedValueOnce(
-      new Error("load failed"),
-    );
+    mockedSimulationApi.listFeedback.mockRejectedValueOnce(new Error("load failed"));
     renderPage();
 
     await openFeedbackTab();
     expect(
       await screen.findByText("시뮬레이션 피드백 목록을 불러오지 못했습니다."),
     ).toBeInTheDocument();
-    expect(toast.error).not.toHaveBeenCalledWith(
-      "시뮬레이션 피드백 목록을 불러오지 못했습니다.",
-    );
+    expect(toast.error).not.toHaveBeenCalledWith("시뮬레이션 피드백 목록을 불러오지 못했습니다.");
 
     fireEvent.click(screen.getByRole("button", { name: "다시 시도" }));
 
-    expect(
-      await screen.findByText("주문번호를 묻지 않았습니다."),
-    ).toBeInTheDocument();
+    expect(await screen.findByText("주문번호를 묻지 않았습니다.")).toBeInTheDocument();
   });
 
   it("검증 케이스 목록 로드 실패는 패널 내부 오류로 표시한다", async () => {
-    mockedSimulationApi.listGoldenCases.mockRejectedValueOnce(
-      new Error("load failed"),
-    );
+    mockedSimulationApi.listGoldenCases.mockRejectedValueOnce(new Error("load failed"));
     renderPage();
 
-    expect(
-      await screen.findByText("검증 케이스 목록을 불러오지 못했습니다."),
-    ).toBeInTheDocument();
-    expect(toast.error).not.toHaveBeenCalledWith(
-      "검증 케이스 목록을 불러오지 못했습니다.",
-    );
+    expect(await screen.findByText("검증 케이스 목록을 불러오지 못했습니다.")).toBeInTheDocument();
+    expect(toast.error).not.toHaveBeenCalledWith("검증 케이스 목록을 불러오지 못했습니다.");
 
     fireEvent.click(screen.getByRole("button", { name: "다시 시도" }));
 
-    expect(
-      await screen.findByText("저장된 검증 케이스가 없습니다."),
-    ).toBeInTheDocument();
+    expect(await screen.findByText("저장된 검증 케이스가 없습니다.")).toBeInTheDocument();
   });
 
   it("OPEN 피드백에서 개선 후보를 생성하고 목록을 새로고침한다", async () => {
@@ -574,16 +571,21 @@ describe("WorkspaceSimulationPage", () => {
     fireEvent.click(await screen.findByRole("button", { name: "후보" }));
 
     await waitFor(() => {
-      expect(
-        mockedSimulationApi.createImprovementCandidate,
-      ).toHaveBeenCalledWith(1, 900);
+      expect(mockedSimulationApi.createImprovementCandidate).toHaveBeenCalledWith(
+        1,
+        900,
+        expect.objectContaining({
+          targetElementType: "WORKFLOW",
+          targetElementId: 100,
+          targetElementKey: "refund_workflow",
+          afterSummary: "주문번호를 먼저 요청합니다.",
+        }),
+      );
     });
     expect(toast.success).toHaveBeenCalledWith("개선 후보를 생성했습니다.");
     await waitFor(() => {
       expect(mockedSimulationApi.listFeedback).toHaveBeenCalledTimes(2);
-      expect(
-        mockedSimulationApi.listImprovementCandidates,
-      ).toHaveBeenCalledTimes(2);
+      expect(mockedSimulationApi.listImprovementCandidates).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -598,22 +600,21 @@ describe("WorkspaceSimulationPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "후보" }));
 
     await waitFor(() => {
-      expect(
-        mockedSimulationApi.createImprovementCandidate,
-      ).toHaveBeenCalledWith(1, 900);
+      expect(mockedSimulationApi.createImprovementCandidate).toHaveBeenCalledWith(
+        1,
+        900,
+        expect.objectContaining({
+          targetElementType: "WORKFLOW",
+          targetElementId: 100,
+        }),
+      );
     });
     expect(toast.success).toHaveBeenCalledWith("개선 후보를 생성했습니다.");
     await waitFor(() => {
-      expect(
-        screen.getByText("개선 후보 목록을 불러오지 못했습니다."),
-      ).toBeInTheDocument();
+      expect(screen.getByText("개선 후보 목록을 불러오지 못했습니다.")).toBeInTheDocument();
     });
-    expect(toast.error).not.toHaveBeenCalledWith(
-      "개선 후보 목록을 불러오지 못했습니다.",
-    );
-    expect(toast.error).not.toHaveBeenCalledWith(
-      "개선 후보를 생성하지 못했습니다.",
-    );
+    expect(toast.error).not.toHaveBeenCalledWith("개선 후보 목록을 불러오지 못했습니다.");
+    expect(toast.error).not.toHaveBeenCalledWith("개선 후보를 생성하지 못했습니다.");
   });
 
   it("개선 후보 상태를 변경하고 후보 목록을 새로고침한다", async () => {
@@ -630,24 +631,15 @@ describe("WorkspaceSimulationPage", () => {
     fireEvent.click(await screen.findByRole("button", { name: "리뷰 요청" }));
 
     await waitFor(() => {
-      expect(
-        mockedSimulationApi.updateImprovementCandidateStatus,
-      ).toHaveBeenCalledWith(1, 1000, {
+      expect(mockedSimulationApi.updateImprovementCandidateStatus).toHaveBeenCalledWith(1, 1000, {
         status: "READY_FOR_REVIEW",
       });
     });
-    expect(toast.success).toHaveBeenCalledWith(
-      "개선 후보 상태를 변경했습니다.",
-    );
+    expect(toast.success).toHaveBeenCalledWith("개선 후보 상태를 변경했습니다.");
     await waitFor(() => {
-      expect(
-        mockedSimulationApi.listImprovementCandidates,
-      ).toHaveBeenCalledTimes(2);
+      expect(mockedSimulationApi.listImprovementCandidates).toHaveBeenCalledTimes(2);
     });
-    expect(screen.getByRole("tab", { name: "개선 후보" })).toHaveAttribute(
-      "aria-selected",
-      "true",
-    );
+    expect(screen.getByRole("tab", { name: "개선 후보" })).toHaveAttribute("aria-selected", "true");
   });
 
   it("개선 후보 상태 변경 후 목록 새로고침 실패는 변경 실패로 처리하지 않는다", async () => {
@@ -670,26 +662,16 @@ describe("WorkspaceSimulationPage", () => {
     fireEvent.click(requestButton);
 
     await waitFor(() => {
-      expect(
-        mockedSimulationApi.updateImprovementCandidateStatus,
-      ).toHaveBeenCalledWith(1, 1000, {
+      expect(mockedSimulationApi.updateImprovementCandidateStatus).toHaveBeenCalledWith(1, 1000, {
         status: "READY_FOR_REVIEW",
       });
     });
-    expect(toast.success).toHaveBeenCalledWith(
-      "개선 후보 상태를 변경했습니다.",
-    );
+    expect(toast.success).toHaveBeenCalledWith("개선 후보 상태를 변경했습니다.");
     await waitFor(() => {
-      expect(
-        screen.getByText("개선 후보 목록을 불러오지 못했습니다."),
-      ).toBeInTheDocument();
+      expect(screen.getByText("개선 후보 목록을 불러오지 못했습니다.")).toBeInTheDocument();
     });
-    expect(toast.error).not.toHaveBeenCalledWith(
-      "개선 후보 목록을 불러오지 못했습니다.",
-    );
-    expect(toast.error).not.toHaveBeenCalledWith(
-      "개선 후보 상태를 변경하지 못했습니다.",
-    );
+    expect(toast.error).not.toHaveBeenCalledWith("개선 후보 목록을 불러오지 못했습니다.");
+    expect(toast.error).not.toHaveBeenCalledWith("개선 후보 상태를 변경하지 못했습니다.");
   });
 
   it("개선 후보 유형 라벨을 표시한다", async () => {
@@ -702,10 +684,7 @@ describe("WorkspaceSimulationPage", () => {
         candidateWithType(1005, "HANDOFF_CONDITION"),
         candidateWithType(1006, "RESPONSE_COPY"),
         candidateWithType(1007, "OTHER"),
-        candidateWithType(
-          1008,
-          "CUSTOM" as SimulationImprovementCandidate["candidateType"],
-        ),
+        candidateWithType(1008, "CUSTOM" as SimulationImprovementCandidate["candidateType"]),
       ],
       page: 0,
       size: 20,
@@ -715,10 +694,7 @@ describe("WorkspaceSimulationPage", () => {
     renderPage();
 
     await openCandidateTab();
-    expect(screen.getByRole("tab", { name: "개선 후보" })).toHaveAttribute(
-      "aria-selected",
-      "true",
-    );
+    expect(screen.getByRole("tab", { name: "개선 후보" })).toHaveAttribute("aria-selected", "true");
     expect(await screen.findByText("intent 설명/예시")).toBeInTheDocument();
     expect(screen.getByText("policy 조건")).toBeInTheDocument();
     expect(screen.getByText("risk rule")).toBeInTheDocument();
@@ -733,24 +709,16 @@ describe("WorkspaceSimulationPage", () => {
   });
 
   it("개선 후보 목록 로드 실패는 패널 내부 오류와 재시도를 제공한다", async () => {
-    mockedSimulationApi.listImprovementCandidates.mockRejectedValueOnce(
-      new Error("load failed"),
-    );
+    mockedSimulationApi.listImprovementCandidates.mockRejectedValueOnce(new Error("load failed"));
     renderPage();
 
     await openCandidateTab();
-    expect(
-      await screen.findByText("개선 후보 목록을 불러오지 못했습니다."),
-    ).toBeInTheDocument();
-    expect(toast.error).not.toHaveBeenCalledWith(
-      "개선 후보 목록을 불러오지 못했습니다.",
-    );
+    expect(await screen.findByText("개선 후보 목록을 불러오지 못했습니다.")).toBeInTheDocument();
+    expect(toast.error).not.toHaveBeenCalledWith("개선 후보 목록을 불러오지 못했습니다.");
 
     fireEvent.click(screen.getByRole("button", { name: "다시 시도" }));
 
-    expect(
-      await screen.findByText("조건에 맞는 개선 후보가 없습니다."),
-    ).toBeInTheDocument();
+    expect(await screen.findByText("조건에 맞는 개선 후보가 없습니다.")).toBeInTheDocument();
   });
 
   it("개선 후보 생성 실패를 토스트로 알린다", async () => {
@@ -764,9 +732,7 @@ describe("WorkspaceSimulationPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "후보" }));
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith(
-        "개선 후보를 생성하지 못했습니다.",
-      );
+      expect(toast.error).toHaveBeenCalledWith("개선 후보를 생성하지 못했습니다.");
     });
   });
 
@@ -790,9 +756,7 @@ describe("WorkspaceSimulationPage", () => {
     fireEvent.click(requestButton);
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith(
-        "개선 후보 상태를 변경하지 못했습니다.",
-      );
+      expect(toast.error).toHaveBeenCalledWith("개선 후보 상태를 변경하지 못했습니다.");
     });
   });
 
@@ -817,19 +781,13 @@ describe("WorkspaceSimulationPage", () => {
     fireEvent.click(await screen.findByRole("button", { name: "승인" }));
 
     await waitFor(() => {
-      expect(
-        mockedSimulationApi.approveImprovementCandidate,
-      ).toHaveBeenCalledWith(1, 1000, {
+      expect(mockedSimulationApi.approveImprovementCandidate).toHaveBeenCalledWith(1, 1000, {
         reason: "시뮬레이션 리뷰 승인",
       });
     });
-    expect(toast.success).toHaveBeenCalledWith(
-      "개선 후보를 초안 버전에 반영했습니다.",
-    );
+    expect(toast.success).toHaveBeenCalledWith("개선 후보를 초안 버전에 반영했습니다.");
     await waitFor(() => {
-      expect(
-        mockedSimulationApi.listImprovementCandidates,
-      ).toHaveBeenCalledTimes(2);
+      expect(mockedSimulationApi.listImprovementCandidates).toHaveBeenCalledTimes(2);
       expect(mockedSimulationApi.listFeedback).toHaveBeenCalledTimes(2);
     });
   });
@@ -882,9 +840,7 @@ describe("WorkspaceSimulationPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "반려" }));
 
     await waitFor(() => {
-      expect(
-        mockedSimulationApi.rejectImprovementCandidate,
-      ).toHaveBeenCalledWith(1, 1000, {
+      expect(mockedSimulationApi.rejectImprovementCandidate).toHaveBeenCalledWith(1, 1000, {
         reason: "근거가 부족합니다.",
       });
     });
@@ -930,22 +886,14 @@ describe("WorkspaceSimulationPage", () => {
     await waitFor(() => {
       expect(screen.getByLabelText("Replay version")).toHaveValue("101");
     });
-    fireEvent.click(
-      await screen.findByRole("button", { name: "환불 검증 replay" }),
-    );
+    fireEvent.click(await screen.findByRole("button", { name: "환불 검증 replay" }));
 
     await waitFor(() => {
-      expect(mockedSimulationApi.replayGoldenCase).toHaveBeenCalledWith(
-        1,
-        950,
-        {
-          domainPackVersionId: 101,
-        },
-      );
+      expect(mockedSimulationApi.replayGoldenCase).toHaveBeenCalledWith(1, 950, {
+        domainPackVersionId: 101,
+      });
     });
-    expect(toast.success).toHaveBeenCalledWith(
-      "검증 케이스 replay가 통과했습니다.",
-    );
+    expect(toast.success).toHaveBeenCalledWith("검증 케이스 replay가 통과했습니다.");
   });
 
   it("최근 replay 실패 요약을 검증 케이스 목록에 표시한다", async () => {
@@ -965,9 +913,7 @@ describe("WorkspaceSimulationPage", () => {
 
     expect(await screen.findByText("FAIL")).toBeInTheDocument();
     expect(
-      screen.getByText(
-        "currentState expected collect_order_no but was handoff",
-      ),
+      screen.getByText("currentState expected collect_order_no but was handoff"),
     ).toBeInTheDocument();
   });
 
@@ -1003,9 +949,7 @@ describe("WorkspaceSimulationPage", () => {
     });
 
     await waitFor(() => {
-      expect(
-        mockedSimulationApi.listImprovementCandidates,
-      ).toHaveBeenCalledWith(1, {
+      expect(mockedSimulationApi.listImprovementCandidates).toHaveBeenCalledWith(1, {
         status: "READY_FOR_REVIEW",
         page: 0,
         size: 20,

--- a/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import {
   Navigate,
+  useLocation,
   useOutletContext,
   useParams,
   useSearchParams,
@@ -17,7 +18,7 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 
-import { useListAllWorkspaceWorkflows } from "@/entities/workflow";
+import { useListAllWorkspaceWorkflows, type WorkspaceWorkflowEntry } from "@/entities/workflow";
 import {
   simulationApi,
   type SimulationFeedback,
@@ -30,10 +31,7 @@ import {
   type SimulationImprovementCandidateStatus,
   type SimulationSessionDetail,
 } from "@/features/simulation";
-import type {
-  ChatMessage,
-  ChatSession,
-} from "@/features/consultation/api/consultationApi";
+import type { ChatMessage, ChatSession } from "@/features/consultation/api/consultationApi";
 import { parseRouteId } from "@/shared/lib/parseRouteId";
 import type { ShellContext } from "@/shared/ui/ostone/chrome";
 import { Button } from "@/shared/ui/button";
@@ -48,16 +46,15 @@ const PAGE_SIZE = 20;
 const DEFAULT_FEEDBACK_TYPE: SimulationFeedbackType = "INTENT_MISMATCH";
 const DEFAULT_FEEDBACK_SEVERITY: SimulationFeedbackSeverity = "MEDIUM";
 
-const FEEDBACK_TYPES: Array<{ value: SimulationFeedbackType; label: string }> =
-  [
-    { value: "INTENT_MISMATCH", label: "잘못된 intent 매칭" },
-    { value: "MISSING_SLOT_QUESTION", label: "누락된 slot 질문" },
-    { value: "INAPPROPRIATE_RESPONSE", label: "부적절한 응답 문구" },
-    { value: "POLICY_CONDITION_MISSING", label: "policy 조건 누락" },
-    { value: "RISK_HANDOFF_REQUIRED", label: "risk/handoff 필요" },
-    { value: "WORKFLOW_BRANCH_ERROR", label: "workflow 분기 오류" },
-    { value: "OTHER", label: "기타" },
-  ];
+const FEEDBACK_TYPES: Array<{ value: SimulationFeedbackType; label: string }> = [
+  { value: "INTENT_MISMATCH", label: "잘못된 intent 매칭" },
+  { value: "MISSING_SLOT_QUESTION", label: "누락된 slot 질문" },
+  { value: "INAPPROPRIATE_RESPONSE", label: "부적절한 응답 문구" },
+  { value: "POLICY_CONDITION_MISSING", label: "policy 조건 누락" },
+  { value: "RISK_HANDOFF_REQUIRED", label: "risk/handoff 필요" },
+  { value: "WORKFLOW_BRANCH_ERROR", label: "workflow 분기 오류" },
+  { value: "OTHER", label: "기타" },
+];
 
 const FEEDBACK_SEVERITIES: Array<{
   value: SimulationFeedbackSeverity;
@@ -95,16 +92,21 @@ const FEEDBACK_LIST_ERROR = "시뮬레이션 피드백 목록을 불러오지 �
 const CANDIDATE_LIST_ERROR = "개선 후보 목록을 불러오지 못했습니다.";
 const GOLDEN_CASE_LIST_ERROR = "검증 케이스 목록을 불러오지 못했습니다.";
 
-const ACTION_TYPES = [
-  "ASK_SLOT",
-  "ADVANCE",
-  "ANSWER",
-  "COMPLETED",
-  "HANDOFF",
-  "WAIT",
-] as const;
+const ACTION_TYPES = ["ASK_SLOT", "ADVANCE", "ANSWER", "COMPLETED", "HANDOFF", "WAIT"] as const;
 
 type SimulationSideTab = "state" | "feedback" | "candidates";
+
+interface SimulationTarget {
+  packId: number | null;
+  versionId: number | null;
+  workflowId: number | null;
+}
+
+interface CandidateWorkflowTarget {
+  workflowId: number;
+  workflowCode: string | null;
+  workflowName: string;
+}
 
 const SIDE_TABS: Array<{ value: SimulationSideTab; label: string }> = [
   { value: "state", label: "상태" },
@@ -118,9 +120,7 @@ function readInitialSideTab(searchParams: URLSearchParams): SimulationSideTab {
   return "state";
 }
 
-function readFeedbackStatusParam(
-  searchParams: URLSearchParams,
-): SimulationFeedbackStatus | "" {
+function readFeedbackStatusParam(searchParams: URLSearchParams): SimulationFeedbackStatus | "" {
   const value = searchParams.get("feedbackStatus");
   return FEEDBACK_STATUSES.some((status) => status.value === value)
     ? (value as SimulationFeedbackStatus | "")
@@ -134,6 +134,79 @@ function readCandidateStatusParam(
   return CANDIDATE_STATUSES.some((status) => status.value === value)
     ? (value as SimulationImprovementCandidateStatus | "")
     : "DRAFT";
+}
+
+function readPositiveIntParam(
+  searchParams: URLSearchParams,
+  key: keyof SimulationTarget,
+): number | null {
+  return parseRouteId(searchParams.get(key) ?? undefined);
+}
+
+function readSimulationTargetFromSearch(searchParams: URLSearchParams): SimulationTarget | null {
+  const packId = readPositiveIntParam(searchParams, "packId");
+  const versionId = readPositiveIntParam(searchParams, "versionId");
+  const workflowId = readPositiveIntParam(searchParams, "workflowId");
+  return packId !== null || versionId !== null || workflowId !== null
+    ? { packId, versionId, workflowId }
+    : null;
+}
+
+function readStateTargetId(value: unknown): number | null {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0 ? value : null;
+}
+
+function readSimulationTargetFromState(state: unknown): SimulationTarget | null {
+  if (typeof state !== "object" || state === null) return null;
+  const value = (state as { simulationTarget?: unknown }).simulationTarget;
+  if (typeof value !== "object" || value === null) return null;
+  const target = value as {
+    packId?: unknown;
+    versionId?: unknown;
+    workflowId?: unknown;
+  };
+  const packId = readStateTargetId(target.packId);
+  const versionId = readStateTargetId(target.versionId);
+  const workflowId = readStateTargetId(target.workflowId);
+  return packId !== null || versionId !== null || workflowId !== null
+    ? { packId, versionId, workflowId }
+    : null;
+}
+
+function findTargetWorkflow(
+  workflows: WorkspaceWorkflowEntry[],
+  target: SimulationTarget | null,
+): WorkspaceWorkflowEntry | null {
+  if (target?.workflowId === null || target?.workflowId === undefined) {
+    return null;
+  }
+
+  return (
+    workflows.find(
+      (workflow) =>
+        workflow.workflowId === target.workflowId &&
+        (target.packId === null || workflow.packId === target.packId) &&
+        (target.versionId === null || workflow.versionId === target.versionId),
+    ) ??
+    workflows.find((workflow) => workflow.workflowId === target.workflowId) ??
+    null
+  );
+}
+
+function formatTargetId(value: number | null, fallback: string): string {
+  return value === null ? fallback : `#${value}`;
+}
+
+function matchesTargetContext(
+  workflow: WorkspaceWorkflowEntry | null,
+  target: SimulationTarget | null,
+): boolean {
+  if (!workflow || !target) return false;
+  return (
+    (target.workflowId === null || workflow.workflowId === target.workflowId) &&
+    (target.packId === null || workflow.packId === target.packId) &&
+    (target.versionId === null || workflow.versionId === target.versionId)
+  );
 }
 
 type Meta = {
@@ -183,9 +256,7 @@ function customerName(session: ChatSession | null): string {
 
 function slotEntries(detail: SimulationSessionDetail | null) {
   const values = detail?.slotValues ?? {};
-  return Object.entries(values).filter(
-    ([, value]) => value !== null && value !== undefined,
-  );
+  return Object.entries(values).filter(([, value]) => value !== null && value !== undefined);
 }
 
 function feedbackTypeLabel(type: SimulationFeedbackType): string {
@@ -193,29 +264,18 @@ function feedbackTypeLabel(type: SimulationFeedbackType): string {
 }
 
 function feedbackSeverityLabel(severity: SimulationFeedbackSeverity): string {
-  return (
-    FEEDBACK_SEVERITIES.find((item) => item.value === severity)?.label ??
-    severity
-  );
+  return FEEDBACK_SEVERITIES.find((item) => item.value === severity)?.label ?? severity;
 }
 
 function feedbackStatusLabel(status: SimulationFeedbackStatus): string {
-  return (
-    FEEDBACK_STATUSES.find((item) => item.value === status)?.label ?? status
-  );
+  return FEEDBACK_STATUSES.find((item) => item.value === status)?.label ?? status;
 }
 
-function candidateStatusLabel(
-  status: SimulationImprovementCandidateStatus,
-): string {
-  return (
-    CANDIDATE_STATUSES.find((item) => item.value === status)?.label ?? status
-  );
+function candidateStatusLabel(status: SimulationImprovementCandidateStatus): string {
+  return CANDIDATE_STATUSES.find((item) => item.value === status)?.label ?? status;
 }
 
-function candidateTypeLabel(
-  type: SimulationImprovementCandidate["candidateType"],
-): string {
+function candidateTypeLabel(type: SimulationImprovementCandidate["candidateType"]): string {
   switch (type) {
     case "INTENT_DESCRIPTION_EXAMPLE":
       return "intent 설명/예시";
@@ -238,9 +298,13 @@ function candidateTypeLabel(
   }
 }
 
-function replayStatusLabel(
-  status?: SimulationGoldenCaseReplayStatus | null,
-): string {
+function candidateTargetLabel(candidate: SimulationImprovementCandidate): string {
+  const id = candidate.targetElementId ? ` #${candidate.targetElementId}` : "";
+  const key = candidate.targetElementKey ? ` · ${candidate.targetElementKey}` : "";
+  return `${candidate.targetElementType}${id}${key}`;
+}
+
+function replayStatusLabel(status?: SimulationGoldenCaseReplayStatus | null): string {
   switch (status) {
     case "PASS":
       return "PASS";
@@ -251,10 +315,7 @@ function replayStatusLabel(
   }
 }
 
-function readExpectedField(
-  goldenCase: SimulationGoldenCase,
-  field: string,
-): string | null {
+function readExpectedField(goldenCase: SimulationGoldenCase, field: string): string | null {
   try {
     const parsed = JSON.parse(goldenCase.expectedJson);
     if (parsed && typeof parsed === "object" && field in parsed) {
@@ -274,12 +335,19 @@ function optionalText(value?: string | null): string | undefined {
 
 export function WorkspaceSimulationPage() {
   const { workspaceId } = useParams();
+  const location = useLocation();
   const [searchParams] = useSearchParams();
   const searchQuery = searchParams.toString();
-  const querySearchParams = useMemo(
-    () => new URLSearchParams(searchQuery),
-    [searchQuery],
+  const querySearchParams = useMemo(() => new URLSearchParams(searchQuery), [searchQuery]);
+  const querySimulationTarget = useMemo(
+    () => readSimulationTargetFromSearch(querySearchParams),
+    [querySearchParams],
   );
+  const stateSimulationTarget = useMemo(
+    () => readSimulationTargetFromState(location.state),
+    [location.state],
+  );
+  const simulationTarget = querySimulationTarget ?? stateSimulationTarget;
   const feedbackStatusFromQuery = useMemo(
     () => readFeedbackStatusParam(querySearchParams),
     [querySearchParams],
@@ -292,19 +360,16 @@ export function WorkspaceSimulationPage() {
   const { setCrumbs } = useOutletContext<ShellContext>();
   const [sessions, setSessions] = useState<ChatSession[]>([]);
   const [detail, setDetail] = useState<SimulationSessionDetail | null>(null);
-  const [selectedSessionId, setSelectedSessionId] = useState<number | null>(
-    null,
-  );
+  const [selectedSessionId, setSelectedSessionId] = useState<number | null>(null);
   const [customerNameInput, setCustomerNameInput] = useState("시뮬레이션 고객");
   const [workflowDefinitionId, setWorkflowDefinitionId] = useState("");
+  const [workflowSelectionTouched, setWorkflowSelectionTouched] = useState(false);
   const [messageInput, setMessageInput] = useState("");
   const [feedbackItems, setFeedbackItems] = useState<SimulationFeedback[]>([]);
-  const [feedbackStatusFilter, setFeedbackStatusFilter] = useState<
-    SimulationFeedbackStatus | ""
-  >(() => feedbackStatusFromQuery);
-  const [candidateItems, setCandidateItems] = useState<
-    SimulationImprovementCandidate[]
-  >([]);
+  const [feedbackStatusFilter, setFeedbackStatusFilter] = useState<SimulationFeedbackStatus | "">(
+    () => feedbackStatusFromQuery,
+  );
+  const [candidateItems, setCandidateItems] = useState<SimulationImprovementCandidate[]>([]);
   const [goldenCases, setGoldenCases] = useState<SimulationGoldenCase[]>([]);
   const [feedbackError, setFeedbackError] = useState<string | null>(null);
   const [candidateError, setCandidateError] = useState<string | null>(null);
@@ -316,9 +381,7 @@ export function WorkspaceSimulationPage() {
     readInitialSideTab(querySearchParams),
   );
   const [feedbackTarget, setFeedbackTarget] = useState("session");
-  const [feedbackType, setFeedbackType] = useState<SimulationFeedbackType>(
-    DEFAULT_FEEDBACK_TYPE,
-  );
+  const [feedbackType, setFeedbackType] = useState<SimulationFeedbackType>(DEFAULT_FEEDBACK_TYPE);
   const [feedbackSeverity, setFeedbackSeverity] =
     useState<SimulationFeedbackSeverity>(DEFAULT_FEEDBACK_SEVERITY);
   const [feedbackDescription, setFeedbackDescription] = useState("");
@@ -335,30 +398,75 @@ export function WorkspaceSimulationPage() {
   const [isSending, setIsSending] = useState(false);
   const [isSubmittingFeedback, setIsSubmittingFeedback] = useState(false);
   const [isCreatingGoldenCase, setIsCreatingGoldenCase] = useState(false);
-  const [replayingGoldenCaseId, setReplayingGoldenCaseId] = useState<
-    number | null
-  >(null);
-  const [creatingCandidateId, setCreatingCandidateId] = useState<number | null>(
-    null,
-  );
-  const [updatingCandidateId, setUpdatingCandidateId] = useState<number | null>(
-    null,
-  );
-  const [candidateRejectReasons, setCandidateRejectReasons] = useState<
-    Record<number, string>
-  >({});
+  const [replayingGoldenCaseId, setReplayingGoldenCaseId] = useState<number | null>(null);
+  const [creatingCandidateId, setCreatingCandidateId] = useState<number | null>(null);
+  const [updatingCandidateId, setUpdatingCandidateId] = useState<number | null>(null);
+  const [candidateRejectReasons, setCandidateRejectReasons] = useState<Record<number, string>>({});
   const [error, setError] = useState<string | null>(null);
 
   const workflows = useListAllWorkspaceWorkflows({
     workspaceId: parsedWorkspaceId,
   });
+  const targetWorkflow = useMemo(
+    () => findTargetWorkflow(workflows.entries, simulationTarget),
+    [simulationTarget, workflows.entries],
+  );
   const selectedWorkflow = useMemo(() => {
     const numericId = Number(workflowDefinitionId);
-    return (
-      workflows.entries.find((entry) => entry.workflowId === numericId) ?? null
-    );
+    return workflows.entries.find((entry) => entry.workflowId === numericId) ?? null;
   }, [workflowDefinitionId, workflows.entries]);
+  const candidateWorkflowTarget = useMemo<CandidateWorkflowTarget | null>(() => {
+    if (selectedWorkflow) {
+      return {
+        workflowId: selectedWorkflow.workflowId,
+        workflowCode: selectedWorkflow.workflowCode,
+        workflowName: selectedWorkflow.name,
+      };
+    }
+
+    if (detail?.matchedWorkflow?.workflowDefinitionId) {
+      return {
+        workflowId: detail.matchedWorkflow.workflowDefinitionId,
+        workflowCode: detail.matchedWorkflow.workflowCode ?? null,
+        workflowName:
+          detail.matchedWorkflow.workflowName ??
+          detail.matchedWorkflow.workflowCode ??
+          `Workflow #${detail.matchedWorkflow.workflowDefinitionId}`,
+      };
+    }
+
+    if (targetWorkflow) {
+      return {
+        workflowId: targetWorkflow.workflowId,
+        workflowCode: targetWorkflow.workflowCode,
+        workflowName: targetWorkflow.name,
+      };
+    }
+
+    if (simulationTarget?.workflowId) {
+      return {
+        workflowId: simulationTarget.workflowId,
+        workflowCode: null,
+        workflowName: `Workflow #${simulationTarget.workflowId}`,
+      };
+    }
+
+    return null;
+  }, [detail?.matchedWorkflow, selectedWorkflow, simulationTarget, targetWorkflow]);
   const matched = detail?.matchedWorkflow ?? null;
+  const isTargetContextConfirmed = matchesTargetContext(targetWorkflow, simulationTarget);
+  const targetPackLabel =
+    (isTargetContextConfirmed ? targetWorkflow?.packName : null) ??
+    (simulationTarget ? `Pack ${formatTargetId(simulationTarget.packId, "미지정")}` : "");
+  const targetVersionLabel = simulationTarget
+    ? `Version ${formatTargetId(simulationTarget.versionId, "미지정")}`
+    : "";
+  const targetWorkflowLabel =
+    targetWorkflow?.name ??
+    (simulationTarget ? `Workflow ${formatTargetId(simulationTarget.workflowId, "미지정")}` : "");
+  const targetWorkflowMeta =
+    targetWorkflow?.workflowCode ??
+    (simulationTarget?.workflowId ? `workflowId ${simulationTarget.workflowId}` : "자동 매칭");
 
   const reloadFeedback = async (status = feedbackStatusFilter) => {
     if (parsedWorkspaceId === null) return;
@@ -382,14 +490,11 @@ export function WorkspaceSimulationPage() {
     if (parsedWorkspaceId === null) return;
     setCandidateError(null);
     try {
-      const page = await simulationApi.listImprovementCandidates(
-        parsedWorkspaceId,
-        {
-          status,
-          page: 0,
-          size: PAGE_SIZE,
-        },
-      );
+      const page = await simulationApi.listImprovementCandidates(parsedWorkspaceId, {
+        status,
+        page: 0,
+        size: PAGE_SIZE,
+      });
       setCandidateItems(page.content);
     } catch (error) {
       console.error("Failed to load simulation improvement candidates:", error);
@@ -430,6 +535,11 @@ export function WorkspaceSimulationPage() {
     setCandidateStatusFilter(candidateStatusFromQuery);
     setActiveSideTab(readInitialSideTab(querySearchParams));
   }, [candidateStatusFromQuery, feedbackStatusFromQuery, querySearchParams]);
+
+  useEffect(() => {
+    if (!simulationTarget?.workflowId || workflowSelectionTouched) return;
+    setWorkflowDefinitionId(String(simulationTarget.workflowId));
+  }, [simulationTarget?.workflowId, workflowSelectionTouched]);
 
   useEffect(() => {
     setFeedbackTarget("session");
@@ -529,10 +639,7 @@ export function WorkspaceSimulationPage() {
       })
       .catch((error) => {
         if (!active) return;
-        console.error(
-          "Failed to load simulation improvement candidates:",
-          error,
-        );
+        console.error("Failed to load simulation improvement candidates:", error);
         setCandidateItems([]);
         setCandidateError(CANDIDATE_LIST_ERROR);
       })
@@ -613,10 +720,17 @@ export function WorkspaceSimulationPage() {
     setIsCreating(true);
     setError(null);
     try {
+      const workflowIdForSession = workflowDefinitionId
+        ? Number(workflowDefinitionId)
+        : !workflowSelectionTouched && simulationTarget?.workflowId
+          ? simulationTarget.workflowId
+          : null;
       const created = await simulationApi.createSession(parsedWorkspaceId, {
         customerName: customerNameInput,
-        ...(workflowDefinitionId
-          ? { workflowDefinitionId: Number(workflowDefinitionId) }
+        ...(workflowIdForSession
+          ? {
+              workflowDefinitionId: workflowIdForSession,
+            }
           : {}),
       });
       setDetail(created);
@@ -635,13 +749,9 @@ export function WorkspaceSimulationPage() {
     setIsSending(true);
     setError(null);
     try {
-      const nextDetail = await simulationApi.sendMessage(
-        parsedWorkspaceId,
-        detail.session.id,
-        {
-          content,
-        },
-      );
+      const nextDetail = await simulationApi.sendMessage(parsedWorkspaceId, detail.session.id, {
+        content,
+      });
       setDetail(nextDetail);
       setMessageInput("");
       await reloadSessions();
@@ -656,21 +766,16 @@ export function WorkspaceSimulationPage() {
     const description = feedbackDescription.trim();
     const expectedBehavior = feedbackExpectedBehavior.trim();
     if (!description || !expectedBehavior || detail?.session.id == null) return;
-    const chatMessageId =
-      feedbackTarget === "session" ? null : Number.parseInt(feedbackTarget, 10);
+    const chatMessageId = feedbackTarget === "session" ? null : Number.parseInt(feedbackTarget, 10);
     setIsSubmittingFeedback(true);
     try {
-      const nextDetail = await simulationApi.createFeedback(
-        parsedWorkspaceId,
-        detail.session.id,
-        {
-          chatMessageId: Number.isNaN(chatMessageId) ? null : chatMessageId,
-          feedbackType,
-          description,
-          expectedBehavior,
-          severity: feedbackSeverity,
-        },
-      );
+      const nextDetail = await simulationApi.createFeedback(parsedWorkspaceId, detail.session.id, {
+        chatMessageId: Number.isNaN(chatMessageId) ? null : chatMessageId,
+        feedbackType,
+        description,
+        expectedBehavior,
+        severity: feedbackSeverity,
+      });
       setDetail(nextDetail);
       setFeedbackDescription("");
       setFeedbackExpectedBehavior("");
@@ -686,9 +791,20 @@ export function WorkspaceSimulationPage() {
   const handleCreateCandidate = async (feedback: SimulationFeedback) => {
     setCreatingCandidateId(feedback.id);
     try {
+      const workflowTargetPayload = candidateWorkflowTarget
+        ? {
+            targetElementType: "WORKFLOW" as const,
+            targetElementId: candidateWorkflowTarget.workflowId,
+            targetElementKey:
+              candidateWorkflowTarget.workflowCode ?? candidateWorkflowTarget.workflowName,
+            beforeSummary: `${candidateWorkflowTarget.workflowName} workflow 피드백: ${feedback.description}`,
+            afterSummary: feedback.expectedBehavior,
+          }
+        : undefined;
       await simulationApi.createImprovementCandidate(
         parsedWorkspaceId,
         feedback.id,
+        workflowTargetPayload,
       );
       toast.success("개선 후보를 생성했습니다.");
       setActiveSideTab("candidates");
@@ -706,13 +822,9 @@ export function WorkspaceSimulationPage() {
   ) => {
     setUpdatingCandidateId(candidate.id);
     try {
-      await simulationApi.updateImprovementCandidateStatus(
-        parsedWorkspaceId,
-        candidate.id,
-        {
-          status,
-        },
-      );
+      await simulationApi.updateImprovementCandidateStatus(parsedWorkspaceId, candidate.id, {
+        status,
+      });
       toast.success("개선 후보 상태를 변경했습니다.");
       await reloadCandidates().catch(() => undefined);
     } catch {
@@ -722,18 +834,12 @@ export function WorkspaceSimulationPage() {
     }
   };
 
-  const handleApproveCandidate = async (
-    candidate: SimulationImprovementCandidate,
-  ) => {
+  const handleApproveCandidate = async (candidate: SimulationImprovementCandidate) => {
     setUpdatingCandidateId(candidate.id);
     try {
-      await simulationApi.approveImprovementCandidate(
-        parsedWorkspaceId,
-        candidate.id,
-        {
-          reason: "시뮬레이션 리뷰 승인",
-        },
-      );
+      await simulationApi.approveImprovementCandidate(parsedWorkspaceId, candidate.id, {
+        reason: "시뮬레이션 리뷰 승인",
+      });
       toast.success("개선 후보를 초안 버전에 반영했습니다.");
       await reloadFeedbackAndCandidates();
     } catch {
@@ -743,9 +849,7 @@ export function WorkspaceSimulationPage() {
     }
   };
 
-  const handleRejectCandidate = async (
-    candidate: SimulationImprovementCandidate,
-  ) => {
+  const handleRejectCandidate = async (candidate: SimulationImprovementCandidate) => {
     const reason = (candidateRejectReasons[candidate.id] ?? "").trim();
     if (!reason) {
       toast.error("반려 사유를 입력하세요.");
@@ -753,11 +857,7 @@ export function WorkspaceSimulationPage() {
     }
     setUpdatingCandidateId(candidate.id);
     try {
-      await simulationApi.rejectImprovementCandidate(
-        parsedWorkspaceId,
-        candidate.id,
-        { reason },
-      );
+      await simulationApi.rejectImprovementCandidate(parsedWorkspaceId, candidate.id, { reason });
       toast.success("개선 후보를 반려했습니다.");
       setCandidateRejectReasons((current) => {
         const next = { ...current };
@@ -776,8 +876,7 @@ export function WorkspaceSimulationPage() {
     if (detail?.session.id == null) return;
     if (
       messages.filter(
-        (message) =>
-          message.senderRole === "USER" || message.senderRole === "CUSTOMER",
+        (message) => message.senderRole === "USER" || message.senderRole === "CUSTOMER",
       ).length === 0
     ) {
       toast.error("고객 메시지가 있어야 검증 케이스로 저장할 수 있습니다.");
@@ -785,18 +884,14 @@ export function WorkspaceSimulationPage() {
     }
     setIsCreatingGoldenCase(true);
     try {
-      await simulationApi.createGoldenCase(
-        parsedWorkspaceId,
-        detail.session.id,
-        {
-          name: optionalText(goldenCaseName),
-          expectedIntentCode: optionalText(matched?.intentCode),
-          expectedWorkflowCode: optionalText(matched?.workflowCode),
-          expectedCurrentState: optionalText(matched?.currentState),
-          expectedActionType: optionalText(expectedActionType),
-          expectedSlotValues: detail.slotValues ?? {},
-        },
-      );
+      await simulationApi.createGoldenCase(parsedWorkspaceId, detail.session.id, {
+        name: optionalText(goldenCaseName),
+        expectedIntentCode: optionalText(matched?.intentCode),
+        expectedWorkflowCode: optionalText(matched?.workflowCode),
+        expectedCurrentState: optionalText(matched?.currentState),
+        expectedActionType: optionalText(expectedActionType),
+        expectedSlotValues: detail.slotValues ?? {},
+      });
       toast.success("검증 케이스를 저장했습니다.");
       await reloadGoldenCases().catch(() => undefined);
     } catch {
@@ -814,13 +909,9 @@ export function WorkspaceSimulationPage() {
     }
     setReplayingGoldenCaseId(goldenCase.id);
     try {
-      const result = await simulationApi.replayGoldenCase(
-        parsedWorkspaceId,
-        goldenCase.id,
-        {
-          domainPackVersionId: versionId,
-        },
-      );
+      const result = await simulationApi.replayGoldenCase(parsedWorkspaceId, goldenCase.id, {
+        domainPackVersionId: versionId,
+      });
       toast.success(
         result.status === "PASS"
           ? "검증 케이스 replay가 통과했습니다."
@@ -837,13 +928,9 @@ export function WorkspaceSimulationPage() {
   const messages = detail?.messages ?? [];
   const slots = slotEntries(detail);
   const feedbackCounts = detail?.feedback?.messageFeedbackCounts ?? {};
-  const selectedFeedbackTarget = messages.find(
-    (message) => String(message.id) === feedbackTarget,
-  );
+  const selectedFeedbackTarget = messages.find((message) => String(message.id) === feedbackTarget);
   const selectedTargetLabel =
-    feedbackTarget === "session"
-      ? "세션 전체"
-      : `Turn ${selectedFeedbackTarget?.seqNo ?? ""}`;
+    feedbackTarget === "session" ? "세션 전체" : `Turn ${selectedFeedbackTarget?.seqNo ?? ""}`;
 
   return (
     <div className={styles.pageWrapper}>
@@ -852,8 +939,7 @@ export function WorkspaceSimulationPage() {
           <p className={styles.eyebrow}>Simulation Lab</p>
           <h1 className={styles.pageTitle}>상담 시뮬레이션</h1>
           <p className={styles.pageSubtitle}>
-            운영 중인 Domain Pack 기준으로 고객 문의를 시험하고 매칭된 workflow
-            상태를 확인합니다.
+            운영 중인 Domain Pack 기준으로 고객 문의를 시험하고 매칭된 workflow 상태를 확인합니다.
           </p>
         </div>
         <Button
@@ -874,10 +960,22 @@ export function WorkspaceSimulationPage() {
 
       {error ? <ErrorState message={error} /> : null}
 
-      <section
-        className={styles.createPanel}
-        aria-labelledby="simulation-create-title"
-      >
+      {simulationTarget ? (
+        <section className={styles.targetBanner} aria-labelledby="simulation-target-title">
+          <div>
+            <p className={styles.eyebrow}>Verification Target</p>
+            <h2 id="simulation-target-title">{targetWorkflowLabel}</h2>
+            <p>
+              {targetPackLabel} · {targetVersionLabel} · {targetWorkflowMeta}
+            </p>
+          </div>
+          <span className={styles.targetBadge}>
+            {isTargetContextConfirmed ? "대상 확인됨" : "대상 ID 유지"}
+          </span>
+        </section>
+      ) : null}
+
+      <section className={styles.createPanel} aria-labelledby="simulation-create-title">
         <div>
           <h2 id="simulation-create-title" className={styles.sectionTitle}>
             새 시뮬레이션
@@ -898,25 +996,26 @@ export function WorkspaceSimulationPage() {
           <span>시작 workflow</span>
           <NativeSelect
             value={workflowDefinitionId}
-            onChange={(event) => setWorkflowDefinitionId(event.target.value)}
+            onChange={(event) => {
+              setWorkflowSelectionTouched(true);
+              setWorkflowDefinitionId(event.target.value);
+            }}
             aria-label="시작 workflow 선택"
           >
             <NativeSelectOption value="">자동 매칭</NativeSelectOption>
+            {simulationTarget?.workflowId && !targetWorkflow ? (
+              <NativeSelectOption value={String(simulationTarget.workflowId)}>
+                {targetWorkflowLabel}
+              </NativeSelectOption>
+            ) : null}
             {workflows.entries.map((workflow) => (
-              <NativeSelectOption
-                key={workflow.workflowId}
-                value={String(workflow.workflowId)}
-              >
+              <NativeSelectOption key={workflow.workflowId} value={String(workflow.workflowId)}>
                 {workflow.packName} · {workflow.name}
               </NativeSelectOption>
             ))}
           </NativeSelect>
         </label>
-        <Button
-          type="button"
-          onClick={handleCreateSession}
-          disabled={isCreating}
-        >
+        <Button type="button" onClick={handleCreateSession} disabled={isCreating}>
           <PlusIcon className={styles.buttonIcon} />
           <span>{isCreating ? "생성 중" : "세션 생성"}</span>
         </Button>
@@ -962,11 +1061,13 @@ export function WorkspaceSimulationPage() {
         <section className={styles.chatPane} aria-label="시뮬레이션 대화">
           <div className={styles.paneHeader}>
             <div>
-              <h2 className={styles.sectionTitle}>
-                {customerName(detail?.session ?? null)}
-              </h2>
+              <h2 className={styles.sectionTitle}>{customerName(detail?.session ?? null)}</h2>
               <p className={styles.sectionDescription}>
-                {selectedWorkflow ? selectedWorkflow.name : "자동 매칭"}{" "}
+                {selectedWorkflow?.name ??
+                  targetWorkflow?.name ??
+                  (simulationTarget?.workflowId
+                    ? `Workflow #${simulationTarget.workflowId}`
+                    : "자동 매칭")}{" "}
                 기준으로 응답합니다.
               </p>
             </div>
@@ -986,22 +1087,13 @@ export function WorkspaceSimulationPage() {
             <>
               <div className={styles.messageList}>
                 {messages.length === 0 ? (
-                  <p className={styles.emptyMessage}>
-                    고객 메시지를 입력하면 응답이 생성됩니다.
-                  </p>
+                  <p className={styles.emptyMessage}>고객 메시지를 입력하면 응답이 생성됩니다.</p>
                 ) : (
                   messages.map((message, index) => (
                     <MessageBubble
-                      key={
-                        message.id ??
-                        `${message.seqNo ?? index}-${message.createdAt ?? ""}`
-                      }
+                      key={message.id ?? `${message.seqNo ?? index}-${message.createdAt ?? ""}`}
                       message={message}
-                      feedbackCount={
-                        message.id
-                          ? (feedbackCounts[String(message.id)] ?? 0)
-                          : 0
-                      }
+                      feedbackCount={message.id ? (feedbackCounts[String(message.id)] ?? 0) : 0}
                       onFeedbackClick={
                         message.id
                           ? () => {
@@ -1041,15 +1133,8 @@ export function WorkspaceSimulationPage() {
           )}
         </section>
 
-        <aside
-          className={styles.statePane}
-          aria-label="시뮬레이션 상태와 개선 작업"
-        >
-          <div
-            className={styles.sideTabList}
-            role="tablist"
-            aria-label="시뮬레이션 우측 패널"
-          >
+        <aside className={styles.statePane} aria-label="시뮬레이션 상태와 개선 작업">
+          <div className={styles.sideTabList} role="tablist" aria-label="시뮬레이션 우측 패널">
             {SIDE_TABS.map((tab) => (
               <button
                 key={tab.value}
@@ -1077,15 +1162,11 @@ export function WorkspaceSimulationPage() {
               <dl className={styles.stateList}>
                 <div>
                   <dt>Intent</dt>
-                  <dd>
-                    {matched?.intentName ?? matched?.intentCode ?? "미매칭"}
-                  </dd>
+                  <dd>{matched?.intentName ?? matched?.intentCode ?? "미매칭"}</dd>
                 </div>
                 <div>
                   <dt>Workflow</dt>
-                  <dd>
-                    {matched?.workflowName ?? matched?.workflowCode ?? "미매칭"}
-                  </dd>
+                  <dd>{matched?.workflowName ?? matched?.workflowCode ?? "미매칭"}</dd>
                 </div>
                 <div>
                   <dt>Current State</dt>
@@ -1093,11 +1174,7 @@ export function WorkspaceSimulationPage() {
                 </div>
                 <div>
                   <dt>Status</dt>
-                  <dd>
-                    {matched?.executionStatus ??
-                      detail?.session.status ??
-                      "대기"}
-                  </dd>
+                  <dd>{matched?.executionStatus ?? detail?.session.status ?? "대기"}</dd>
                 </div>
               </dl>
 
@@ -1135,14 +1212,10 @@ export function WorkspaceSimulationPage() {
                   <span>기대 action</span>
                   <NativeSelect
                     value={expectedActionType}
-                    onChange={(event) =>
-                      setExpectedActionType(event.target.value)
-                    }
+                    onChange={(event) => setExpectedActionType(event.target.value)}
                     aria-label="기대 action"
                   >
-                    <NativeSelectOption value="">
-                      현재 replay에서 비교 안 함
-                    </NativeSelectOption>
+                    <NativeSelectOption value="">현재 replay에서 비교 안 함</NativeSelectOption>
                     {ACTION_TYPES.map((type) => (
                       <NativeSelectOption key={type} value={type}>
                         {type}
@@ -1168,9 +1241,7 @@ export function WorkspaceSimulationPage() {
                   <span>{isCreatingGoldenCase ? "저장 중" : "등록"}</span>
                 </Button>
                 {isLoadingGoldenCases ? (
-                  <p className={styles.feedbackMuted}>
-                    검증 케이스를 불러오는 중입니다.
-                  </p>
+                  <p className={styles.feedbackMuted}>검증 케이스를 불러오는 중입니다.</p>
                 ) : goldenCaseError ? (
                   <div className={styles.secondaryErrorState}>
                     <ErrorState
@@ -1181,22 +1252,13 @@ export function WorkspaceSimulationPage() {
                     />
                   </div>
                 ) : goldenCases.length === 0 ? (
-                  <p className={styles.feedbackMuted}>
-                    저장된 검증 케이스가 없습니다.
-                  </p>
+                  <p className={styles.feedbackMuted}>저장된 검증 케이스가 없습니다.</p>
                 ) : (
                   <ul className={styles.goldenCaseList}>
                     {goldenCases.map((goldenCase) => {
-                      const replayStatus =
-                        goldenCase.latestReplayResult?.status;
-                      const state = readExpectedField(
-                        goldenCase,
-                        "currentState",
-                      );
-                      const action = readExpectedField(
-                        goldenCase,
-                        "actionType",
-                      );
+                      const replayStatus = goldenCase.latestReplayResult?.status;
+                      const state = readExpectedField(goldenCase, "currentState");
+                      const action = readExpectedField(goldenCase, "actionType");
                       return (
                         <li key={goldenCase.id}>
                           <div className={styles.feedbackRowHeader}>
@@ -1220,9 +1282,7 @@ export function WorkspaceSimulationPage() {
                               {replayStatus === "FAIL" ? (
                                 <XCircleIcon className={styles.buttonIcon} />
                               ) : replayStatus === "PASS" ? (
-                                <CheckCircleIcon
-                                  className={styles.buttonIcon}
-                                />
+                                <CheckCircleIcon className={styles.buttonIcon} />
                               ) : (
                                 <PlayIcon className={styles.buttonIcon} />
                               )}
@@ -1239,17 +1299,13 @@ export function WorkspaceSimulationPage() {
                               type="button"
                               variant="outline"
                               size="sm"
-                              onClick={() =>
-                                void handleReplayGoldenCase(goldenCase)
-                              }
+                              onClick={() => void handleReplayGoldenCase(goldenCase)}
                               disabled={replayingGoldenCaseId === goldenCase.id}
                               aria-label={`${goldenCase.name} replay`}
                             >
                               <PlayIcon className={styles.buttonIcon} />
                               <span>
-                                {replayingGoldenCaseId === goldenCase.id
-                                  ? "Replay 중"
-                                  : "Replay"}
+                                {replayingGoldenCaseId === goldenCase.id ? "Replay 중" : "Replay"}
                               </span>
                             </Button>
                           </div>
@@ -1281,9 +1337,7 @@ export function WorkspaceSimulationPage() {
                     onChange={(event) => setFeedbackTarget(event.target.value)}
                     aria-label="피드백 대상 선택"
                   >
-                    <NativeSelectOption value="session">
-                      세션 전체
-                    </NativeSelectOption>
+                    <NativeSelectOption value="session">세션 전체</NativeSelectOption>
                     {messages.map((message) => (
                       <NativeSelectOption
                         key={message.id ?? message.seqNo}
@@ -1300,9 +1354,7 @@ export function WorkspaceSimulationPage() {
                   <NativeSelect
                     value={feedbackType}
                     onChange={(event) =>
-                      setFeedbackType(
-                        event.target.value as SimulationFeedbackType,
-                      )
+                      setFeedbackType(event.target.value as SimulationFeedbackType)
                     }
                     aria-label="피드백 유형 선택"
                   >
@@ -1318,9 +1370,7 @@ export function WorkspaceSimulationPage() {
                   <NativeSelect
                     value={feedbackSeverity}
                     onChange={(event) =>
-                      setFeedbackSeverity(
-                        event.target.value as SimulationFeedbackSeverity,
-                      )
+                      setFeedbackSeverity(event.target.value as SimulationFeedbackSeverity)
                     }
                     aria-label="피드백 심각도 선택"
                   >
@@ -1335,9 +1385,7 @@ export function WorkspaceSimulationPage() {
                   <span>설명</span>
                   <textarea
                     value={feedbackDescription}
-                    onChange={(event) =>
-                      setFeedbackDescription(event.target.value)
-                    }
+                    onChange={(event) => setFeedbackDescription(event.target.value)}
                     maxLength={2000}
                     rows={3}
                   />
@@ -1346,9 +1394,7 @@ export function WorkspaceSimulationPage() {
                   <span>기대 응답/행동</span>
                   <textarea
                     value={feedbackExpectedBehavior}
-                    onChange={(event) =>
-                      setFeedbackExpectedBehavior(event.target.value)
-                    }
+                    onChange={(event) => setFeedbackExpectedBehavior(event.target.value)}
                     maxLength={2000}
                     rows={3}
                   />
@@ -1364,9 +1410,7 @@ export function WorkspaceSimulationPage() {
                   }
                 >
                   <FlagIcon className={styles.buttonIcon} />
-                  <span>
-                    {isSubmittingFeedback ? "저장 중" : "피드백 저장"}
-                  </span>
+                  <span>{isSubmittingFeedback ? "저장 중" : "피드백 저장"}</span>
                 </Button>
               </div>
 
@@ -1376,26 +1420,19 @@ export function WorkspaceSimulationPage() {
                   <NativeSelect
                     value={feedbackStatusFilter}
                     onChange={(event) =>
-                      setFeedbackStatusFilter(
-                        event.target.value as SimulationFeedbackStatus | "",
-                      )
+                      setFeedbackStatusFilter(event.target.value as SimulationFeedbackStatus | "")
                     }
                     aria-label="피드백 상태 필터"
                   >
                     {FEEDBACK_STATUSES.map((item) => (
-                      <NativeSelectOption
-                        key={item.value || "ALL"}
-                        value={item.value}
-                      >
+                      <NativeSelectOption key={item.value || "ALL"} value={item.value}>
                         {item.label}
                       </NativeSelectOption>
                     ))}
                   </NativeSelect>
                 </div>
                 {isLoadingFeedback ? (
-                  <p className={styles.feedbackMuted}>
-                    피드백을 불러오는 중입니다.
-                  </p>
+                  <p className={styles.feedbackMuted}>피드백을 불러오는 중입니다.</p>
                 ) : feedbackError ? (
                   <div className={styles.secondaryErrorState}>
                     <ErrorState
@@ -1406,18 +1443,14 @@ export function WorkspaceSimulationPage() {
                     />
                   </div>
                 ) : feedbackItems.length === 0 ? (
-                  <p className={styles.feedbackMuted}>
-                    조건에 맞는 피드백이 없습니다.
-                  </p>
+                  <p className={styles.feedbackMuted}>조건에 맞는 피드백이 없습니다.</p>
                 ) : (
                   <ul className={styles.feedbackList}>
                     {feedbackItems.map((feedback) => (
                       <li key={feedback.id}>
                         <div className={styles.feedbackRowHeader}>
                           <div>
-                            <strong>
-                              {feedbackTypeLabel(feedback.feedbackType)}
-                            </strong>
+                            <strong>{feedbackTypeLabel(feedback.feedbackType)}</strong>
                             <span>
                               {feedbackSeverityLabel(feedback.severity)} ·{" "}
                               {feedbackStatusLabel(feedback.status)}
@@ -1429,16 +1462,11 @@ export function WorkspaceSimulationPage() {
                             size="sm"
                             onClick={() => void handleCreateCandidate(feedback)}
                             disabled={
-                              feedback.status !== "OPEN" ||
-                              creatingCandidateId === feedback.id
+                              feedback.status !== "OPEN" || creatingCandidateId === feedback.id
                             }
                           >
                             <LightbulbIcon className={styles.buttonIcon} />
-                            <span>
-                              {creatingCandidateId === feedback.id
-                                ? "생성 중"
-                                : "후보"}
-                            </span>
+                            <span>{creatingCandidateId === feedback.id ? "생성 중" : "후보"}</span>
                           </Button>
                         </div>
                         <p>{feedback.description}</p>
@@ -1464,27 +1492,20 @@ export function WorkspaceSimulationPage() {
                     value={candidateStatusFilter}
                     onChange={(event) =>
                       setCandidateStatusFilter(
-                        event.target.value as
-                          | SimulationImprovementCandidateStatus
-                          | "",
+                        event.target.value as SimulationImprovementCandidateStatus | "",
                       )
                     }
                     aria-label="개선 후보 상태 필터"
                   >
                     {CANDIDATE_STATUSES.map((item) => (
-                      <NativeSelectOption
-                        key={item.value || "ALL"}
-                        value={item.value}
-                      >
+                      <NativeSelectOption key={item.value || "ALL"} value={item.value}>
                         {item.label}
                       </NativeSelectOption>
                     ))}
                   </NativeSelect>
                 </div>
                 {isLoadingCandidates ? (
-                  <p className={styles.feedbackMuted}>
-                    개선 후보를 불러오는 중입니다.
-                  </p>
+                  <p className={styles.feedbackMuted}>개선 후보를 불러오는 중입니다.</p>
                 ) : candidateError ? (
                   <div className={styles.secondaryErrorState}>
                     <ErrorState
@@ -1495,21 +1516,17 @@ export function WorkspaceSimulationPage() {
                     />
                   </div>
                 ) : candidateItems.length === 0 ? (
-                  <p className={styles.feedbackMuted}>
-                    조건에 맞는 개선 후보가 없습니다.
-                  </p>
+                  <p className={styles.feedbackMuted}>조건에 맞는 개선 후보가 없습니다.</p>
                 ) : (
                   <ul className={styles.candidateList}>
                     {candidateItems.map((candidate) => (
                       <li key={candidate.id}>
                         <div className={styles.feedbackRowHeader}>
                           <div>
-                            <strong>
-                              {candidateTypeLabel(candidate.candidateType)}
-                            </strong>
+                            <strong>{candidateTypeLabel(candidate.candidateType)}</strong>
                             <span>
                               버전 #{candidate.domainPackVersionId} · 대상:{" "}
-                              {candidate.targetElementType}
+                              {candidateTargetLabel(candidate)}
                             </span>
                           </div>
                           <span className={styles.statusPill}>
@@ -1534,9 +1551,7 @@ export function WorkspaceSimulationPage() {
                                 {candidate.chatMessageId
                                   ? ` · 메시지 #${candidate.chatMessageId}`
                                   : ""}
-                                {candidate.feedbackId
-                                  ? ` · 피드백 #${candidate.feedbackId}`
-                                  : ""}
+                                {candidate.feedbackId ? ` · 피드백 #${candidate.feedbackId}` : ""}
                               </span>
                             </dd>
                           </div>
@@ -1549,16 +1564,11 @@ export function WorkspaceSimulationPage() {
                               size="sm"
                               disabled={updatingCandidateId === candidate.id}
                               onClick={() =>
-                                void handleCandidateStatusChange(
-                                  candidate,
-                                  "READY_FOR_REVIEW",
-                                )
+                                void handleCandidateStatusChange(candidate, "READY_FOR_REVIEW")
                               }
                             >
                               <span>
-                                {updatingCandidateId === candidate.id
-                                  ? "요청 중"
-                                  : "리뷰 요청"}
+                                {updatingCandidateId === candidate.id ? "요청 중" : "리뷰 요청"}
                               </span>
                             </Button>
                           </div>
@@ -1583,9 +1593,7 @@ export function WorkspaceSimulationPage() {
                                 variant="outline"
                                 size="sm"
                                 disabled={updatingCandidateId === candidate.id}
-                                onClick={() =>
-                                  void handleRejectCandidate(candidate)
-                                }
+                                onClick={() => void handleRejectCandidate(candidate)}
                               >
                                 <span>반려</span>
                               </Button>
@@ -1593,9 +1601,7 @@ export function WorkspaceSimulationPage() {
                                 type="button"
                                 size="sm"
                                 disabled={updatingCandidateId === candidate.id}
-                                onClick={() =>
-                                  void handleApproveCandidate(candidate)
-                                }
+                                onClick={() => void handleApproveCandidate(candidate)}
                               >
                                 <span>승인</span>
                               </Button>
@@ -1626,23 +1632,14 @@ type MessageBubbleProps = Readonly<{
   onFeedbackClick?: () => void;
 }>;
 
-function MessageBubble({
-  message,
-  feedbackCount,
-  onFeedbackClick,
-}: MessageBubbleProps) {
-  const isCustomer =
-    message.senderRole === "USER" || message.senderRole === "CUSTOMER";
+function MessageBubble({ message, feedbackCount, onFeedbackClick }: MessageBubbleProps) {
+  const isCustomer = message.senderRole === "USER" || message.senderRole === "CUSTOMER";
   return (
-    <article
-      className={`${styles.message} ${isCustomer ? styles.messageCustomer : ""}`}
-    >
+    <article className={`${styles.message} ${isCustomer ? styles.messageCustomer : ""}`}>
       <div className={styles.messageMeta}>
         <span>{roleLabel(message.senderRole)}</span>
         <div className={styles.messageActions}>
-          {feedbackCount > 0 ? (
-            <span className={styles.feedbackBadge}>{feedbackCount}</span>
-          ) : null}
+          {feedbackCount > 0 ? <span className={styles.feedbackBadge}>{feedbackCount}</span> : null}
           {onFeedbackClick ? (
             <button
               type="button"

--- a/frontend/src/pages/workspace/ui/simulation/workspace-simulation-page.module.css
+++ b/frontend/src/pages/workspace/ui/simulation/workspace-simulation-page.module.css
@@ -65,6 +65,45 @@
   background: var(--paper);
 }
 
+.targetBanner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s-4);
+  padding: var(--s-4) var(--s-5);
+  border: 1px solid var(--ink);
+  border-radius: var(--r-3);
+  background: var(--paper);
+}
+
+.targetBanner h2 {
+  margin: var(--s-1) 0 0;
+  color: var(--ink);
+  font-size: 17px;
+  font-weight: 540;
+  letter-spacing: 0;
+  line-height: 1.25;
+}
+
+.targetBanner p:last-child {
+  margin: var(--s-2) 0 0;
+  color: var(--ink-2);
+  font-size: 13px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.targetBadge {
+  flex-shrink: 0;
+  border: 1px solid var(--line);
+  border-radius: var(--r-pill);
+  color: var(--ink);
+  font-size: 12px;
+  font-weight: 540;
+  line-height: 1;
+  padding: 7px 10px;
+}
+
 .sectionTitle {
   margin: 0;
   color: var(--ink);
@@ -115,10 +154,7 @@
   display: grid;
   height: clamp(420px, calc(100dvh - 300px), 780px);
   min-height: 0;
-  grid-template-columns: minmax(220px, 280px) minmax(360px, 1fr) minmax(
-      260px,
-      340px
-    );
+  grid-template-columns: minmax(220px, 280px) minmax(360px, 1fr) minmax(260px, 340px);
   gap: var(--s-4);
   align-items: stretch;
   overflow: hidden;
@@ -783,7 +819,8 @@
   }
 
   .createPanel,
-  .pageHeader {
+  .pageHeader,
+  .targetBanner {
     align-items: stretch;
     flex-direction: column;
   }

--- a/frontend/src/shared/lib/demoRoutes.test.ts
+++ b/frontend/src/shared/lib/demoRoutes.test.ts
@@ -5,18 +5,30 @@ import { buildDemoChatPath, buildWorkspaceSimulationPath } from "./demoRoutes";
 describe("demoRoutes", () => {
   it("buildWorkspaceSimulationPath가 워크스페이스 시뮬레이션 경로를 만든다", () => {
     expect(buildWorkspaceSimulationPath(42)).toBe("/workspaces/42/simulation");
-    expect(buildWorkspaceSimulationPath("space key")).toBe(
-      "/workspaces/space%20key/simulation",
-    );
-    expect(buildWorkspaceSimulationPath("a/b?c&d")).toBe(
-      "/workspaces/a%2Fb%3Fc%26d/simulation",
-    );
+    expect(buildWorkspaceSimulationPath("space key")).toBe("/workspaces/space%20key/simulation");
+    expect(buildWorkspaceSimulationPath("a/b?c&d")).toBe("/workspaces/a%2Fb%3Fc%26d/simulation");
+  });
+
+  it("buildWorkspaceSimulationPath가 검증 대상 query를 함께 만든다", () => {
+    expect(
+      buildWorkspaceSimulationPath(42, {
+        packId: 11,
+        versionId: 22,
+        workflowId: 100,
+      }),
+    ).toBe("/workspaces/42/simulation?packId=11&versionId=22&workflowId=100");
+    expect(
+      buildWorkspaceSimulationPath("space key", {
+        workflowId: "wf/100",
+        feedbackStatus: "OPEN",
+      }),
+    ).toBe("/workspaces/space%20key/simulation?workflowId=wf%2F100&feedbackStatus=OPEN");
   });
 
   it("buildDemoChatPath가 고객용 데모 채팅 경로와 query string을 만든다", () => {
     expect(buildDemoChatPath(42)).toBe("/demo/chat/42");
-    expect(
-      buildDemoChatPath("space key", new URLSearchParams({ name: "김민지" })),
-    ).toBe("/demo/chat/space%20key?name=%EA%B9%80%EB%AF%BC%EC%A7%80");
+    expect(buildDemoChatPath("space key", new URLSearchParams({ name: "김민지" }))).toBe(
+      "/demo/chat/space%20key?name=%EA%B9%80%EB%AF%BC%EC%A7%80",
+    );
   });
 });

--- a/frontend/src/shared/lib/demoRoutes.ts
+++ b/frontend/src/shared/lib/demoRoutes.ts
@@ -1,9 +1,38 @@
 export const DEMO_SELECTION_PATH = "/demo";
 
+export interface WorkspaceSimulationPathParams {
+  packId?: number | string | null;
+  versionId?: number | string | null;
+  workflowId?: number | string | null;
+  feedbackStatus?: string | null;
+  candidateStatus?: string | null;
+}
+
+function appendDefinedParam(
+  searchParams: URLSearchParams,
+  key: keyof WorkspaceSimulationPathParams,
+  value: WorkspaceSimulationPathParams[keyof WorkspaceSimulationPathParams],
+) {
+  if (value === null || value === undefined || value === "") return;
+  searchParams.set(key, String(value));
+}
+
 export function buildWorkspaceSimulationPath(
   workspaceId: number | string,
+  params?: WorkspaceSimulationPathParams | URLSearchParams,
 ): string {
-  return `/workspaces/${encodeURIComponent(String(workspaceId))}/simulation`;
+  const searchParams = params instanceof URLSearchParams ? params : new URLSearchParams();
+
+  if (params && !(params instanceof URLSearchParams)) {
+    appendDefinedParam(searchParams, "packId", params.packId);
+    appendDefinedParam(searchParams, "versionId", params.versionId);
+    appendDefinedParam(searchParams, "workflowId", params.workflowId);
+    appendDefinedParam(searchParams, "feedbackStatus", params.feedbackStatus);
+    appendDefinedParam(searchParams, "candidateStatus", params.candidateStatus);
+  }
+
+  const search = searchParams.toString();
+  return `/workspaces/${encodeURIComponent(String(workspaceId))}/simulation${search ? `?${search}` : ""}`;
 }
 
 export function buildDemoChatPath(


### PR DESCRIPTION
Closes #784

## 변경 사항

- 이슈 784 요구사항과 acceptance criteria를 `.agent/specs/784.md`에 정리했습니다.
- `buildWorkspaceSimulationPath`가 기존 workspace simulation 경로에 `packId`, `versionId`, `workflowId`와 기존 feedback/candidate 상태 query를 함께 붙일 수 있게 했습니다.
- 워크플로우 상세 화면에 현재 pack/version/workflow 맥락을 담은 `검증` 링크를 추가해 시뮬레이션으로 바로 이동할 수 있게 했습니다.
- 대시보드 추천 액션이 workflow detail path를 가리키는 경우 simulation target query로 변환해 추천에서 검증 화면으로 이동해도 대상 맥락이 유지되도록 했습니다.
- 시뮬레이션 화면이 query 또는 route state의 검증 대상을 해석하고, 상단 banner와 시작 workflow 기본값으로 표시합니다. 대상이 없으면 기존 자동 매칭 흐름은 유지됩니다.
- 피드백에서 개선 후보를 만들 때 선택/매칭/전달된 workflow target을 `WORKFLOW` target payload로 함께 보내 후보가 검증 대상 workflow와 연결되도록 했습니다.

## 검증

- `pnpm --dir frontend test -- WorkspaceSimulationPage.test.tsx WorkflowDraftReadPage.test.tsx WorkspaceDashboardPage.test.tsx demoRoutes.test.ts` (4 files, 67 tests; API/FSD audits passed)
- `pnpm --dir frontend exec eslint src/shared/lib/demoRoutes.ts src/shared/lib/demoRoutes.test.ts src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx src/pages/domain-pack/ui/WorkflowDraftReadPage.test.tsx src/pages/workspace/ui/WorkspaceDashboardPage.tsx src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx src/pages/workspace/ui/WorkspaceSimulationPage.tsx src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx`
- `pnpm exec vp fmt --check src/shared/lib/demoRoutes.ts src/shared/lib/demoRoutes.test.ts src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx src/pages/domain-pack/ui/WorkflowDraftReadPage.test.tsx src/pages/workspace/ui/WorkspaceDashboardPage.tsx src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx src/pages/workspace/ui/WorkspaceSimulationPage.tsx src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx src/pages/workspace/ui/simulation/workspace-simulation-page.module.css`
- `pnpm --dir frontend build` (기존 chunk-size warning만 표시)
- `git diff --check`

## 참고

- 구현 전 issue 784, `WorkspaceSimulationPage`, `WorkflowDraftReadPage`, `WorkspaceDashboardPage`, `features/simulation` API wrapper, `frontend/DESIGN.md`, frontend FSD/test/code-review rules를 확인했습니다.
- spec review 2회 수행: issue fidelity 관점에서 query/state 수신, 상단 대상 표시, 상세/대시보드 진입, 후보 workflow 연결, 무맥락 기본 흐름을 매핑했고, repository compliance 관점에서 파일명/브랜치/FSD 경계/참조 경로를 확인했습니다.
- self-review 3회 수행: Round 1에서 상세/대시보드 링크와 후보 payload의 acceptance 매핑을 확인했고, Round 2에서 target banner label과 responsive style, FSD import 방향을 점검했으며, Round 3에서 query target 후 `자동 매칭`으로 되돌리는 회귀와 route state 진입 테스트를 보강했습니다.
- `pnpm --dir frontend lint`와 pre-commit hook은 이번 변경과 무관한 기존 frontend ESLint baseline 45건으로 실패합니다. 변경 파일 대상 ESLint, focused tests, build, format check, diff check는 통과했습니다. hook 실패가 repository-wide baseline 때문이라 변경 파일 대상 검증을 근거로 hook을 우회해 커밋했습니다.
- 이 thread에서는 in-app browser navigation/screenshot tool이 노출되지 않아 별도 브라우저 시각 검증은 수행하지 못했습니다.