### PR TITLE
feat(dx): 개발 환경 사전 진단을 제공

### DIFF
--- a/.agent/specs/604.md
+++ b/.agent/specs/604.md
@@ -1,0 +1,78 @@
+# 개발 환경 doctor 명령 제공
+
+## Goal
+
+신규 개발자가 로컬 스택을 실행하기 전에 필수 도구 버전, 포트 점유, `.env`, backend JAR 준비 상태를 한 번에 점검하고 실패 항목별 조치 방법을 확인할 수 있게 한다.
+
+## Problem
+
+프로젝트는 Java, Node/pnpm, Python/uv, Docker Compose, PostgreSQL, Airflow, MinIO를 함께 사용한다. 현재 `pnpm run dev:setup`은 실행 준비를 돕지만 `.env` 생성과 backend JAR 빌드를 수행하는 mutating command다. 신규 개발자가 실제 준비 동작을 실행하기 전에 자신의 환경이 저장소 기준과 맞는지 비파괴적으로 확인하는 루트 명령이 없어, 도구 버전 불일치, 포트 충돌, `.env` 누락, backend JAR 누락을 실행 중 오류로 발견하기 쉽다.
+
+## Scope
+
+- 루트 `package.json`에 `doctor` script를 추가한다.
+- `scripts/doctor.mjs`를 추가해 다음 항목을 비파괴적으로 점검한다.
+  - Java, Node, pnpm, Python, uv, Docker CLI, Docker Compose, Docker daemon 가용성과 버전.
+  - `mise.toml`, 루트 `package.json`, `ml/.python-version`에 명시된 로컬 개발 기준과의 일치 여부.
+  - `.env` 존재 여부와 필수 키(`DB_PASSWORD`, `JWT_SECRET`, `AIRFLOW_WEBHOOK_SECRET`)의 누락, 빈 값, placeholder 여부.
+  - `docker compose config --quiet` 기준 compose 설정 유효성.
+  - 주요 호스트 포트 점유 상태. 기본은 full profile 기준으로 5432, 5173, 8080, 8081, 9000, 9001을 점검하고 `--profile light|pipeline|full`로 범위를 조정할 수 있다.
+  - `scripts/preflight-backend-jar.mjs --check-only`를 통한 backend JAR 존재 및 신선도 확인.
+- `scripts/doctor.test.mjs`에 순수 helper 테스트를 추가한다.
+- README와 AGENTS의 루트 개발 명령 안내에 `pnpm run doctor`를 추가한다.
+
+## Non-goals
+
+- `pnpm run dev:setup`의 `.env` 생성, JAR 자동 빌드, 포트 경고 정책은 변경하지 않는다.
+- Docker Compose 서비스 정의, runtime env key 구성, backend/frontend/ML 애플리케이션 코드는 변경하지 않는다.
+- doctor 명령이 누락된 도구를 설치하거나 `.env`를 생성하거나 backend JAR를 빌드하지 않는다.
+- OS별 패키지 매니저 자동 감지 또는 설치 자동화는 제공하지 않는다.
+
+## Affected Paths
+
+- `scripts/doctor.mjs`
+- `scripts/doctor.test.mjs`
+- `scripts/dev-setup.mjs`
+- `package.json`
+- `README.md`
+- `AGENTS.md`
+- `.agent/specs/604.md`
+
+## Requirements
+
+1. 루트에서 `pnpm run doctor`를 실행할 수 있어야 한다.
+2. doctor 명령은 Java, Node, pnpm, Python, uv, Docker CLI, Docker Compose, Docker daemon 상태를 점검해야 한다.
+3. 저장소 기준 버전은 확인된 파일(`mise.toml`, `package.json`, `ml/.python-version`)에서 읽어야 하며, 하드코딩만으로 관리하지 않아야 한다.
+4. 필수 도구가 없거나 버전이 맞지 않으면 실패로 표시하고 설치/정렬 경로를 안내해야 한다.
+5. `.env`가 없거나 필수 키가 누락, 빈 값, placeholder이면 실패로 표시하고 `pnpm run dev:setup` 또는 `.env` 편집 안내를 출력해야 한다.
+6. backend JAR가 없거나 backend source보다 오래되면 실패로 표시하고 `pnpm run build:backend:jar`를 안내해야 한다.
+7. 주요 포트가 외부 프로세스에 점유되어 있으면 실패로 표시하고 기존 compose 종료 또는 포트 해제/override 안내를 출력해야 한다.
+8. 이미 실행 중인 본 프로젝트 compose 서비스가 자기 포트를 점유하는 경우에는 포트 충돌 실패로 보지 않아야 한다.
+9. 출력은 항목별 pass/warn/fail과 마지막 summary를 포함해야 하며, 실패가 하나라도 있으면 종료 코드 1을 반환해야 한다.
+10. Docker 없이도 helper 단위 테스트는 `node --test`로 검증 가능해야 한다.
+
+## Data/API Impact
+
+- API, database schema, generated client, runtime behavior 변경은 없다.
+- 로컬 파일을 생성하거나 수정하지 않는 비파괴 점검 명령만 추가한다.
+
+## Acceptance Criteria
+
+- `pnpm run doctor`가 루트에서 실행되고 도구, `.env`, compose 설정, 포트, backend JAR 준비 상태를 항목별로 출력한다.
+- 누락된 도구 또는 버전 불일치가 있으면 어떤 도구가 문제인지와 `mise install`, `corepack enable`, Docker Desktop 실행 등 해결 경로가 출력된다.
+- `.env` 누락과 필수 env 키 누락/placeholder가 실행 전에 실패로 드러난다.
+- 5173, 8080, 8081, 9000, 9001 포트 점유가 실행 전에 드러난다.
+- backend JAR가 준비되지 않은 상태에서 doctor 명령은 자동 빌드하지 않고 `pnpm run build:backend:jar`를 안내한다.
+- `node --test "scripts/**/*.test.mjs"`가 신규 테스트를 포함해 통과한다.
+
+## Validation
+
+- `node --test "scripts/**/*.test.mjs"`
+- `pnpm run doctor`
+- `node -e 'JSON.parse(require("fs").readFileSync("package.json", "utf8")); console.log("package.json ok")'`
+- `pnpm run format:check`
+- `git diff --check`
+
+## Open Questions
+
+- 없음. 이슈 본문과 조사 근거가 doctor의 점검 대상과 기준 파일을 정하기에 충분하다.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,6 +166,7 @@ ml/
 # light 실행 (postgres + minio(+init) + backend + frontend)
 # dev:setup 부트스트랩이 .env 자동 생성(JWT_SECRET 랜덤 채움)·필수 env 점검·jar preflight·
 # compose config 검증·포트 사전 점검을 수행하고, 기동 후 접속 URL을 출력한다.
+pnpm run doctor         # 비파괴 개발 환경 진단(도구 버전/env/포트/JAR)
 pnpm run dev            # = pnpm run up:light
 
 # 기동 없이 준비·점검만
@@ -256,6 +257,7 @@ pnpm run ci:backend
 | ----------------- | ------------------------ |
 | 의존성 설치       | `pnpm install`           |
 | Husky 설치        | `pnpm run prepare`       |
+| 개발 환경 진단    | `pnpm run doctor`        |
 | 로컬 전체 실행    | `pnpm run dev`           |
 | 로컬 부트스트랩   | `pnpm run dev:setup`     |
 | 전체 품질 검사    | `pnpm run check`         |

--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@ pnpm install
 
 | 목적                 | 루트 명령            | 수행 내용                                                 |
 | -------------------- | -------------------- | --------------------------------------------------------- |
+| 개발 환경 진단       | `pnpm run doctor`    | 도구 버전, `.env`, 포트, Compose 설정, backend JAR 상태를 비파괴 점검 |
 | 전체 로컬 스택 실행  | `pnpm run dev`       | 부트스트랩(`dev:setup`) 후 Docker Compose 기동, 접속 URL 출력 |
 | 로컬 개발 부트스트랩 | `pnpm run dev:setup` | `.env` 생성/점검, backend JAR preflight, Compose 설정 검증, 포트 점검 |
 | 전체 품질 검사       | `pnpm run check`     | `check:backend` → `check:frontend` → `check:ml` 순차 실행 |
@@ -404,10 +405,14 @@ pnpm install
 ### 실행
 
 ```bash
+pnpm run doctor       # 개발 도구/포트/env/JAR 사전 진단
+
 # 제품 런타임(light) 실행 — postgres + minio + backend + frontend
 # .env가 없으면 .env.example 기반으로 자동 생성된다(최초 1회 수동 준비 불필요)
 pnpm run dev          # = pnpm run up:light
 ```
+
+`pnpm run doctor`는 파일을 생성하거나 backend JAR를 빌드하지 않는 사전 진단 명령이다. 기본은 full profile 기준으로 주요 포트(5432/5173/8080/8081/9000/9001)를 확인하며, light만 확인하려면 `pnpm run doctor -- --profile light`를 사용한다.
 
 `pnpm run dev`(=`up:light`)는 부트스트랩(`pnpm run dev:setup`)을 먼저 수행한 뒤 `docker compose up -d`로 **light** 모드를 기동하고, 성공 시 접속 URL을 출력한다. 부트스트랩은 다음을 한 번에 처리한다.
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "preinstall": "node -e \"const ua=process.env.npm_config_user_agent||''; if(!ua.startsWith('pnpm/')){console.error('Use pnpm for root dependencies. Run: corepack enable && pnpm install'); process.exit(1)}\"",
     "prepare": "husky",
     "env:check": "test -f .env || (echo 'Missing .env. Run: pnpm run dev:setup (or cp .env.example .env)' && exit 1)",
+    "doctor": "node scripts/doctor.mjs",
     "dev": "pnpm run up:light",
     "dev:setup": "node scripts/dev-setup.mjs",
     "up": "pnpm run up:light",

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -1,0 +1,477 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import net from "node:net";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  findRequiredEnvIssues,
+  parseEnvFile,
+  REQUIRED_ENV_KEYS,
+  resolveHostPorts,
+} from "./dev-setup.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, "..");
+const ENV_FILE = join(ROOT, ".env");
+const MISE_FILE = join(ROOT, "mise.toml");
+const ROOT_PACKAGE_FILE = join(ROOT, "package.json");
+const PYTHON_VERSION_FILE = join(ROOT, "ml/.python-version");
+const BACKEND_JAR_PREFLIGHT_FILE = join(
+  ROOT,
+  "scripts/preflight-backend-jar.mjs",
+);
+const HOST_PORT_OVERRIDE_KEYS = [
+  "POSTGRES_HOST_PORT",
+  "BACKEND_HOST_PORT",
+  "FRONTEND_HOST_PORT",
+];
+
+function readText(path) {
+  return readFileSync(path, "utf8");
+}
+
+export function parseMiseTools(content) {
+  const tools = {};
+  let inTools = false;
+  for (const rawLine of content.split("\n")) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    if (/^\[.+]$/.test(line)) {
+      inTools = line === "[tools]";
+      continue;
+    }
+    if (!inTools) continue;
+    const match = line.match(/^([A-Za-z0-9_-]+)\s*=\s*"([^"]+)"$/);
+    if (match) tools[match[1]] = match[2];
+  }
+  return tools;
+}
+
+export function parsePackageManagerVersion(packageJson) {
+  const parsed = JSON.parse(packageJson);
+  const raw = parsed.packageManager ?? "";
+  const match = raw.match(/^pnpm@(.+)$/);
+  return match?.[1] ?? null;
+}
+
+export function normalizeVersion(output) {
+  const match = output.match(/(\d+(?:\.\d+){0,2})/);
+  return match?.[1] ?? null;
+}
+
+export function expectedMajor(raw) {
+  return normalizeVersion(raw)?.split(".")[0] ?? null;
+}
+
+export function versionMatches(actual, expected, mode) {
+  if (!actual || !expected) return false;
+  if (mode === "major") return actual.split(".")[0] === expected;
+  if (mode === "prefix")
+    return actual === expected || actual.startsWith(`${expected}.`);
+  return actual === expected;
+}
+
+export function effectiveEnv(envFromFile, processEnv = process.env) {
+  const merged = { ...envFromFile };
+  const overlayKeys = [
+    ...REQUIRED_ENV_KEYS.map(({ key }) => key),
+    ...HOST_PORT_OVERRIDE_KEYS,
+  ];
+  for (const key of overlayKeys) {
+    if (processEnv[key] !== undefined) merged[key] = processEnv[key];
+  }
+  return merged;
+}
+
+export function classifyPortStatus({ service, port, inUse, runningServices }) {
+  if (!inUse) {
+    return {
+      status: "pass",
+      title: `port ${port} (${service})`,
+      detail: "free",
+    };
+  }
+  if (runningServices.has(service)) {
+    return {
+      status: "pass",
+      title: `port ${port} (${service})`,
+      detail: "already used by this compose service",
+    };
+  }
+  return {
+    status: "fail",
+    title: `port ${port} (${service})`,
+    detail: "already in use",
+    guide:
+      "Stop the process using the port, run `pnpm run down` for an old compose stack, or set the matching *_HOST_PORT override in .env.",
+  };
+}
+
+export function summarize(results) {
+  return results.reduce(
+    (acc, check) => {
+      acc[check.status] += 1;
+      return acc;
+    },
+    { pass: 0, warn: 0, fail: 0 },
+  );
+}
+
+function result(status, title, detail, guide = null) {
+  return { status, title, detail, guide };
+}
+
+function run(command, args) {
+  return spawnSync(command, args, {
+    cwd: ROOT,
+    encoding: "utf8",
+  });
+}
+
+function expectedLabel(expected, mode) {
+  if (mode === "major") return `major ${expected}`;
+  if (mode === "prefix") return `${expected}.x`;
+  return expected;
+}
+
+function runVersionCheck({ title, command, args, expected, mode, guide }) {
+  const r = run(command, args);
+  if (r.status !== 0) {
+    return result("fail", title, `${command} not available`, guide);
+  }
+  const output = `${r.stdout}\n${r.stderr}`.trim();
+  const actual = normalizeVersion(output);
+  if (!versionMatches(actual, expected, mode)) {
+    return result(
+      "fail",
+      title,
+      `expected ${expectedLabel(expected, mode)}, got ${actual ?? output}`,
+      guide,
+    );
+  }
+  return result("pass", title, actual);
+}
+
+function runCandidateVersionCheck({
+  title,
+  candidates,
+  expected,
+  mode,
+  guide,
+}) {
+  const attempts = candidates.map(({ command, args }) => ({
+    command,
+    check: runVersionCheck({ title, command, args, expected, mode, guide }),
+  }));
+  const passing = attempts.find(({ check }) => check.status === "pass");
+  if (passing) {
+    return result("pass", title, `${passing.command} ${passing.check.detail}`);
+  }
+  const availableMismatch = attempts.find(
+    ({ check }) => !check.detail.includes("not available"),
+  );
+  return availableMismatch?.check ?? attempts[0].check;
+}
+
+function loadExpectedVersions() {
+  const miseTools = parseMiseTools(readText(MISE_FILE));
+  const pnpmVersion = parsePackageManagerVersion(readText(ROOT_PACKAGE_FILE));
+  const pythonVersion = readText(PYTHON_VERSION_FILE).trim();
+  return {
+    javaMajor: expectedMajor(miseTools.java),
+    node: miseTools.node,
+    pnpm: pnpmVersion,
+    python: pythonVersion || miseTools.python,
+    uv: miseTools.uv,
+  };
+}
+
+function checkTools() {
+  const expected = loadExpectedVersions();
+  return [
+    runVersionCheck({
+      title: "Java",
+      command: "java",
+      args: ["-version"],
+      expected: expected.javaMajor,
+      mode: "major",
+      guide: "Run `mise install` or install Temurin Java 21.",
+    }),
+    runVersionCheck({
+      title: "Node",
+      command: "node",
+      args: ["--version"],
+      expected: expected.node,
+      mode: "exact",
+      guide: "Run `mise install` from the repository root.",
+    }),
+    runVersionCheck({
+      title: "pnpm",
+      command: "pnpm",
+      args: ["--version"],
+      expected: expected.pnpm,
+      mode: "exact",
+      guide:
+        "Run `corepack enable` and `mise install` from the repository root.",
+    }),
+    runCandidateVersionCheck({
+      title: "Python",
+      candidates: [
+        { command: "python3", args: ["--version"] },
+        { command: "python", args: ["--version"] },
+      ],
+      expected: expected.python,
+      mode: "prefix",
+      guide: "Run `mise install` from the repository root.",
+    }),
+    runVersionCheck({
+      title: "uv",
+      command: "uv",
+      args: ["--version"],
+      expected: expected.uv,
+      mode: "exact",
+      guide: "Run `mise install` from the repository root.",
+    }),
+  ];
+}
+
+function checkDocker() {
+  const dockerVersion = run("docker", ["--version"]);
+  if (dockerVersion.status !== 0) {
+    return [
+      result(
+        "fail",
+        "Docker CLI",
+        "docker not available",
+        "Install and start Docker Desktop, or install docker CLI with the compose plugin.",
+      ),
+      result(
+        "fail",
+        "Docker Compose",
+        "skipped because docker is not available",
+        "Install Docker Desktop, or install docker CLI with the compose plugin.",
+      ),
+      result(
+        "fail",
+        "Docker daemon",
+        "skipped because docker is not available",
+        "Start Docker Desktop and retry.",
+      ),
+    ];
+  }
+
+  const compose = run("docker", ["compose", "version"]);
+  const daemon = run("docker", ["info"]);
+  return [
+    result(
+      "pass",
+      "Docker CLI",
+      normalizeVersion(dockerVersion.stdout) ?? dockerVersion.stdout.trim(),
+    ),
+    compose.status === 0
+      ? result(
+          "pass",
+          "Docker Compose",
+          normalizeVersion(compose.stdout) ?? compose.stdout.trim(),
+        )
+      : result(
+          "fail",
+          "Docker Compose",
+          "docker compose not available",
+          "Install Docker Desktop or the docker compose plugin.",
+        ),
+    daemon.status === 0
+      ? result("pass", "Docker daemon", "running")
+      : result(
+          "fail",
+          "Docker daemon",
+          "not reachable",
+          "Start Docker Desktop and retry.",
+        ),
+  ];
+}
+
+function checkEnv() {
+  if (!existsSync(ENV_FILE)) {
+    return [
+      result(
+        "fail",
+        ".env",
+        "missing",
+        "Run `pnpm run dev:setup` to create it from .env.example.",
+      ),
+    ];
+  }
+
+  const env = effectiveEnv(parseEnvFile(readText(ENV_FILE)));
+  const issues = findRequiredEnvIssues(env);
+  if (issues.length === 0) {
+    return [result("pass", ".env", "required keys are set")];
+  }
+  return issues.map(({ key, reason, hint }) =>
+    result(
+      "fail",
+      `.env ${key}`,
+      reason,
+      `${hint} Update .env, then rerun doctor.`,
+    ),
+  );
+}
+
+function runningComposeServices() {
+  const r = run("docker", [
+    "compose",
+    "ps",
+    "--status",
+    "running",
+    "--services",
+  ]);
+  if (r.status !== 0) return new Set();
+  return new Set(
+    r.stdout
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean),
+  );
+}
+
+function isPortInUse(port) {
+  return new Promise((resolvePromise) => {
+    const socket = net.connect({ port, host: "127.0.0.1" });
+    const finish = (inUse) => {
+      socket.destroy();
+      resolvePromise(inUse);
+    };
+    socket.once("connect", () => finish(true));
+    socket.once("error", () => finish(false));
+    socket.setTimeout(700, () => finish(false));
+  });
+}
+
+async function checkPorts(profile) {
+  const env = existsSync(ENV_FILE)
+    ? effectiveEnv(parseEnvFile(readText(ENV_FILE)))
+    : effectiveEnv({});
+  const runningServices = runningComposeServices();
+  const checks = [];
+  for (const port of resolveHostPorts(env, profile)) {
+    checks.push(
+      classifyPortStatus({
+        ...port,
+        inUse: await isPortInUse(port.port),
+        runningServices,
+      }),
+    );
+  }
+  return checks;
+}
+
+function checkComposeConfig(profile) {
+  const r = spawnSync("docker", ["compose", "config", "--quiet"], {
+    cwd: ROOT,
+    encoding: "utf8",
+    env: { ...process.env, COMPOSE_PROFILES: profile },
+  });
+  if (r.status === 0) {
+    return result(
+      "pass",
+      "docker compose config",
+      `valid (profile=${profile})`,
+    );
+  }
+  return result(
+    "fail",
+    "docker compose config",
+    `invalid (profile=${profile})`,
+    r.stderr.trim() ||
+      "Run `pnpm run dev:setup` for the full compose preflight.",
+  );
+}
+
+function checkBackendJar() {
+  const r = spawnSync(
+    process.execPath,
+    [BACKEND_JAR_PREFLIGHT_FILE, "--check-only"],
+    {
+      cwd: ROOT,
+      encoding: "utf8",
+    },
+  );
+  return r.status === 0
+    ? result("pass", "backend JAR", "ready")
+    : result(
+        "fail",
+        "backend JAR",
+        "missing or older than backend sources",
+        "Run `pnpm run build:backend:jar`.",
+      );
+}
+
+function parseArgs(argv) {
+  const profileIndex = argv.indexOf("--profile");
+  const profile = profileIndex >= 0 ? argv[profileIndex + 1] : "full";
+  if (!["light", "pipeline", "full"].includes(profile ?? "")) {
+    return {
+      error: `Unknown profile: ${profile}. Use light, pipeline, or full.`,
+    };
+  }
+  return { profile };
+}
+
+function printResult(check) {
+  const label = check.status.toUpperCase().padEnd(4, " ");
+  process.stdout.write(`[doctor] ${label} ${check.title}: ${check.detail}\n`);
+  if (check.guide) process.stdout.write(`         Fix: ${check.guide}\n`);
+}
+
+export async function main(argv) {
+  const args = parseArgs(argv);
+  if (args.error) {
+    process.stderr.write(`[doctor] ${args.error}\n`);
+    return 1;
+  }
+
+  process.stdout.write(
+    `[doctor] Ostone development environment check (profile=${args.profile})\n`,
+  );
+
+  const results = [...checkTools(), ...checkDocker(), ...checkEnv()];
+
+  const dockerOk = !results.some(
+    (check) => check.title.startsWith("Docker") && check.status === "fail",
+  );
+  const envOk = !results.some(
+    (check) => check.title.startsWith(".env") && check.status === "fail",
+  );
+  if (dockerOk && envOk) {
+    results.push(checkComposeConfig(args.profile));
+  } else {
+    results.push(
+      result(
+        "warn",
+        "docker compose config",
+        dockerOk
+          ? "skipped because .env is not ready"
+          : "skipped because Docker is not ready",
+      ),
+    );
+  }
+
+  results.push(...(await checkPorts(args.profile)));
+  results.push(checkBackendJar());
+
+  for (const check of results) printResult(check);
+
+  const counts = summarize(results);
+  process.stdout.write(
+    `[doctor] Summary: ${counts.pass} passed, ${counts.warn} warning(s), ${counts.fail} failed\n`,
+  );
+  return counts.fail > 0 ? 1 : 0;
+}
+
+const isMain = process.argv[1] === fileURLToPath(import.meta.url);
+if (isMain) {
+  process.exit(await main(process.argv.slice(2)));
+}

--- a/scripts/doctor.test.mjs
+++ b/scripts/doctor.test.mjs
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  classifyPortStatus,
+  effectiveEnv,
+  expectedMajor,
+  normalizeVersion,
+  parseMiseTools,
+  parsePackageManagerVersion,
+  summarize,
+  versionMatches,
+} from "./doctor.mjs";
+
+test("parseMiseTools: [tools] section versions are extracted", () => {
+  const tools = parseMiseTools(
+    [
+      "[env]",
+      'FOO = "bar"',
+      "",
+      "[tools]",
+      'java = "temurin-21"',
+      'node = "22.13.0"',
+      'pnpm = "10.33.0"',
+      'python = "3.13"',
+      'uv = "0.11.19"',
+      "",
+      "[settings]",
+      'idiomatic_version_file_enable_tools = ["python"]',
+    ].join("\n"),
+  );
+  assert.deepEqual(tools, {
+    java: "temurin-21",
+    node: "22.13.0",
+    pnpm: "10.33.0",
+    python: "3.13",
+    uv: "0.11.19",
+  });
+});
+
+test("parsePackageManagerVersion: root pnpm version is extracted", () => {
+  assert.equal(
+    parsePackageManagerVersion('{"packageManager":"pnpm@10.33.0"}'),
+    "10.33.0",
+  );
+  assert.equal(parsePackageManagerVersion("{}"), null);
+});
+
+test("normalizeVersion and expectedMajor: common tool outputs are normalized", () => {
+  assert.equal(
+    normalizeVersion('openjdk version "21.0.7" 2026-04-15'),
+    "21.0.7",
+  );
+  assert.equal(normalizeVersion("v22.13.0"), "22.13.0");
+  assert.equal(normalizeVersion("uv 0.11.19 (Homebrew 2026-06-01)"), "0.11.19");
+  assert.equal(expectedMajor("temurin-21"), "21");
+});
+
+test("versionMatches: exact, prefix, and major modes are supported", () => {
+  assert.equal(versionMatches("22.13.0", "22.13.0", "exact"), true);
+  assert.equal(versionMatches("22.13.1", "22.13.0", "exact"), false);
+  assert.equal(versionMatches("3.13.4", "3.13", "prefix"), true);
+  assert.equal(versionMatches("3.12.9", "3.13", "prefix"), false);
+  assert.equal(versionMatches("21.0.7", "21", "major"), true);
+  assert.equal(versionMatches("17.0.15", "21", "major"), false);
+});
+
+test("effectiveEnv: shell values override .env values for checked keys", () => {
+  const env = effectiveEnv(
+    {
+      DB_PASSWORD: "file-db",
+      JWT_SECRET: "file-jwt",
+      AIRFLOW_WEBHOOK_SECRET: "file-airflow",
+      BACKEND_HOST_PORT: "8080",
+    },
+    {
+      JWT_SECRET: "shell-jwt",
+      BACKEND_HOST_PORT: "18080",
+      IGNORED: "value",
+    },
+  );
+  assert.deepEqual(env, {
+    DB_PASSWORD: "file-db",
+    JWT_SECRET: "shell-jwt",
+    AIRFLOW_WEBHOOK_SECRET: "file-airflow",
+    BACKEND_HOST_PORT: "18080",
+  });
+});
+
+test("classifyPortStatus: running compose service is not treated as collision", () => {
+  const runningServices = new Set(["backend"]);
+  assert.equal(
+    classifyPortStatus({
+      service: "backend",
+      port: 8080,
+      inUse: true,
+      runningServices,
+    }).status,
+    "pass",
+  );
+  assert.equal(
+    classifyPortStatus({
+      service: "frontend",
+      port: 5173,
+      inUse: true,
+      runningServices,
+    }).status,
+    "fail",
+  );
+});
+
+test("summarize: counts pass, warn, and fail statuses", () => {
+  assert.deepEqual(
+    summarize([
+      { status: "pass" },
+      { status: "warn" },
+      { status: "fail" },
+      { status: "pass" },
+    ]),
+    { pass: 2, warn: 1, fail: 1 },
+  );
+});


### PR DESCRIPTION
Closes #604

## 변경 사항

- 이슈 604 요구사항과 acceptance criteria를 `.agent/specs/604.md`에 정리했습니다.
- 루트 `pnpm run doctor` 명령을 추가해 로컬 스택 실행 전에 개발 환경을 비파괴적으로 진단할 수 있게 했습니다.
- `scripts/doctor.mjs`는 저장소 기준 파일(`mise.toml`, `package.json`, `ml/.python-version`)을 읽어 Java, Node, pnpm, Python, uv 버전을 확인하고 Docker CLI/Compose/daemon 상태를 점검합니다.
- `.env` 존재와 필수 키(`DB_PASSWORD`, `JWT_SECRET`, `AIRFLOW_WEBHOOK_SECRET`) 상태를 확인하고, 준비되지 않은 경우 `docker compose config`는 cascade 실패 대신 skip 경고로 표시합니다.
- full profile 기본값으로 5432/5173/8080/8081/9000/9001 포트 점유를 확인하고, 본 프로젝트 compose 서비스가 이미 자기 포트를 사용하는 경우는 충돌로 보지 않습니다. `--profile light|pipeline|full`로 점검 범위를 조정할 수 있습니다.
- backend JAR 준비 상태는 기존 `scripts/preflight-backend-jar.mjs --check-only` 경로를 사용해 자동 빌드 없이 확인합니다.
- README와 AGENTS의 루트 개발 명령 안내에 `pnpm run doctor`를 추가했습니다.

## 검증

- `node --test "scripts/**/*.test.mjs"` (44 passed)
- `node --test scripts/doctor.test.mjs scripts/dev-setup.test.mjs scripts/preflight-backend-jar.test.mjs` (28 passed)
- `node -e 'JSON.parse(require("fs").readFileSync("package.json", "utf8")); console.log("package.json ok")'`
- `pnpm run format:check`
- `pnpm exec prettier --check .agent/specs/604.md scripts/doctor.mjs scripts/doctor.test.mjs package.json AGENTS.md`
- `git diff --check`
- `pnpm run doctor` 실행 확인: 현재 실행 호스트가 Java 17/Node 24/Python 3.14, `.env` 없음, backend JAR 없음, 5432/8081 포트 점유 상태라 명확한 fail/warn/fix 안내와 함께 exit 1로 종료되는 것을 확인했습니다.

## 참고

- 구현 전 기존 `scripts/dev-setup.mjs`, `scripts/preflight-backend-jar.mjs`, 관련 script 테스트, `mise.toml`, `frontend/package.json`, `ml/.python-version`, `.env.example`, `docker-compose.yml`의 로컬 개발 기준과 포트/env 정책을 확인했습니다.
- spec review 2회 수행: issue fidelity 관점에서 도구 버전, 포트, `.env`, backend JAR/dev readiness, 실패별 해결 안내를 Scope/Requirements/AC에 매핑했고, repository compliance 관점에서 파일명, 브랜치명, 참조 경로 실재 여부를 확인했습니다.
- self-review 3회 수행: Round 1에서 이슈 요구사항과 doctor 출력/종료 코드 매핑을 확인했습니다. Round 2에서 `dev-setup` helper 재사용, 비파괴 동작, generated/client/runtime 계약 불변을 확인했습니다. Round 3에서 테스트 범위, 포맷, diff check, 의도 외 README 재포맷 제거, stale path 여부를 확인했습니다.
- README.md 전체는 main 기준으로 prettier 대상이 아니므로 전체 재포맷하지 않고 `doctor` 안내 줄만 기존 표기 스타일에 맞춰 추가했습니다.