### PR TITLE
feat(frontend): 시뮬레이션 피드백 개선 대상 선택을 보장

### DIFF
--- a/.agent/specs/805.md
+++ b/.agent/specs/805.md
@@ -1,0 +1,173 @@
+# Frontend FSD Spec: 시뮬레이션 피드백 개선 대상 세분화
+
+> Issue: #805 `시뮬레이션 피드백을 intent/slot/policy/risk/workflow 단위로 세분화해 개선 후보 타깃을 정한다`
+> Dominant Area: Frontend
+> Branch: `feature/805-simulation-feedback-targets`
+
+---
+
+## Goal
+
+시뮬레이션 피드백에서 개선 후보를 만들기 전에 운영자가 feedback type별 기본 Domain Pack 구성요소 target을 확인하고, 필요한 경우 지원되는 target type으로 수정할 수 있게 한다.
+
+---
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["운영자가 시뮬레이션 피드백 목록을 확인"] --> B["OPEN 피드백의 기본 개선 대상 표시"]
+    B --> C{"기본 대상이 의도와 맞는가?"}
+    C -->|Yes| D["후보 생성"]
+    C -->|No| E["target type 선택"]
+    E --> D
+    D --> F["feedback type과 선택 target을 후보 생성 API payload로 전달"]
+    F --> G["개선 후보 탭에서 target type과 workflow 맥락 확인"]
+```
+
+---
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+|------|-------|-------|----------|
+| 개선 후보 target | UI가 모든 피드백을 `WORKFLOW` target payload로 생성 | feedback type별 기본 target type을 표시하고 생성 payload에 반영 | intent/slot/policy/risk/workflow/response 단위로 대상 세분화 |
+| 운영자 확인 | 후보 버튼만 제공 | 후보 생성 전 target type과 현재 element 확인/수정 UI 제공 | 후보 생성 의도를 운영자가 검토 가능 |
+| workflow 맥락 | 후보 target 자체가 workflow로 고정 | workflow target이 아닐 때도 workflow context를 설명으로 유지 | 기존 시뮬레이션 맥락 보존 |
+| 지원 제한 | 세부 element 미식별 상태가 보이지 않음 | ID/key가 없는 target은 제한 문구로 표시 | 후속 API/element picker 필요성을 명확히 노출 |
+
+---
+
+## Component Tree
+
+```text
+WorkspaceSimulationPage
+├─ FeedbackPanel
+│    └─ WorkspaceFeedbackList
+│         └─ FeedbackItem
+│              ├─ TargetTypeSelect
+│              ├─ TargetElementSummary
+│              └─ CreateCandidateButton
+└─ ImprovementCandidatePanel
+     └─ CandidateTargetSummary
+```
+
+---
+
+## API Integration
+
+### Existing Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/v1/workspaces/:workspaceId/simulation/improvement-candidates/from-feedback/:feedbackId` | feedback 기반 개선 후보 생성 |
+
+### Contract Use
+
+- `frontend/src/features/simulation/api/simulationApi.ts`의 `CreateSimulationImprovementCandidatePayload.targetElementType`, `targetElementId`, `targetElementKey`, `beforeSummary`, `afterSummary`를 사용한다.
+- `backend/src/main/java/com/init/workflowruntime/application/SimulationImprovementCandidateService.java`는 target type 누락 시 feedback type 기반 target을 이미 추론한다. 이번 변경은 UI에서 해당 의도를 노출하고, 사용자가 선택한 target type을 명시적으로 전달한다.
+- generated OpenAPI 재생성, backend schema 변경, 신규 endpoint 추가는 포함하지 않는다.
+
+---
+
+## Data Flow
+
+```text
+SimulationFeedback.feedbackType
+  -> inferDefaultCandidateTarget(feedbackType)
+  -> operator sees/changes targetElementType
+  -> createImprovementCandidate(feedbackId, target payload)
+  -> candidate list displays targetElementType/id/key
+```
+
+---
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `frontend/src/pages/workspace/ui/WorkspaceSimulationPage.tsx` | modify | feedback type별 기본 target 추론, target select, 제한 표시, 후보 payload 생성 |
+| `frontend/src/pages/workspace/ui/simulation/workspace-simulation-page.module.css` | modify | feedback row 내부 target 확인/수정 UI 스타일 |
+| `frontend/src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx` | modify | target type 기본값, 수정, workflow 맥락 유지 회귀 테스트 |
+
+---
+
+## State Management
+
+- `candidateTargetSelections: Record<number, SimulationImprovementCandidateTargetType>`를 feedback id 기준 local state로 둔다.
+- feedback이 새로 로드되면 별도 초기화 없이 각 row 렌더링 시 feedback type 기반 기본값을 fallback으로 사용한다.
+- 선택 target이 `WORKFLOW`이면 현재 선택/매칭/검증 workflow의 id와 key를 payload에 포함한다.
+- 선택 target이 `WORKFLOW`가 아니면 `targetElementType`만 payload에 포함하고, exact element id/key 미확인은 제한 안내로 표시한다.
+
+---
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+|------|------|------|------|
+| 페이지 테스트 | feedback type별 target 표시와 payload 검증 | RTL + Vitest | `WorkspaceSimulationPage.test.tsx` |
+| 페이지 테스트 | target type 수정 후 후보 생성 payload 검증 | RTL + Vitest | 지원되는 select 옵션 회귀 |
+| 페이지 테스트 | workflow target 선택 시 기존 workflow context payload 유지 | RTL + Vitest | #784 회귀 방지 |
+
+### Happy Path
+
+| # | 시나리오 | 사전 조건 | 조작 | 기대 결과 |
+|---|---------|---------|------|----------|
+| 1 | slot 피드백 기본 대상 확인 | `MISSING_SLOT_QUESTION` OPEN 피드백 존재 | 피드백 탭 진입 | 기본 대상이 `SLOT`으로 표시되고 제한 문구가 보인다 |
+| 2 | target type 수정 | OPEN 피드백 존재 | target type을 `POLICY`로 변경 후 후보 생성 | payload `targetElementType`이 `POLICY`다 |
+| 3 | workflow target 유지 | matched workflow 존재 | target type을 `WORKFLOW`로 변경 후 후보 생성 | workflow id/key와 before/after summary가 payload에 포함된다 |
+
+### Error & Edge Cases
+
+| # | 시나리오 | 조작 | 기대 결과 |
+|---|---------|------|----------|
+| 1 | exact element id/key 미지원 | `INTENT`, `SLOT`, `POLICY`, `RISK_RULE`, `HANDOFF`, `RESPONSE` target 표시 | 제한 문구로 현재 후보는 type까지만 지정됨을 알린다 |
+| 2 | workflow context 없음 | `WORKFLOW` target 선택 후 후보 생성 | id/key 없이 `targetElementType: "WORKFLOW"`만 전달되고 생성 실패 토스트는 기존대로 처리 |
+| 3 | 후보 생성 중 | 후보 버튼 클릭 | 해당 feedback row 버튼이 disabled 상태를 유지한다 |
+
+### 반응형 & 접근성
+
+| # | 확인 항목 | 기대 결과 |
+|---|---------|----------|
+| 1 | 키보드 조작 | target type select와 후보 버튼이 Tab 순서에 포함된다 |
+| 2 | 스크린 리더 | target type select는 feedback id별 명확한 `aria-label`을 가진다 |
+| 3 | 모바일 폭 | target 확인/수정 영역이 줄바꿈되고 텍스트가 영역 밖으로 넘치지 않는다 |
+
+---
+
+## Non-goals
+
+- intent/slot/policy/risk/workflow 실제 element picker를 새로 만들지 않는다.
+- backend 후보 생성 API, DB schema, generated OpenAPI를 변경하지 않는다.
+- Domain Pack mutation 또는 review task 적용 로직을 변경하지 않는다.
+- 후보를 feedback당 1개로 제한하는 기존 backend 정책을 변경하지 않는다.
+
+---
+
+## Implementation Quality Brief
+
+- 확인한 기존 패턴: `WorkspaceSimulationPage`의 feedback/candidate tab 구조, `candidateWorkflowTarget` payload 생성, `simulationApi.createImprovementCandidate` payload contract, backend `SimulationImprovementCandidateService`의 feedback type 기반 target 추론.
+- 최소 diff: simulation page 내부 helper/state/UI와 해당 CSS/test만 변경한다.
+- 위험 표면: #784 workflow context 회귀, target type select 접근성, exact element 미지원 안내 누락, 후보 생성 실패/refresh 실패 기존 처리 유지, FSD import 방향.
+- 검증 계획: 관련 Vitest 파일을 우선 실행하고, 가능하면 frontend type/build 또는 CI frontend 명령으로 확장한다.
+
+---
+
+## Self-review Passes
+
+### Pass 1: Issue Fidelity
+
+- feedback type별 기본 개선 대상 구분, 후보 생성 전 target 확인/수정, unsupported exact element 제한 표시, 기존 workflow context 유지 요구사항을 spec에 매핑했다.
+- issue에 없는 backend/API 확장은 non-goal로 제한했다.
+- backend가 target type을 이미 지원한다는 확인 결과를 API Integration에 반영했다.
+
+### Pass 2: Ostone Compliance
+
+- Frontend 템플릿을 기준으로 작성했고 파일명은 `.agent/specs/805.md`다.
+- final branch는 enhancement 규칙에 따라 `feature/805-simulation-feedback-targets`다.
+- 참조한 production/test/style/backend 파일 경로는 repository에서 존재를 확인했다.
+- FSD 방향은 pages가 features/entities/shared를 사용하는 기존 구조 안에 머문다.

--- a/frontend/src/features/simulation/index.ts
+++ b/frontend/src/features/simulation/index.ts
@@ -3,6 +3,7 @@ export type {
   CreateSimulationSessionPayload,
   CreateSimulationFeedbackPayload,
   CreateSimulationGoldenCasePayload,
+  CreateSimulationImprovementCandidatePayload,
   SimulationFeedback,
   SimulationFeedbackPage,
   SimulationFeedbackSeverity,

--- a/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx
@@ -568,7 +568,39 @@ describe("WorkspaceSimulationPage", () => {
     renderPage();
 
     await openFeedbackTab();
+    expect(await screen.findByLabelText("피드백 #900 개선 대상 선택")).toHaveValue("SLOT");
+    expect(screen.getByText("세부 element 미선택")).toBeInTheDocument();
+    expect(screen.getByText("현재 화면은 세부 element 선택을 지원하지 않아 target type까지만 후보에 저장합니다.")).toBeInTheDocument();
     fireEvent.click(await screen.findByRole("button", { name: "후보" }));
+
+    await waitFor(() => {
+      expect(mockedSimulationApi.createImprovementCandidate).toHaveBeenCalledWith(
+        1,
+        900,
+        expect.objectContaining({
+          targetElementType: "SLOT",
+          beforeSummary: "Slot 개선 후보 (환불 처리 workflow 맥락): 주문번호를 묻지 않았습니다.",
+          afterSummary: "주문번호를 먼저 요청합니다.",
+        }),
+      );
+    });
+    expect(toast.success).toHaveBeenCalledWith("개선 후보를 생성했습니다.");
+    await waitFor(() => {
+      expect(mockedSimulationApi.listFeedback).toHaveBeenCalledTimes(2);
+      expect(mockedSimulationApi.listImprovementCandidates).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("개선 후보 target을 workflow로 바꾸면 기존 workflow context payload를 유지한다", async () => {
+    renderPage();
+
+    await openFeedbackTab();
+    fireEvent.change(await screen.findByLabelText("피드백 #900 개선 대상 선택"), {
+      target: { value: "WORKFLOW" },
+    });
+    expect(screen.getByText("#100 · refund_workflow")).toBeInTheDocument();
+    expect(screen.getByText("환불 처리 workflow id/key를 후보에 함께 저장합니다.")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "후보" }));
 
     await waitFor(() => {
       expect(mockedSimulationApi.createImprovementCandidate).toHaveBeenCalledWith(
@@ -578,14 +610,31 @@ describe("WorkspaceSimulationPage", () => {
           targetElementType: "WORKFLOW",
           targetElementId: 100,
           targetElementKey: "refund_workflow",
+          beforeSummary: "Workflow 개선 후보 (환불 처리 workflow 맥락): 주문번호를 묻지 않았습니다.",
           afterSummary: "주문번호를 먼저 요청합니다.",
         }),
       );
     });
-    expect(toast.success).toHaveBeenCalledWith("개선 후보를 생성했습니다.");
+  });
+
+  it("개선 후보 target을 policy로 바꿔 생성할 수 있다", async () => {
+    renderPage();
+
+    await openFeedbackTab();
+    fireEvent.change(await screen.findByLabelText("피드백 #900 개선 대상 선택"), {
+      target: { value: "POLICY" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "후보" }));
+
     await waitFor(() => {
-      expect(mockedSimulationApi.listFeedback).toHaveBeenCalledTimes(2);
-      expect(mockedSimulationApi.listImprovementCandidates).toHaveBeenCalledTimes(2);
+      expect(mockedSimulationApi.createImprovementCandidate).toHaveBeenCalledWith(
+        1,
+        900,
+        expect.objectContaining({
+          targetElementType: "POLICY",
+          beforeSummary: "Policy 개선 후보 (환불 처리 workflow 맥락): 주문번호를 묻지 않았습니다.",
+        }),
+      );
     });
   });
 
@@ -604,8 +653,7 @@ describe("WorkspaceSimulationPage", () => {
         1,
         900,
         expect.objectContaining({
-          targetElementType: "WORKFLOW",
-          targetElementId: 100,
+          targetElementType: "SLOT",
         }),
       );
     });

--- a/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx
@@ -4,7 +4,11 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { toast } from "sonner";
 
 import { WorkspaceSimulationPage } from "./WorkspaceSimulationPage";
-import { simulationApi, type SimulationImprovementCandidate } from "@/features/simulation";
+import {
+  simulationApi,
+  type SimulationFeedbackType,
+  type SimulationImprovementCandidate,
+} from "@/features/simulation";
 import { useListAllWorkspaceWorkflows } from "@/entities/workflow";
 
 const setCrumbs = vi.fn();
@@ -190,6 +194,14 @@ function candidateWithType(
     ...candidate,
     id,
     candidateType,
+  };
+}
+
+function feedbackWithType(id: number, feedbackType: SimulationFeedbackType) {
+  return {
+    ...detail.feedback.items[0],
+    id,
+    feedbackType,
   };
 }
 
@@ -636,6 +648,80 @@ describe("WorkspaceSimulationPage", () => {
         }),
       );
     });
+  });
+
+  it("feedback type별 기본 개선 대상을 서로 다르게 표시한다", async () => {
+    mockedSimulationApi.listFeedback.mockResolvedValue({
+      content: [
+        feedbackWithType(901, "INTENT_MISMATCH"),
+        feedbackWithType(902, "MISSING_SLOT_QUESTION"),
+        feedbackWithType(903, "POLICY_CONDITION_MISSING"),
+        feedbackWithType(904, "RISK_HANDOFF_REQUIRED"),
+        feedbackWithType(905, "WORKFLOW_BRANCH_ERROR"),
+        feedbackWithType(906, "INAPPROPRIATE_RESPONSE"),
+        feedbackWithType(907, "OTHER"),
+      ],
+      page: 0,
+      size: 20,
+      totalElements: 7,
+      totalPages: 1,
+    });
+    renderPage();
+
+    await openFeedbackTab();
+
+    expect(await screen.findByLabelText("피드백 #901 개선 대상 선택")).toHaveValue("INTENT");
+    expect(screen.getByLabelText("피드백 #902 개선 대상 선택")).toHaveValue("SLOT");
+    expect(screen.getByLabelText("피드백 #903 개선 대상 선택")).toHaveValue("POLICY");
+    expect(screen.getByLabelText("피드백 #904 개선 대상 선택")).toHaveValue("RISK_RULE");
+    expect(screen.getByLabelText("피드백 #905 개선 대상 선택")).toHaveValue("WORKFLOW");
+    expect(screen.getByLabelText("피드백 #906 개선 대상 선택")).toHaveValue("RESPONSE");
+    expect(screen.getByLabelText("피드백 #907 개선 대상 선택")).toHaveValue("UNKNOWN");
+    expect(screen.getByText("기타 피드백은 구체 대상이 확정되지 않은 제한 상태로 후보화됩니다.")).toBeInTheDocument();
+  });
+
+  it("workflow 맥락이 없으면 workflow target type만 후보 payload에 보존한다", async () => {
+    mockedWorkflows.mockReturnValue({
+      loading: false,
+      error: null,
+      entries: [],
+    });
+    mockedSimulationApi.getSession.mockResolvedValue({
+      ...detail,
+      matchedWorkflow: null,
+    });
+    mockedSimulationApi.listFeedback.mockResolvedValue({
+      content: [feedbackWithType(905, "WORKFLOW_BRANCH_ERROR")],
+      page: 0,
+      size: 20,
+      totalElements: 1,
+      totalPages: 1,
+    });
+    renderPage();
+
+    await openFeedbackTab();
+    expect(
+      await screen.findByText("workflow 맥락이 확인되지 않아 target type만 후보에 저장됩니다."),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "후보" }));
+
+    await waitFor(() => {
+      expect(mockedSimulationApi.createImprovementCandidate).toHaveBeenCalledWith(
+        1,
+        905,
+        expect.objectContaining({
+          targetElementType: "WORKFLOW",
+          beforeSummary: "Workflow 개선 후보: 주문번호를 묻지 않았습니다.",
+        }),
+      );
+    });
+    expect(mockedSimulationApi.createImprovementCandidate).toHaveBeenCalledWith(
+      1,
+      905,
+      expect.not.objectContaining({
+        targetElementId: expect.any(Number),
+      }),
+    );
   });
 
   it("개선 후보 생성 후 목록 새로고침 실패는 생성 실패로 처리하지 않는다", async () => {

--- a/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.tsx
@@ -27,8 +27,10 @@ import {
   type SimulationFeedbackType,
   type SimulationGoldenCase,
   type SimulationGoldenCaseReplayStatus,
+  type CreateSimulationImprovementCandidatePayload,
   type SimulationImprovementCandidate,
   type SimulationImprovementCandidateStatus,
+  type SimulationImprovementCandidateTargetType,
   type SimulationSessionDetail,
 } from "@/features/simulation";
 import type { ChatMessage, ChatSession } from "@/features/consultation/api/consultationApi";
@@ -86,6 +88,20 @@ const CANDIDATE_STATUSES: Array<{
   { value: "APPLIED", label: "반영됨" },
   { value: "REJECTED", label: "반려됨" },
   { value: "", label: "전체" },
+];
+
+const CANDIDATE_TARGET_TYPES: Array<{
+  value: SimulationImprovementCandidateTargetType;
+  label: string;
+}> = [
+  { value: "INTENT", label: "Intent" },
+  { value: "SLOT", label: "Slot" },
+  { value: "POLICY", label: "Policy" },
+  { value: "RISK_RULE", label: "Risk rule" },
+  { value: "WORKFLOW", label: "Workflow" },
+  { value: "HANDOFF", label: "Handoff" },
+  { value: "RESPONSE", label: "Response" },
+  { value: "UNKNOWN", label: "기타" },
 ];
 
 const FEEDBACK_LIST_ERROR = "시뮬레이션 피드백 목록을 불러오지 못했습니다.";
@@ -304,6 +320,91 @@ function candidateTargetLabel(candidate: SimulationImprovementCandidate): string
   return `${candidate.targetElementType}${id}${key}`;
 }
 
+function candidateTargetTypeLabel(type: SimulationImprovementCandidateTargetType): string {
+  return CANDIDATE_TARGET_TYPES.find((item) => item.value === type)?.label ?? type;
+}
+
+function inferCandidateTargetType(
+  feedbackType: SimulationFeedbackType,
+): SimulationImprovementCandidateTargetType {
+  switch (feedbackType) {
+    case "INTENT_MISMATCH":
+      return "INTENT";
+    case "MISSING_SLOT_QUESTION":
+      return "SLOT";
+    case "POLICY_CONDITION_MISSING":
+      return "POLICY";
+    case "RISK_HANDOFF_REQUIRED":
+      return "RISK_RULE";
+    case "WORKFLOW_BRANCH_ERROR":
+      return "WORKFLOW";
+    case "INAPPROPRIATE_RESPONSE":
+      return "RESPONSE";
+    case "OTHER":
+      return "UNKNOWN";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+function candidateTargetDescription(
+  targetType: SimulationImprovementCandidateTargetType,
+  workflowTarget: CandidateWorkflowTarget | null,
+): string {
+  if (targetType === "WORKFLOW") {
+    return workflowTarget
+      ? `${workflowTarget.workflowName} workflow id/key를 후보에 함께 저장합니다.`
+      : "workflow 맥락이 확인되지 않아 target type만 후보에 저장됩니다.";
+  }
+
+  if (targetType === "UNKNOWN") {
+    return "기타 피드백은 구체 대상이 확정되지 않은 제한 상태로 후보화됩니다.";
+  }
+
+  return "현재 화면은 세부 element 선택을 지원하지 않아 target type까지만 후보에 저장합니다.";
+}
+
+function candidateTargetElementLabel(
+  targetType: SimulationImprovementCandidateTargetType,
+  workflowTarget: CandidateWorkflowTarget | null,
+): string {
+  if (targetType === "WORKFLOW" && workflowTarget) {
+    const key = workflowTarget.workflowCode ?? workflowTarget.workflowName;
+    return `#${workflowTarget.workflowId} · ${key}`;
+  }
+
+  return "세부 element 미선택";
+}
+
+function buildCandidateBeforeSummary(
+  feedback: SimulationFeedback,
+  targetType: SimulationImprovementCandidateTargetType,
+  workflowTarget: CandidateWorkflowTarget | null,
+): string {
+  const targetLabel = candidateTargetTypeLabel(targetType);
+  const workflowLabel = workflowTarget ? ` (${workflowTarget.workflowName} workflow 맥락)` : "";
+  return `${targetLabel} 개선 후보${workflowLabel}: ${feedback.description}`;
+}
+
+function buildCandidateTargetPayload(
+  feedback: SimulationFeedback,
+  targetType: SimulationImprovementCandidateTargetType,
+  workflowTarget: CandidateWorkflowTarget | null,
+): CreateSimulationImprovementCandidatePayload {
+  const payload: CreateSimulationImprovementCandidatePayload = {
+    targetElementType: targetType,
+    beforeSummary: buildCandidateBeforeSummary(feedback, targetType, workflowTarget),
+    afterSummary: feedback.expectedBehavior,
+  };
+
+  if (targetType === "WORKFLOW" && workflowTarget) {
+    payload.targetElementId = workflowTarget.workflowId;
+    payload.targetElementKey = workflowTarget.workflowCode ?? workflowTarget.workflowName;
+  }
+
+  return payload;
+}
+
 function replayStatusLabel(status?: SimulationGoldenCaseReplayStatus | null): string {
   switch (status) {
     case "PASS":
@@ -400,6 +501,9 @@ export function WorkspaceSimulationPage() {
   const [isCreatingGoldenCase, setIsCreatingGoldenCase] = useState(false);
   const [replayingGoldenCaseId, setReplayingGoldenCaseId] = useState<number | null>(null);
   const [creatingCandidateId, setCreatingCandidateId] = useState<number | null>(null);
+  const [candidateTargetSelections, setCandidateTargetSelections] = useState<
+    Record<number, SimulationImprovementCandidateTargetType>
+  >({});
   const [updatingCandidateId, setUpdatingCandidateId] = useState<number | null>(null);
   const [candidateRejectReasons, setCandidateRejectReasons] = useState<Record<number, string>>({});
   const [error, setError] = useState<string | null>(null);
@@ -791,20 +895,13 @@ export function WorkspaceSimulationPage() {
   const handleCreateCandidate = async (feedback: SimulationFeedback) => {
     setCreatingCandidateId(feedback.id);
     try {
-      const workflowTargetPayload = candidateWorkflowTarget
-        ? {
-            targetElementType: "WORKFLOW" as const,
-            targetElementId: candidateWorkflowTarget.workflowId,
-            targetElementKey:
-              candidateWorkflowTarget.workflowCode ?? candidateWorkflowTarget.workflowName,
-            beforeSummary: `${candidateWorkflowTarget.workflowName} workflow 피드백: ${feedback.description}`,
-            afterSummary: feedback.expectedBehavior,
-          }
-        : undefined;
+      const targetType =
+        candidateTargetSelections[feedback.id] ?? inferCandidateTargetType(feedback.feedbackType);
+      const payload = buildCandidateTargetPayload(feedback, targetType, candidateWorkflowTarget);
       await simulationApi.createImprovementCandidate(
         parsedWorkspaceId,
         feedback.id,
-        workflowTargetPayload,
+        payload,
       );
       toast.success("개선 후보를 생성했습니다.");
       setActiveSideTab("candidates");
@@ -1446,32 +1543,81 @@ export function WorkspaceSimulationPage() {
                   <p className={styles.feedbackMuted}>조건에 맞는 피드백이 없습니다.</p>
                 ) : (
                   <ul className={styles.feedbackList}>
-                    {feedbackItems.map((feedback) => (
-                      <li key={feedback.id}>
-                        <div className={styles.feedbackRowHeader}>
-                          <div>
-                            <strong>{feedbackTypeLabel(feedback.feedbackType)}</strong>
-                            <span>
-                              {feedbackSeverityLabel(feedback.severity)} ·{" "}
-                              {feedbackStatusLabel(feedback.status)}
-                            </span>
+                    {feedbackItems.map((feedback) => {
+                      const targetType =
+                        candidateTargetSelections[feedback.id] ??
+                        inferCandidateTargetType(feedback.feedbackType);
+                      const targetDescription = candidateTargetDescription(
+                        targetType,
+                        candidateWorkflowTarget,
+                      );
+                      const targetElementLabel = candidateTargetElementLabel(
+                        targetType,
+                        candidateWorkflowTarget,
+                      );
+                      const isCandidateActionDisabled =
+                        feedback.status !== "OPEN" || creatingCandidateId === feedback.id;
+                      return (
+                        <li key={feedback.id}>
+                          <div className={styles.feedbackRowHeader}>
+                            <div>
+                              <strong>{feedbackTypeLabel(feedback.feedbackType)}</strong>
+                              <span>
+                                {feedbackSeverityLabel(feedback.severity)} ·{" "}
+                                {feedbackStatusLabel(feedback.status)}
+                              </span>
+                            </div>
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="sm"
+                              onClick={() => void handleCreateCandidate(feedback)}
+                              disabled={isCandidateActionDisabled}
+                            >
+                              <LightbulbIcon className={styles.buttonIcon} />
+                              <span>
+                                {creatingCandidateId === feedback.id ? "생성 중" : "후보"}
+                              </span>
+                            </Button>
                           </div>
-                          <Button
-                            type="button"
-                            variant="outline"
-                            size="sm"
-                            onClick={() => void handleCreateCandidate(feedback)}
-                            disabled={
-                              feedback.status !== "OPEN" || creatingCandidateId === feedback.id
-                            }
-                          >
-                            <LightbulbIcon className={styles.buttonIcon} />
-                            <span>{creatingCandidateId === feedback.id ? "생성 중" : "후보"}</span>
-                          </Button>
-                        </div>
-                        <p>{feedback.description}</p>
-                      </li>
-                    ))}
+                          <p>{feedback.description}</p>
+                          <div className={styles.candidateTargetPanel}>
+                            <label className={styles.candidateTargetField}>
+                              <span>개선 대상</span>
+                              <NativeSelect
+                                value={targetType}
+                                onChange={(event) =>
+                                  setCandidateTargetSelections((current) => ({
+                                    ...current,
+                                    [feedback.id]: event.target
+                                      .value as SimulationImprovementCandidateTargetType,
+                                  }))
+                                }
+                                disabled={isCandidateActionDisabled}
+                                aria-label={`피드백 #${feedback.id} 개선 대상 선택`}
+                              >
+                                {CANDIDATE_TARGET_TYPES.map((item) => (
+                                  <NativeSelectOption key={item.value} value={item.value}>
+                                    {item.label}
+                                  </NativeSelectOption>
+                                ))}
+                              </NativeSelect>
+                            </label>
+                            <dl className={styles.candidateTargetSummary}>
+                              <div>
+                                <dt>Target type</dt>
+                                <dd>{candidateTargetTypeLabel(targetType)}</dd>
+                              </div>
+                              <div>
+                                <dt>Target element</dt>
+                                <dd>{targetElementLabel}</dd>
+                              </div>
+                            </dl>
+                            <p>{targetDescription}</p>
+                          </div>
+                        </li>
+                      );
+                    })}
                   </ul>
                 )}
               </div>

--- a/frontend/src/pages/workspace/ui/simulation/workspace-simulation-page.module.css
+++ b/frontend/src/pages/workspace/ui/simulation/workspace-simulation-page.module.css
@@ -718,6 +718,58 @@
   line-height: 1.5;
 }
 
+.candidateTargetPanel {
+  display: grid;
+  gap: var(--s-2);
+  margin-top: var(--s-2);
+  border: 1px solid var(--line);
+  border-radius: var(--r-3);
+  background: var(--paper-2);
+  padding: var(--s-2);
+}
+
+.candidateTargetPanel p {
+  margin: 0;
+  color: var(--ink-3);
+  font-size: 11px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.candidateTargetField {
+  display: grid;
+  gap: var(--s-2);
+  color: var(--ink-2);
+  font-size: 11px;
+  font-weight: 540;
+}
+
+.candidateTargetSummary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--s-2);
+  margin: 0;
+}
+
+.candidateTargetSummary div {
+  min-width: 0;
+}
+
+.candidateTargetSummary dt {
+  color: var(--ink-3);
+  font-size: 10px;
+  font-weight: 540;
+  text-transform: uppercase;
+}
+
+.candidateTargetSummary dd {
+  margin: 3px 0 0;
+  color: var(--ink);
+  font-size: 11px;
+  font-weight: 540;
+  overflow-wrap: anywhere;
+}
+
 .candidateList {
   display: grid;
   gap: var(--s-2);


### PR DESCRIPTION
Closes #805

## 변경 사항

- 이슈 805 요구사항과 acceptance criteria를 `.agent/specs/805.md`에 정리했습니다.
- 시뮬레이션 피드백 목록에서 feedback type별 기본 개선 대상 target type을 표시합니다. `INTENT_MISMATCH`, `MISSING_SLOT_QUESTION`, `POLICY_CONDITION_MISSING`, `RISK_HANDOFF_REQUIRED`, `WORKFLOW_BRANCH_ERROR`, `INAPPROPRIATE_RESPONSE`, `OTHER`가 서로 다른 기본 target으로 매핑됩니다.
- 운영자가 후보 생성 전에 target type을 select로 확인하거나 수정할 수 있게 했고, target element summary를 함께 표시합니다.
- `WORKFLOW` target을 선택하면 기존 선택/매칭/검증 workflow id/key를 후보 생성 payload에 포함해 #784의 workflow context를 유지합니다.
- intent/slot/policy/risk/handoff/response처럼 현재 화면에서 exact element picker가 없는 target은 `세부 element 미선택`과 제한 안내를 표시하고, target type까지만 후보 payload에 보존합니다.
- simulation feature public barrel에서 `CreateSimulationImprovementCandidatePayload` 타입을 내보내 페이지가 기존 feature API 경계를 유지하도록 했습니다.

## 검증

- `pnpm --dir frontend exec vp test run src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx` (1 file, 34 tests)
- `pnpm --dir frontend exec eslint src/features/simulation/index.ts src/pages/workspace/ui/WorkspaceSimulationPage.tsx src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx`
- `pnpm --dir frontend build` (기존 chunk-size warning만 표시)
- `pnpm --dir frontend test -- --run src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx` (API/FSD audits passed, 1 file, 34 tests)
- `git diff --check`

## 참고

- 구현 전 issue 805, `WorkspaceSimulationPage`, `simulationApi` candidate payload contract, backend `SimulationImprovementCandidateService`의 feedback type 기반 target 추론, 기존 spec #784/#527, `frontend/DESIGN.md`, frontend FSD/test rules를 확인했습니다.
- spec review 2회 수행: issue fidelity 관점에서 feedback type별 target 구분, 후보 생성 전 target 확인/수정, 미지원 exact element 제한 표시, workflow context 유지를 매핑했고, repository compliance 관점에서 파일명/브랜치/FSD 경계/참조 경로를 확인했습니다.
- initial self-review 3회 수행: Round 1에서 target element summary가 빠진 점을 발견해 `Target element` 표시와 테스트를 보강했습니다. Round 2에서 feature barrel import, backend enum/API contract, FSD 경계, #784 workflow payload 회귀를 확인했습니다. Round 3에서 테스트 커버리지, 접근성 label, disabled 상태, whitespace, 검증 명령 기록, 의도 외 파일 여부를 확인했습니다.
- follow-up self-review 3회 수행: Sonar new coverage 실패를 확인한 뒤 feedback type별 기본 target 표시 전체와 workflow context 부재 payload를 테스트로 보강했습니다. Round 1에서 이슈 수용 기준, Round 2에서 test-only diff의 FSD/API 영향, Round 3에서 CI/검증 근거와 unintended file 여부를 확인했고 추가 수정 필요 사항은 없었습니다.
- `pnpm run lint:frontend`와 pre-commit hook은 이번 변경과 무관한 기존 frontend ESLint baseline 45건으로 실패합니다. 변경 파일 대상 ESLint, API/FSD audit, focused tests, build, diff check는 통과했습니다. hook 실패가 repository-wide baseline 때문이라 변경 파일 대상 검증을 근거로 hook을 우회해 커밋했습니다.
- 이 thread에서는 in-app browser navigation/screenshot tool이 노출되지 않아 별도 브라우저 시각 검증은 수행하지 못했습니다.