### PR TITLE
feat(ml): manage LLM service lifecycle in Airflow

### DIFF
--- a/infra/terraform/ecs-airflow.tf
+++ b/infra/terraform/ecs-airflow.tf
@@ -226,6 +226,18 @@ locals {
       value = "http://${aws_lb.ml_llm_internal.dns_name}:${var.llm_service_container_port}/v1"
     },
     {
+      name  = "PIPELINE_LLM_ECS_SERVICE"
+      value = aws_ecs_service.ml_llm.name
+    },
+    {
+      name  = "PIPELINE_LLM_ECS_DESIRED_COUNT"
+      value = "1"
+    },
+    {
+      name  = "PIPELINE_LLM_HEALTH_URL"
+      value = "http://${aws_lb.ml_llm_internal.dns_name}:${var.llm_service_container_port}/health"
+    },
+    {
       name  = "S3_EXPECTED_BUCKET_OWNER"
       value = data.aws_caller_identity.current.account_id
     },

--- a/infra/terraform/iam.tf
+++ b/infra/terraform/iam.tf
@@ -310,6 +310,15 @@ data "aws_iam_policy_document" "ecs_airflow_task" {
   }
 
   statement {
+    sid = "ManageLlmServiceLifecycle"
+    actions = [
+      "ecs:DescribeServices",
+      "ecs:UpdateService"
+    ]
+    resources = [aws_ecs_service.ml_llm.arn]
+  }
+
+  statement {
     sid     = "PassStageTaskRoles"
     actions = ["iam:PassRole"]
     resources = [

--- a/ml/src/dags/domain_pack_generation.py
+++ b/ml/src/dags/domain_pack_generation.py
@@ -28,6 +28,8 @@ from pipeline.common.context import StageContext
 from pipeline.common.dag_defaults import default_dag_args
 from pipeline.common.exceptions import PipelineConfigurationError
 from pipeline.ecs_stage_worker import STAGE_MODULES
+from pipeline.llm_service_lifecycle import start_llm_service as start_llm_ecs_service
+from pipeline.llm_service_lifecycle import stop_llm_service as stop_llm_ecs_service
 
 RUN_MODE_INITIAL = "INITIAL"
 RUN_MODE_DOMAIN_CONFIRMED_REPLAY = "DOMAIN_CONFIRMED_REPLAY"
@@ -417,6 +419,11 @@ def domain_pack_generation() -> None:  # pragma: no cover - Airflow imports this
             upstream_manifest_path=intent_discovery_result["artifact_manifest_path"],
         )
 
+    @task(task_id="start_llm_service")
+    def start_llm_service(flow_splitting_result: dict[str, str]) -> dict[str, str]:
+        start_llm_ecs_service()
+        return flow_splitting_result
+
     @task(task_id="feedback_candidate_generation")
     def feedback_candidate_generation(flow_splitting_result: dict[str, str]) -> dict[str, str]:
         if _conf_bool("skip_feedback_checkpoint") or _run_mode() == RUN_MODE_FEEDBACK_REPLAY:
@@ -446,6 +453,10 @@ def domain_pack_generation() -> None:  # pragma: no cover - Airflow imports this
             upstream_manifest_path=human_feedback_result["artifact_manifest_path"],
         )
 
+    @task(task_id="stop_llm_service", trigger_rule="all_done")
+    def stop_llm_service() -> dict[str, object]:
+        return stop_llm_ecs_service()
+
     @task(task_id="evaluation")
     def evaluation(draft_generation_result: dict[str, str]) -> dict[str, str]:
         return _run_stage(
@@ -468,15 +479,25 @@ def domain_pack_generation() -> None:  # pragma: no cover - Airflow imports this
     domain_confirmation_task = domain_confirmation_checkpoint(domain_candidate_task)
     intent_discovery_task = intent_discovery(domain_confirmation_task)
     flow_splitting_task = flow_splitting(intent_discovery_task)
-    feedback_candidate_task = feedback_candidate_generation(flow_splitting_task)
+    start_llm_task = start_llm_service(flow_splitting_task)
+    feedback_candidate_task = feedback_candidate_generation(start_llm_task)
     human_feedback_task = human_feedback_checkpoint(feedback_candidate_task)
     draft_generation_task = draft_generation(human_feedback_task)
+    stop_llm_task = stop_llm_service()
     evaluation_task = evaluation(draft_generation_task)
     publish_candidate_task = publish_candidate(evaluation_task)
 
     ingestion_task >> preprocessing_task >> representation_task >> domain_candidate_task >> domain_confirmation_task
-    domain_confirmation_task >> intent_discovery_task >> flow_splitting_task >> feedback_candidate_task
+    (
+        domain_confirmation_task
+        >> intent_discovery_task
+        >> flow_splitting_task
+        >> start_llm_task
+        >> feedback_candidate_task
+    )
     feedback_candidate_task >> human_feedback_task >> draft_generation_task
+    human_feedback_task >> stop_llm_task
+    draft_generation_task >> stop_llm_task
     draft_generation_task >> evaluation_task >> publish_candidate_task
 
 

--- a/ml/src/pipeline/llm_service_lifecycle.py
+++ b/ml/src/pipeline/llm_service_lifecycle.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import logging
+import os
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Any
+
+import boto3
+
+from pipeline.common.exceptions import PipelineConfigurationError, PipelineStageError
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_DESIRED_COUNT = 1
+DEFAULT_POLL_INTERVAL_SECONDS = 15.0
+DEFAULT_START_TIMEOUT_SECONDS = 1200.0
+DEFAULT_STOP_TIMEOUT_SECONDS = 600.0
+DEFAULT_HEALTH_REQUEST_TIMEOUT_SECONDS = 5.0
+
+
+@dataclass(frozen=True)
+class LlmServiceLifecycleConfig:
+    cluster: str
+    service: str
+    desired_count: int
+    poll_interval_seconds: float
+    start_timeout_seconds: float
+    stop_timeout_seconds: float
+    health_url: str | None
+    health_request_timeout_seconds: float
+
+
+def start_llm_service() -> dict[str, object]:
+    config = _config_from_env()
+    if config is None:
+        return {"enabled": False, "reason": "missing_pipeline_llm_ecs_service"}
+
+    ecs = boto3.client("ecs")
+    logger.info(
+        "Starting LLM ECS service cluster=%s service=%s desired_count=%s",
+        config.cluster,
+        config.service,
+        config.desired_count,
+    )
+    ecs.update_service(cluster=config.cluster, service=config.service, desiredCount=config.desired_count)
+    _wait_for_service_count(
+        ecs, config, desired_count=config.desired_count, timeout_seconds=config.start_timeout_seconds
+    )
+    if config.health_url:
+        _wait_for_health(config)
+    return {
+        "enabled": True,
+        "cluster": config.cluster,
+        "service": config.service,
+        "desiredCount": config.desired_count,
+        "healthUrl": config.health_url,
+    }
+
+
+def stop_llm_service() -> dict[str, object]:
+    config = _config_from_env()
+    if config is None:
+        return {"enabled": False, "reason": "missing_pipeline_llm_ecs_service"}
+
+    ecs = boto3.client("ecs")
+    logger.info("Stopping LLM ECS service cluster=%s service=%s", config.cluster, config.service)
+    ecs.update_service(cluster=config.cluster, service=config.service, desiredCount=0)
+    _wait_for_service_count(ecs, config, desired_count=0, timeout_seconds=config.stop_timeout_seconds)
+    return {"enabled": True, "cluster": config.cluster, "service": config.service, "desiredCount": 0}
+
+
+def _config_from_env() -> LlmServiceLifecycleConfig | None:
+    enabled_override = _optional_env("PIPELINE_LLM_SERVICE_LIFECYCLE_ENABLED")
+    service = _optional_env("PIPELINE_LLM_ECS_SERVICE")
+    cluster = _optional_env("PIPELINE_LLM_ECS_CLUSTER") or _optional_env("PIPELINE_ECS_CLUSTER")
+    default_enabled = bool(service)
+    enabled = _bool_env("PIPELINE_LLM_SERVICE_LIFECYCLE_ENABLED", default=default_enabled)
+    if not enabled:
+        return None
+    if not service:
+        if enabled_override is not None:
+            raise PipelineConfigurationError("PIPELINE_LLM_ECS_SERVICE is required when LLM lifecycle is enabled.")
+        return None
+    if not cluster:
+        raise PipelineConfigurationError("PIPELINE_LLM_ECS_CLUSTER or PIPELINE_ECS_CLUSTER is required.")
+
+    return LlmServiceLifecycleConfig(
+        cluster=cluster,
+        service=service,
+        desired_count=_positive_int_env("PIPELINE_LLM_ECS_DESIRED_COUNT", DEFAULT_DESIRED_COUNT),
+        poll_interval_seconds=_positive_float_env(
+            "PIPELINE_LLM_SERVICE_POLL_INTERVAL_SECONDS",
+            DEFAULT_POLL_INTERVAL_SECONDS,
+        ),
+        start_timeout_seconds=_positive_float_env(
+            "PIPELINE_LLM_SERVICE_START_TIMEOUT_SECONDS",
+            DEFAULT_START_TIMEOUT_SECONDS,
+        ),
+        stop_timeout_seconds=_positive_float_env(
+            "PIPELINE_LLM_SERVICE_STOP_TIMEOUT_SECONDS",
+            DEFAULT_STOP_TIMEOUT_SECONDS,
+        ),
+        health_url=_optional_env("PIPELINE_LLM_HEALTH_URL") or _health_url_from_runtime_base_url(),
+        health_request_timeout_seconds=_positive_float_env(
+            "PIPELINE_LLM_HEALTH_REQUEST_TIMEOUT_SECONDS",
+            DEFAULT_HEALTH_REQUEST_TIMEOUT_SECONDS,
+        ),
+    )
+
+
+def _wait_for_service_count(
+    ecs: Any,
+    config: LlmServiceLifecycleConfig,
+    *,
+    desired_count: int,
+    timeout_seconds: float,
+) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        service = _describe_service(ecs, config)
+        running_count = int(service.get("runningCount") or 0)
+        pending_count = int(service.get("pendingCount") or 0)
+        if desired_count == 0:
+            if running_count == 0 and pending_count == 0:
+                return
+        elif running_count >= desired_count:
+            return
+
+        if time.monotonic() >= deadline:
+            raise PipelineStageError(
+                "Timed out waiting for LLM ECS service "
+                f"{config.service} desired={desired_count} running={running_count} pending={pending_count}"
+            )
+        time.sleep(config.poll_interval_seconds)
+
+
+def _describe_service(ecs: Any, config: LlmServiceLifecycleConfig) -> dict[str, Any]:
+    response = ecs.describe_services(cluster=config.cluster, services=[config.service])
+    failures = response.get("failures") or []
+    if failures:
+        raise PipelineStageError(f"Failed to describe LLM ECS service {config.service}: {failures}")
+    services = response.get("services") or []
+    if not services:
+        raise PipelineStageError(f"LLM ECS service not found: {config.service}")
+    return dict(services[0])
+
+
+def _wait_for_health(config: LlmServiceLifecycleConfig) -> None:
+    if not config.health_url:
+        return
+    deadline = time.monotonic() + config.start_timeout_seconds
+    last_error = "not ready"
+    while True:
+        ready, last_error = _health_ready(config)
+        if ready:
+            return
+        if time.monotonic() >= deadline:
+            raise PipelineStageError(f"Timed out waiting for LLM health endpoint {config.health_url}: {last_error}")
+        time.sleep(config.poll_interval_seconds)
+
+
+def _health_ready(config: LlmServiceLifecycleConfig) -> tuple[bool, str]:
+    assert config.health_url is not None
+    try:
+        with urllib.request.urlopen(config.health_url, timeout=config.health_request_timeout_seconds) as response:
+            status = int(response.status)
+            return 200 <= status < 500, f"http_status={status}"
+    except urllib.error.HTTPError as exc:
+        status = int(exc.code)
+        reason = str(exc.reason or exc.msg or "").strip()
+        detail = f"http_error={status}"
+        if reason:
+            detail = f"{detail} {reason}"
+        return 200 <= status < 500, detail
+    except OSError as exc:
+        return False, str(exc) or type(exc).__name__
+
+
+def _health_url_from_runtime_base_url() -> str | None:
+    base_url = _optional_env("LLM_RUNTIME_BASE_URL")
+    if not base_url:
+        return None
+    normalized = base_url.rstrip("/")
+    if normalized.endswith("/v1"):
+        normalized = normalized[:-3].rstrip("/")
+    return f"{normalized}/health"
+
+
+def _bool_env(name: str, *, default: bool) -> bool:
+    value = _optional_env(name)
+    if value is None:
+        return default
+    normalized = value.lower()
+    if normalized in {"1", "true", "yes", "y", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "n", "off"}:
+        return False
+    raise PipelineConfigurationError(f"{name} must be a boolean value.")
+
+
+def _positive_int_env(name: str, default: int) -> int:
+    value = _optional_env(name)
+    if value is None:
+        return default
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise PipelineConfigurationError(f"{name} must be an integer.") from exc
+    if parsed <= 0:
+        raise PipelineConfigurationError(f"{name} must be greater than 0.")
+    return parsed
+
+
+def _positive_float_env(name: str, default: float) -> float:
+    value = _optional_env(name)
+    if value is None:
+        return default
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise PipelineConfigurationError(f"{name} must be a number.") from exc
+    if parsed <= 0:
+        raise PipelineConfigurationError(f"{name} must be greater than 0.")
+    return parsed
+
+
+def _optional_env(name: str) -> str | None:
+    value = os.getenv(name)
+    if value is None:
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+__all__ = ["start_llm_service", "stop_llm_service"]

--- a/ml/tests/test_llm_service_lifecycle.py
+++ b/ml/tests/test_llm_service_lifecycle.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import urllib.error
+from email.message import Message
+from typing import Any
+
+import pytest
+
+from pipeline.common.exceptions import PipelineConfigurationError, PipelineStageError
+from pipeline.llm_service_lifecycle import (
+    LlmServiceLifecycleConfig,
+    _config_from_env,
+    _health_ready,
+    _health_url_from_runtime_base_url,
+    _wait_for_health,
+    _wait_for_service_count,
+    start_llm_service,
+    stop_llm_service,
+)
+
+
+class FakeEcsClient:
+    def __init__(self, services: list[dict[str, Any]] | None = None) -> None:
+        self.services = services or [{"runningCount": 1, "pendingCount": 0}]
+        self.update_calls: list[dict[str, Any]] = []
+        self.describe_calls: list[dict[str, Any]] = []
+
+    def update_service(self, **kwargs: Any) -> dict[str, Any]:
+        self.update_calls.append(kwargs)
+        return {"service": {"serviceName": kwargs["service"], "desiredCount": kwargs["desiredCount"]}}
+
+    def describe_services(self, **kwargs: Any) -> dict[str, Any]:
+        self.describe_calls.append(kwargs)
+        service = self.services[min(len(self.describe_calls) - 1, len(self.services) - 1)]
+        return {"services": [service]}
+
+
+def test_start_llm_service_is_disabled_without_service_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_lifecycle_env(monkeypatch)
+
+    assert start_llm_service() == {"enabled": False, "reason": "missing_pipeline_llm_ecs_service"}
+
+
+def test_stop_llm_service_is_disabled_without_service_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_lifecycle_env(monkeypatch)
+
+    assert stop_llm_service() == {"enabled": False, "reason": "missing_pipeline_llm_ecs_service"}
+
+
+def test_lifecycle_can_be_explicitly_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_lifecycle_env(monkeypatch)
+    _set_lifecycle_env(monkeypatch)
+    monkeypatch.setenv("PIPELINE_LLM_SERVICE_LIFECYCLE_ENABLED", "false")
+
+    assert _config_from_env() is None
+
+
+def test_start_llm_service_requires_service_when_explicitly_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_lifecycle_env(monkeypatch)
+    monkeypatch.setenv("PIPELINE_LLM_SERVICE_LIFECYCLE_ENABLED", "true")
+    monkeypatch.setenv("PIPELINE_ECS_CLUSTER", "cluster")
+
+    with pytest.raises(PipelineConfigurationError, match="PIPELINE_LLM_ECS_SERVICE"):
+        start_llm_service()
+
+
+def test_start_llm_service_requires_cluster(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_lifecycle_env(monkeypatch)
+    monkeypatch.setenv("PIPELINE_LLM_ECS_SERVICE", "llm-service")
+
+    with pytest.raises(PipelineConfigurationError, match="PIPELINE_LLM_ECS_CLUSTER"):
+        start_llm_service()
+
+
+def test_start_llm_service_updates_service_and_waits_for_health(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_lifecycle_env(monkeypatch)
+    _set_lifecycle_env(monkeypatch)
+    ecs = FakeEcsClient(services=[{"runningCount": 0, "pendingCount": 1}, {"runningCount": 1, "pendingCount": 0}])
+    health_calls: list[str | None] = []
+
+    monkeypatch.setattr("pipeline.llm_service_lifecycle.boto3.client", lambda service: ecs)
+    monkeypatch.setattr("pipeline.llm_service_lifecycle.time.sleep", lambda _seconds: None)
+    monkeypatch.setattr(
+        "pipeline.llm_service_lifecycle._wait_for_health",
+        lambda config: health_calls.append(config.health_url),
+    )
+
+    result = start_llm_service()
+
+    assert result["enabled"] is True
+    assert result["desiredCount"] == 1
+    assert ecs.update_calls == [{"cluster": "cluster", "service": "llm-service", "desiredCount": 1}]
+    assert len(ecs.describe_calls) == 2
+    assert health_calls == ["http://llm.local:8000/health"]
+
+
+def test_stop_llm_service_scales_service_to_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_lifecycle_env(monkeypatch)
+    _set_lifecycle_env(monkeypatch)
+    ecs = FakeEcsClient(services=[{"runningCount": 1, "pendingCount": 0}, {"runningCount": 0, "pendingCount": 0}])
+
+    monkeypatch.setattr("pipeline.llm_service_lifecycle.boto3.client", lambda service: ecs)
+    monkeypatch.setattr("pipeline.llm_service_lifecycle.time.sleep", lambda _seconds: None)
+
+    result = stop_llm_service()
+
+    assert result == {"enabled": True, "cluster": "cluster", "service": "llm-service", "desiredCount": 0}
+    assert ecs.update_calls == [{"cluster": "cluster", "service": "llm-service", "desiredCount": 0}]
+    assert len(ecs.describe_calls) == 2
+
+
+def test_wait_for_service_count_raises_on_describe_failure() -> None:
+    class FailureEcsClient:
+        def describe_services(self, **_kwargs: Any) -> dict[str, Any]:
+            return {"failures": [{"reason": "missing"}]}
+
+    with pytest.raises(PipelineStageError, match="Failed to describe LLM ECS service"):
+        _wait_for_service_count(
+            FailureEcsClient(),
+            _config(),
+            desired_count=1,
+            timeout_seconds=1,
+        )
+
+
+def test_wait_for_service_count_times_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    monotonic_values = iter([0.0, 2.0])
+    monkeypatch.setattr("pipeline.llm_service_lifecycle.time.monotonic", lambda: next(monotonic_values))
+
+    with pytest.raises(PipelineStageError, match="Timed out waiting for LLM ECS service"):
+        _wait_for_service_count(
+            FakeEcsClient(services=[{"runningCount": 0, "pendingCount": 0}]),
+            _config(),
+            desired_count=1,
+            timeout_seconds=1,
+        )
+
+
+def test_config_derives_health_url_from_llm_runtime_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_lifecycle_env(monkeypatch)
+    _set_lifecycle_env(monkeypatch, health_url=None)
+    monkeypatch.setenv("LLM_RUNTIME_BASE_URL", "http://llm.local:8000/v1")
+
+    config = _config_from_env()
+
+    assert config is not None
+    assert config.health_url == "http://llm.local:8000/health"
+
+
+def test_health_url_from_runtime_base_url_handles_non_v1_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_lifecycle_env(monkeypatch)
+    monkeypatch.setenv("LLM_RUNTIME_BASE_URL", "http://llm.local:8000/openai")
+
+    assert _health_url_from_runtime_base_url() == "http://llm.local:8000/openai/health"
+
+
+def test_health_ready_accepts_http_error_below_500(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_urlopen(*_args: object, **_kwargs: object) -> object:
+        raise urllib.error.HTTPError("http://llm.local/health", 404, "Not Found", Message(), None)
+
+    monkeypatch.setattr("pipeline.llm_service_lifecycle.urllib.request.urlopen", fake_urlopen)
+
+    assert _health_ready(_config()) == (True, "http_error=404 Not Found")
+
+
+def test_health_ready_rejects_connection_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_urlopen(*_args: object, **_kwargs: object) -> object:
+        raise OSError("connection refused")
+
+    monkeypatch.setattr("pipeline.llm_service_lifecycle.urllib.request.urlopen", fake_urlopen)
+
+    assert _health_ready(_config()) == (False, "connection refused")
+
+
+def test_wait_for_health_times_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    monotonic_values = iter([0.0, 2.0])
+    monkeypatch.setattr("pipeline.llm_service_lifecycle.time.monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr("pipeline.llm_service_lifecycle._health_ready", lambda _config: (False, "connection refused"))
+
+    with pytest.raises(PipelineStageError, match="connection refused"):
+        _wait_for_health(_config())
+
+
+@pytest.mark.parametrize(
+    ("name", "value", "message"),
+    [
+        ("PIPELINE_LLM_SERVICE_LIFECYCLE_ENABLED", "maybe", "boolean"),
+        ("PIPELINE_LLM_ECS_DESIRED_COUNT", "0", "greater than 0"),
+        ("PIPELINE_LLM_SERVICE_POLL_INTERVAL_SECONDS", "soon", "number"),
+    ],
+)
+def test_config_rejects_invalid_env_values(
+    monkeypatch: pytest.MonkeyPatch,
+    name: str,
+    value: str,
+    message: str,
+) -> None:
+    _clear_lifecycle_env(monkeypatch)
+    _set_lifecycle_env(monkeypatch)
+    monkeypatch.setenv(name, value)
+
+    with pytest.raises(PipelineConfigurationError, match=message):
+        _config_from_env()
+
+
+def _config() -> LlmServiceLifecycleConfig:
+    return LlmServiceLifecycleConfig(
+        cluster="cluster",
+        service="llm-service",
+        desired_count=1,
+        poll_interval_seconds=0.01,
+        start_timeout_seconds=1,
+        stop_timeout_seconds=1,
+        health_url="http://llm.local:8000/health",
+        health_request_timeout_seconds=0.01,
+    )
+
+
+def _set_lifecycle_env(
+    monkeypatch: pytest.MonkeyPatch, *, health_url: str | None = "http://llm.local:8000/health"
+) -> None:
+    monkeypatch.setenv("PIPELINE_ECS_CLUSTER", "cluster")
+    monkeypatch.setenv("PIPELINE_LLM_ECS_SERVICE", "llm-service")
+    monkeypatch.setenv("PIPELINE_LLM_SERVICE_POLL_INTERVAL_SECONDS", "0.01")
+    monkeypatch.setenv("PIPELINE_LLM_SERVICE_START_TIMEOUT_SECONDS", "1")
+    monkeypatch.setenv("PIPELINE_LLM_SERVICE_STOP_TIMEOUT_SECONDS", "1")
+    if health_url is None:
+        monkeypatch.delenv("PIPELINE_LLM_HEALTH_URL", raising=False)
+    else:
+        monkeypatch.setenv("PIPELINE_LLM_HEALTH_URL", health_url)
+
+
+def _clear_lifecycle_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in (
+        "PIPELINE_LLM_SERVICE_LIFECYCLE_ENABLED",
+        "PIPELINE_LLM_ECS_SERVICE",
+        "PIPELINE_LLM_ECS_CLUSTER",
+        "PIPELINE_LLM_ECS_DESIRED_COUNT",
+        "PIPELINE_LLM_SERVICE_POLL_INTERVAL_SECONDS",
+        "PIPELINE_LLM_SERVICE_START_TIMEOUT_SECONDS",
+        "PIPELINE_LLM_SERVICE_STOP_TIMEOUT_SECONDS",
+        "PIPELINE_LLM_HEALTH_URL",
+        "PIPELINE_LLM_HEALTH_REQUEST_TIMEOUT_SECONDS",
+        "PIPELINE_ECS_CLUSTER",
+        "LLM_RUNTIME_BASE_URL",
+    ):
+        monkeypatch.delenv(key, raising=False)


### PR DESCRIPTION
## Summary

- Add an Airflow-controlled lifecycle for the internal `ml-llm` ECS service.
- Start `ml-llm` after `flow_splitting`, before LLM-backed feedback question and draft enrichment run.
- Stop `ml-llm` with an `all_done` cleanup task after the feedback/draft path reaches a terminal state.
- Inject the LLM ECS service name and health URL into Airflow task env via Terraform.
- Grant the ECS Airflow task role `ecs:DescribeServices` and `ecs:UpdateService` so it can scale the LLM service.

## Why

The GPU ASG can scale from 0 to 1 for GPU stage tasks, but the local LLM runtime is a separate ECS service behind the internal LLM ALB. Airflow triggering a GPU stage does not automatically start that service, so LLM enrichment can fall back while `ostone-prod-ml-llm` remains at `desired=0`.

This change keeps the default idle state at 0 tasks, but lets a pipeline run temporarily scale the LLM service to 1 only around the stages that need it.

## Validation

- `pnpm run ci:ml`
- `pnpm run lint:ml`
- `pnpm run typecheck:ml`
- `terraform fmt -check infra/terraform/ecs-airflow.tf infra/terraform/iam.tf`

## Deploy Check

After merge/deploy, trigger a pipeline run and verify:

- Airflow shows `start_llm_service` before `feedback_candidate_generation`.
- ECS service `ostone-prod-ml-llm` moves `0 -> 1` and becomes healthy behind the internal target group.
- `feedback_review_questions.json.enrichmentSummary.appliedCount` is greater than 0 or any fallback reason is explicit.
- Airflow eventually runs `stop_llm_service` and ECS returns `ostone-prod-ml-llm` to `desired=0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 파이프라인에 LLM ECS 서비스의 자동 시작·종료 및 헬스 체크 기반 준비 판정 추가

* **Chores**
  * 런타임 환경변수로 LLM 서비스 제어용 변수 추가 및 관련 권한 설정 업데이트

* **Tests**
  * LLM 서비스 라이프사이클과 헬스/타임아웃/구성 검증을 포함한 단위 테스트 세트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->