### PR TITLE
feat(frontend): 고객 화면 미리보기와 공개 데모 구분을 보장

### DIFF
--- a/.agent/specs/808.md
+++ b/.agent/specs/808.md
@@ -1,0 +1,111 @@
+# Frontend Spec: 고객 화면 미리보기와 공개 데모 라벨 분리
+
+## Goal
+
+운영자용 워크스페이스 미리보기와 외부 공유 가능한 공개 데모 CTA의 라벨을 분리하여 사용자가 인증 상태와 사용 목적을 혼동하지 않게 한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["워크스페이스 운영자 화면"] --> B{"CTA 위치"}
+    B -->|사이드바| C["운영자 미리보기"]
+    C --> D["/chat/:workspaceId 새 탭 이동"]
+    B -->|대시보드 empty state| E["공개 데모 체험"]
+    E --> F["/demo/chat/:workspaceId 이동"]
+```
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+|------|-------|-------|----------|
+| 사이드바 workspace preview | `사용자 화면 미리보기` | 운영자 검수/내부 확인 성격의 라벨 | `/chat/:workspaceId` 경로의 인증 기반 미리보기 목적을 드러낸다. |
+| 대시보드 empty state public demo | `고객 화면 미리보기` | 외부 공유/비로그인 체험 성격의 라벨 | `/demo/chat/:workspaceId` 경로의 공개 데모 목적을 드러낸다. |
+| 관련 새 탭 안내/브레드크럼 | preview/demo 용어 혼재 가능 | CTA와 동일한 용어 체계 | 같은 라벨이 서로 다른 경로 성격에 재사용되지 않게 한다. |
+
+## Component Tree
+
+```
+OstoneShell
+├─ Sidebar
+│  └─ 운영자 미리보기 링크 (/chat/:workspaceId)
+└─ Topbar
+   └─ 운영자 미리보기 breadcrumb
+
+WorkspaceDashboardPage
+└─ DashboardStatePanel
+   └─ 공개 데모 체험 CTA (/demo/chat/:workspaceId)
+```
+
+## API Integration
+
+API 변경은 없다. 기존 프론트엔드 라우팅 의도와 경로는 유지한다.
+
+| Route | Purpose |
+|-------|---------|
+| `/chat/:workspaceId` | 인증된 운영자가 현재 워크스페이스 고객 화면을 내부 검수한다. |
+| `/demo/chat/:workspaceId` | 비로그인 또는 외부 공유용 공개 데모 채팅을 체험한다. |
+
+## Data Flow
+
+```
+shared route/copy constants
+├─ Sidebar / OstoneShell
+│  └─ authenticated workspace preview label
+└─ WorkspaceDashboardPage
+   └─ public demo label
+```
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `frontend/src/shared/lib/userChatRoutes.ts` | update | 인증 기반 workspace preview 라벨과 새 탭 안내 문구를 라우트 목적과 함께 관리한다. |
+| `frontend/src/shared/lib/demoRoutes.ts` | update | public demo CTA 라벨과 새 탭 안내 문구를 라우트 목적과 함께 관리한다. |
+| `frontend/src/shared/ui/ostone/chrome/Sidebar.tsx` | update | `/chat/:workspaceId` 사이드바 링크를 내부 검수용 라벨로 표시한다. |
+| `frontend/src/widgets/ostone-shell/ui/OstoneShell.tsx` | update | chat 섹션 breadcrumb를 사이드바 라벨과 맞춘다. |
+| `frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx` | update | `/demo/chat/:workspaceId` empty state CTA를 공개 데모 성격으로 표시한다. |
+| `frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx` | update | 사이드바 라벨과 경로 유지 여부를 검증한다. |
+| `frontend/src/widgets/ostone-shell/ui/OstoneShell.test.tsx` | update | shell navigation 라벨을 검증한다. |
+| `frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx` | update | public demo CTA 라벨과 경로 유지 여부를 검증한다. |
+
+## State Management
+
+상태 관리 변경은 없다. 라벨 변경은 기존 라우트 빌더와 렌더링 흐름을 그대로 사용한다.
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+|------|------|------|------|
+| 컴포넌트 테스트 | 사이드바/쉘/대시보드 CTA 렌더링 검증 | Vitest + React Testing Library | 라벨과 href를 함께 확인한다. |
+| 정적 검증 | 프론트엔드 타입/빌드 검증 | `pnpm run ci:frontend` | 가능하면 변경 후 실행한다. |
+
+### Test Scenarios
+
+#### Happy Path
+
+| # | 시나리오 | 사전 조건 | 조작 | 기대 결과 |
+|---|---------|---------|------|----------|
+| 1 | 사이드바 workspace preview | `basePath=/workspaces/7` | 사이드바 렌더링 | CTA 라벨은 내부 검수용이고 href는 `/chat/7`이다. |
+| 2 | 대시보드 public demo | workspace id `1` | empty state 렌더링 | CTA 라벨은 공개 데모용이고 href는 `/demo/chat/1`이다. |
+
+#### Error & Edge Cases
+
+| # | 시나리오 | 기대 결과 |
+|---|---------|----------|
+| 1 | 사이드바에서 workspaceId 추출 불가 | fallback `/demo` 링크는 공개 데모 선택 화면 안내를 유지한다. |
+| 2 | 같은 화면에 preview/demo 라벨이 함께 존재 | 동일한 라벨이 서로 다른 경로 목적에 재사용되지 않는다. |
+
+## Non-goals
+
+- `/chat/:workspaceId` 또는 `/demo/chat/:workspaceId` 라우팅 구조를 변경하지 않는다.
+- 인증/인가, API, 채팅 런타임 동작을 변경하지 않는다.
+- 새로운 화면이나 공유 링크 생성 기능을 추가하지 않는다.
+
+## Open Questions
+
+- 없음. 이슈의 요구는 기존 라우팅 의도를 유지하면서 CTA 라벨과 설명을 분리하는 범위로 충분히 해석 가능하다.

--- a/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx
@@ -395,7 +395,7 @@ describe("WorkspaceDashboardPage", () => {
       "/workspaces/1/simulation",
     );
     expect(screen.getByRole("link", { name: /시뮬레이션 시작/ })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /고객 화면 미리보기/ })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /공개 데모 체험/ })).toBeInTheDocument();
     expect(screen.getByTestId("dashboard-customer-preview-cta")).toHaveAttribute(
       "href",
       "/demo/chat/1",

--- a/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx
@@ -23,7 +23,11 @@ import {
   type WorkspaceDashboardActionRecommendations,
 } from "@/features/workspace-dashboard-health/api/workspaceDashboardHealthApi";
 import type { ShellContext } from "@/shared/ui/ostone/chrome";
-import { buildDemoChatPath, buildWorkspaceSimulationPath } from "@/shared/lib/demoRoutes";
+import {
+  buildDemoChatPath,
+  buildWorkspaceSimulationPath,
+  PUBLIC_DEMO_CHAT_LABEL,
+} from "@/shared/lib/demoRoutes";
 import { parseRouteId } from "@/shared/lib/parseRouteId";
 import { Button } from "@/shared/ui/button";
 import { LoadingSpinner } from "@/shared/ui/ostone/atoms/LoadingSpinner";
@@ -822,7 +826,7 @@ export function DashboardStatePanel({ state, workspaceId }: DashboardStatePanelP
         <Button asChild variant="outline">
           <Link to={buildDemoChatPath(workspaceId)} data-testid="dashboard-customer-preview-cta">
             <MonitorSmartphoneIcon aria-hidden="true" />
-            고객 화면 미리보기
+            {PUBLIC_DEMO_CHAT_LABEL}
           </Link>
         </Button>
       </div>

--- a/frontend/src/shared/lib/demoRoutes.ts
+++ b/frontend/src/shared/lib/demoRoutes.ts
@@ -1,4 +1,7 @@
 export const DEMO_SELECTION_PATH = "/demo";
+export const PUBLIC_DEMO_CHAT_LABEL = "공개 데모 체험";
+export const PUBLIC_DEMO_SELECTION_LABEL = "공개 데모 선택";
+export const PUBLIC_DEMO_SELECTION_NEW_TAB_LABEL = "공개 데모 선택 화면을 새 탭에서 엽니다";
 
 export interface WorkspaceSimulationPathParams {
   packId?: number | string | null;

--- a/frontend/src/shared/lib/userChatRoutes.ts
+++ b/frontend/src/shared/lib/userChatRoutes.ts
@@ -1,5 +1,9 @@
 import { DEMO_SELECTION_PATH } from "./demoRoutes";
 
+export const WORKSPACE_PREVIEW_LABEL = "운영자 미리보기";
+export const WORKSPACE_PREVIEW_NEW_TAB_LABEL =
+  "현재 워크스페이스 운영자 미리보기를 새 탭에서 엽니다";
+
 export function buildUserChatPath(workspaceId: string | number): string {
   return `/chat/${encodeURIComponent(String(workspaceId))}`;
 }

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
@@ -26,12 +26,12 @@ describe("Sidebar", () => {
     expect(screen.getByTitle("대시보드")).toBeInTheDocument();
     expect(screen.getByTitle("상담 응대")).toBeInTheDocument();
     expect(screen.getByTitle("시뮬레이션")).toBeInTheDocument();
-    expect(screen.getByTitle("사용자 화면 미리보기")).toBeInTheDocument();
+    expect(screen.getByTitle("공개 데모 선택")).toBeInTheDocument();
     expect(screen.getByTitle("상담 로그 수집")).toBeInTheDocument();
     expect(screen.getByTitle("도메인팩 관리")).toBeInTheDocument();
     expect(screen.getByText("상담 응대")).toBeInTheDocument();
     expect(screen.getByText("시뮬레이션")).toBeInTheDocument();
-    expect(screen.getByText("사용자 화면 미리보기")).toBeInTheDocument();
+    expect(screen.getByText("공개 데모 선택")).toBeInTheDocument();
     expect(screen.getByText("상담 로그 수집")).toBeInTheDocument();
     expect(screen.queryByTitle("Workflows")).not.toBeInTheDocument();
   });
@@ -83,54 +83,54 @@ describe("Sidebar", () => {
     expect(screen.getByTitle("대시보드")).toHaveAttribute("href", "/workspaces/7/dashboard");
     expect(screen.getByTitle("상담 응대")).toHaveAttribute("href", "/workspaces/7/consultation");
     expect(screen.getByTitle("시뮬레이션")).toHaveAttribute("href", "/workspaces/7/simulation");
-    expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute("href", "/chat/7");
-    expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute("target", "_blank");
-    expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute("rel", "noopener noreferrer");
+    expect(screen.getByTitle("운영자 미리보기")).toHaveAttribute("href", "/chat/7");
+    expect(screen.getByTitle("운영자 미리보기")).toHaveAttribute("target", "_blank");
+    expect(screen.getByTitle("운영자 미리보기")).toHaveAttribute("rel", "noopener noreferrer");
     expect(screen.getByTitle("도메인팩 관리")).toHaveAttribute(
       "href",
       "/workspaces/7/domain-packs",
     );
   });
 
-  it("workspaceId를 추출하면 사용자 화면 미리보기를 현재 워크스페이스 채팅으로 보낸다", () => {
+  it("workspaceId를 추출하면 운영자 미리보기를 현재 워크스페이스 채팅으로 보낸다", () => {
     renderSidebar({ basePath: "/workspaces/7" });
 
-    expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute("href", "/chat/7");
-    expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute("target", "_blank");
-    expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute("rel", "noopener noreferrer");
+    expect(screen.getByTitle("운영자 미리보기")).toHaveAttribute("href", "/chat/7");
+    expect(screen.getByTitle("운영자 미리보기")).toHaveAttribute("target", "_blank");
+    expect(screen.getByTitle("운영자 미리보기")).toHaveAttribute("rel", "noopener noreferrer");
   });
 
-  it("workspaceId를 추출할 수 없어도 사용자 화면 미리보기는 공개 데모 선택 화면으로 보낸다", () => {
+  it("workspaceId를 추출할 수 없으면 공개 데모 선택 화면으로 보낸다", () => {
     renderSidebar({ basePath: "/workspaces" });
 
-    expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute("href", "/demo");
+    expect(screen.getByTitle("공개 데모 선택")).toHaveAttribute("href", "/demo");
     expect(screen.getByLabelText("공개 데모 선택 화면을 새 탭에서 엽니다")).toBeInTheDocument();
   });
 
-  it("새 탭 링크(사용자 화면 미리보기)에만 목적이 분명한 새 탭 안내 아이콘을 표시한다", () => {
+  it("새 탭 링크(운영자 미리보기)에만 목적이 분명한 새 탭 안내 아이콘을 표시한다", () => {
     renderSidebar({ basePath: "/workspaces/7" });
 
-    const newTabIcon = screen.getByLabelText("현재 워크스페이스 사용자 화면을 새 탭에서 엽니다");
+    const newTabIcon = screen.getByLabelText("현재 워크스페이스 운영자 미리보기를 새 탭에서 엽니다");
     expect(newTabIcon).toBeInTheDocument();
     expect(screen.getByTestId("sidebar-link-chat")).toContainElement(newTabIcon);
     expect(
-      screen.getAllByLabelText("현재 워크스페이스 사용자 화면을 새 탭에서 엽니다"),
+      screen.getAllByLabelText("현재 워크스페이스 운영자 미리보기를 새 탭에서 엽니다"),
     ).toHaveLength(1);
 
     expect(
       screen
         .getByTestId("sidebar-link-consult")
-        .querySelector('[aria-label="현재 워크스페이스 사용자 화면을 새 탭에서 엽니다"]'),
+        .querySelector('[aria-label="현재 워크스페이스 운영자 미리보기를 새 탭에서 엽니다"]'),
     ).toBeNull();
     expect(
       screen
         .getByTestId("sidebar-link-simulation")
-        .querySelector('[aria-label="현재 워크스페이스 사용자 화면을 새 탭에서 엽니다"]'),
+        .querySelector('[aria-label="현재 워크스페이스 운영자 미리보기를 새 탭에서 엽니다"]'),
     ).toBeNull();
     expect(
       screen
         .getByTestId("sidebar-domain-link")
-        .querySelector('[aria-label="현재 워크스페이스 사용자 화면을 새 탭에서 엽니다"]'),
+        .querySelector('[aria-label="현재 워크스페이스 운영자 미리보기를 새 탭에서 엽니다"]'),
     ).toBeNull();
   });
 

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
@@ -1,8 +1,16 @@
 import type { CSSProperties, MouseEvent, ReactNode } from "react";
 import { ExternalLink } from "lucide-react";
 import { NavLink } from "react-router-dom";
-import { DEMO_SELECTION_PATH } from "@/shared/lib/demoRoutes";
-import { buildWorkspacePreviewChatPath } from "@/shared/lib/userChatRoutes";
+import {
+  DEMO_SELECTION_PATH,
+  PUBLIC_DEMO_SELECTION_LABEL,
+  PUBLIC_DEMO_SELECTION_NEW_TAB_LABEL,
+} from "@/shared/lib/demoRoutes";
+import {
+  buildWorkspacePreviewChatPath,
+  WORKSPACE_PREVIEW_LABEL,
+  WORKSPACE_PREVIEW_NEW_TAB_LABEL,
+} from "@/shared/lib/userChatRoutes";
 import { Icon } from "../atoms/Icon";
 import type { IconName } from "../atoms/Icon";
 import { AccountMenu } from "./AccountMenu";
@@ -58,7 +66,7 @@ const TOP_NAV_ITEMS: TopNavItem[] = [
   {
     key: "chat",
     icon: "msg",
-    label: "사용자 화면 미리보기",
+    label: WORKSPACE_PREVIEW_LABEL,
     getPath: buildWorkspacePreviewChatPath,
     openInNewTab: true,
   },
@@ -167,22 +175,30 @@ export function Sidebar({
           width: "100%",
         }}
       >
-        {TOP_NAV_ITEMS.map((item) => (
-          <SidebarLink
-            key={item.key}
-            to={item.getPath(basePath)}
-            icon={item.icon}
-            label={item.label}
-            isActive={active === item.key}
-            activeColor={activeColor}
-            defaultColor={defaultColor}
-            hoverBg={hoverBg}
-            activeBg={activeBg}
-            testId={`sidebar-link-${item.key}`}
-            target={item.openInNewTab ? "_blank" : undefined}
-            newTabLabel={item.openInNewTab ? getNewTabLabel(item.getPath(basePath)) : undefined}
-          />
-        ))}
+        {TOP_NAV_ITEMS.map((item) => {
+          const to = item.getPath(basePath);
+          const label =
+            item.key === "chat" && to === DEMO_SELECTION_PATH
+              ? PUBLIC_DEMO_SELECTION_LABEL
+              : item.label;
+
+          return (
+            <SidebarLink
+              key={item.key}
+              to={to}
+              icon={item.icon}
+              label={label}
+              isActive={active === item.key}
+              activeColor={activeColor}
+              defaultColor={defaultColor}
+              hoverBg={hoverBg}
+              activeBg={activeBg}
+              testId={`sidebar-link-${item.key}`}
+              target={item.openInNewTab ? "_blank" : undefined}
+              newTabLabel={item.openInNewTab ? getNewTabLabel(to) : undefined}
+            />
+          );
+        })}
 
         <SidebarLink
           to={`${basePath}/domain-packs`}
@@ -232,11 +248,10 @@ interface SidebarLinkProps {
   newTabLabel?: string;
 }
 
-const NEW_TAB_PREVIEW_LABEL = "현재 워크스페이스 사용자 화면을 새 탭에서 엽니다";
-const NEW_TAB_PUBLIC_DEMO_LABEL = "공개 데모 선택 화면을 새 탭에서 엽니다";
-
 function getNewTabLabel(to: string): string {
-  return to === DEMO_SELECTION_PATH ? NEW_TAB_PUBLIC_DEMO_LABEL : NEW_TAB_PREVIEW_LABEL;
+  return to === DEMO_SELECTION_PATH
+    ? PUBLIC_DEMO_SELECTION_NEW_TAB_LABEL
+    : WORKSPACE_PREVIEW_NEW_TAB_LABEL;
 }
 
 function buildLinkStyle({

--- a/frontend/src/widgets/ostone-shell/ui/OstoneShell.test.tsx
+++ b/frontend/src/widgets/ostone-shell/ui/OstoneShell.test.tsx
@@ -23,7 +23,7 @@ describe("OstoneShell", () => {
     expect(screen.queryByTitle("Pipeline")).not.toBeInTheDocument();
     expect(screen.getByTitle("대시보드")).toBeInTheDocument();
     expect(screen.getByTitle("상담 응대")).toBeInTheDocument();
-    expect(screen.getByTitle("사용자 화면 미리보기")).toBeInTheDocument();
+    expect(screen.getByTitle("공개 데모 선택")).toBeInTheDocument();
     expect(screen.getByTitle("상담 로그 수집")).toBeInTheDocument();
     expect(screen.getByTitle("도메인팩 관리")).toBeInTheDocument();
     expect(screen.queryByTitle("Workflows")).not.toBeInTheDocument();
@@ -51,6 +51,18 @@ describe("OstoneShell", () => {
 
     expect(screen.queryByText("CARD-CS")).not.toBeInTheDocument();
     expect(screen.getAllByText("상담 로그 수집").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("chat 상위 화면 breadcrumb를 운영자 미리보기 라벨로 표시한다", () => {
+    render(
+      <OstoneShell active="chat" crumbs={["CARD-CS"]} basePath="/workspaces/7">
+        <div>content</div>
+      </OstoneShell>,
+      { wrapper: Wrapper },
+    );
+
+    expect(screen.queryByText("CARD-CS")).not.toBeInTheDocument();
+    expect(screen.getAllByText("운영자 미리보기").length).toBeGreaterThanOrEqual(1);
   });
 
   it("상세 화면의 여러 breadcrumb는 그대로 유지한다", () => {

--- a/frontend/src/widgets/ostone-shell/ui/OstoneShell.tsx
+++ b/frontend/src/widgets/ostone-shell/ui/OstoneShell.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode } from "react";
 import { useParams } from "react-router-dom";
+import { WORKSPACE_PREVIEW_LABEL } from "@/shared/lib/userChatRoutes";
 import { Sidebar, Topbar, type SidebarActive } from "@/shared/ui/ostone/chrome";
 import type { Crumb, CrumbItem } from "@/shared/ui/ostone/chrome/Topbar";
 import { WorkspaceMarker } from "@/shared/ui/ostone/chrome/WorkspaceMarker";
@@ -29,7 +30,7 @@ const TOP_LEVEL_CRUMB_BY_ACTIVE: Partial<Record<SidebarActive, string>> = {
   consult: "상담 응대",
   domain: "도메인팩 관리",
   settings: "워크스페이스 설정",
-  chat: "사용자 화면 미리보기",
+  chat: WORKSPACE_PREVIEW_LABEL,
   intent: "상담 유형",
   slot: "확인 항목",
   policy: "응대 기준",


### PR DESCRIPTION
Closes #808

## 변경 사항

- 이슈 808 요구사항과 acceptance criteria를 `.agent/specs/808.md`에 정리했습니다.
- `/chat/:workspaceId`로 이동하는 사이드바 workspace preview 라벨을 `운영자 미리보기`로 분리하고, 새 탭 안내와 chat breadcrumb도 같은 용어를 사용하게 했습니다.
- `/demo/chat/:workspaceId`로 이동하는 대시보드 empty state CTA 라벨을 `공개 데모 체험`으로 분리했습니다.
- workspace id를 추출하지 못해 `/demo`로 fallback되는 사이드바 경로는 `공개 데모 선택`으로 표시해 내부 검수용 preview 라벨과 섞이지 않게 했습니다.
- 기존 `/chat/:workspaceId`, `/demo/chat/:workspaceId`, `/demo` 라우팅 목적과 href는 유지했습니다.

## 검증

- `pnpm --dir frontend exec vp test src/shared/ui/ostone/chrome/Sidebar.test.tsx src/widgets/ostone-shell/ui/OstoneShell.test.tsx src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx --run` (3 files, 32 tests)
- `pnpm run ci:frontend` (285 files, 2223 tests, production build 통과; 기존 `BillingFailPage.test.tsx` nested `vi.mock` warning과 chunk-size warning만 표시)
- `pnpm --dir frontend exec eslint src/shared/lib/demoRoutes.ts src/shared/lib/userChatRoutes.ts src/shared/ui/ostone/chrome/Sidebar.tsx src/widgets/ostone-shell/ui/OstoneShell.tsx src/pages/workspace/ui/WorkspaceDashboardPage.tsx src/shared/ui/ostone/chrome/Sidebar.test.tsx src/widgets/ostone-shell/ui/OstoneShell.test.tsx src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx`
- `git diff --check`

## 참고

- 구현 전 `frontend/DESIGN.md`, frontend FSD/test rules, `userChatRoutes.ts`, `demoRoutes.ts`, `Sidebar.tsx`, `OstoneShell.tsx`, `WorkspaceDashboardPage.tsx`와 관련 테스트를 확인했습니다.
- spec review 2회 수행: issue fidelity 관점에서 authenticated preview/public demo 라벨 분리, 라우팅 유지, CTA 용어 재사용 금지를 매핑했고, repository compliance 관점에서 파일명/브랜치/FSD 경계/참조 경로를 확인했습니다.
- self-review 3회 수행: Round 1에서 `/chat`과 `/demo/chat` CTA의 사용자-visible 라벨 및 href 유지 여부를 확인했습니다. Round 2에서 shared route helper 기반 라벨 상수, FSD import 방향, API/generated/runtime 계약 불변을 확인했습니다. Round 3에서 stale label 검색, 변경 파일 범위, whitespace, 검증 명령 기록, fallback `/demo` 라벨을 확인했습니다.
- `pnpm run lint:frontend`는 API/FSD audit 통과 후 이번 변경과 무관한 기존 frontend ESLint baseline 45건으로 실패합니다. 변경 파일 대상 ESLint, focused tests, frontend CI, diff check는 통과했습니다. hook 실패가 repository-wide baseline 때문이라 변경 파일 대상 검증을 근거로 hook을 우회해 커밋했습니다.