### PR TITLE
feat(frontend): 검증 케이스 기대 동작 확인을 보장

### DIFF
--- a/.agent/specs/806.md
+++ b/.agent/specs/806.md
@@ -1,0 +1,150 @@
+# Frontend FSD Spec: Golden Case 기대 동작 명시 개선
+
+## Goal
+
+Golden Case 생성 화면에서 현재 시뮬레이션 실행 결과와 운영자가 의도한 기대 결과를 분리해 보여주고, 저장 전 intent/workflow/action 중심 기대값을 명시적으로 확인하거나 수정할 수 있게 한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A[시뮬레이션 세션 선택] --> B[Runtime State 확인]
+    B --> C[검증 케이스 패널 확인]
+    C --> D[현재 실행 결과 영역 확인]
+    D --> E[기대 결과 입력값 확인 또는 수정]
+    E --> F{고객 메시지 존재?}
+    F -->|No| G[저장 차단 및 안내]
+    F -->|Yes| H[Golden Case 저장]
+    H --> I[검증 케이스 목록 갱신]
+    I --> J[현재 target version 기준 replay 실행]
+```
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+|------|-------|-------|----------|
+| Golden Case 생성 | 현재 runtime matched 결과를 payload 기본값으로 바로 사용 | 현재 실행 결과와 기대 결과 입력 영역을 분리 | 잘못된 현재 실행 결과가 무심코 기준값으로 저장되는 위험을 낮춘다 |
+| 기대값 편집 | 이름, 기대 action, replay version 중심 | expected intent/workflow/state/action/required slots를 확인 및 수정 | 운영자가 intent/workflow/action 수준의 기대 동작을 저장 전 확인한다 |
+| replay version | matched workflow version 문자열을 입력 | 시뮬레이션 target version을 우선 기본값으로 사용하고 없으면 현재 matched version 사용 | 대시보드/추천에서 진입한 검증 대상 버전 맥락을 유지한다 |
+| 저장 조건 | 고객 메시지 존재 여부만 검사 | 고객 메시지와 필수 기대값 확인 | intent/workflow/action 기대값이 비어 있으면 저장을 막는다 |
+
+## Scope
+
+- `WorkspaceSimulationPage`의 Golden Case 생성 UI와 저장 payload 구성만 변경한다.
+- 현재 API 계약에 존재하는 기대값 필드인 intent, workflow, current state, action type, slot values를 운영자가 확인 및 수정할 수 있게 한다.
+- replay version 기본값은 현재 시뮬레이션 target version을 우선하고, target version이 없을 때 현재 matched workflow의 domain pack version을 사용한다.
+
+## Non-goals
+
+- Backend Golden Case 저장/재생 계약을 변경하지 않는다.
+- `expected response`의 정확한 문구를 별도 필드로 저장하지 않는다. 현재 확인된 `CreateSimulationGoldenCasePayload`에는 응답 본문 기대값 필드가 없으므로, 이번 PR에서는 `expectedActionType`으로 응답/행동 종류를 검증하는 범위에 머문다.
+- Golden Case 목록/상세 API의 pagination, replay 결과 비교 로직, Domain Pack runtime 실행 로직은 변경하지 않는다.
+
+## Component Tree
+
+```text
+WorkspaceSimulationPage
+├─ Runtime State tab
+│  ├─ stateList
+│  ├─ slotPanel
+│  └─ goldenCasePanel
+│     ├─ currentSnapshot summary
+│     ├─ expectedResult fields
+│     │  ├─ name input
+│     │  ├─ expected intent input
+│     │  ├─ expected workflow input
+│     │  ├─ expected state input
+│     │  ├─ expected action select
+│     │  └─ required slots textarea
+│     ├─ replay version input
+│     └─ saved golden case list
+```
+
+## API Integration
+
+### Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/workspaces/{workspaceId}/simulation/golden-cases` | Golden Case 목록 조회 |
+| POST | `/api/v1/workspaces/{workspaceId}/simulation/sessions/{sessionId}/golden-cases` | 현재 세션 입력 메시지와 기대 결과로 Golden Case 생성 |
+| POST | `/api/v1/workspaces/{workspaceId}/simulation/golden-cases/{goldenCaseId}/replays` | 선택된 domain pack version으로 Golden Case replay |
+
+### Data Contract
+
+- `CreateSimulationGoldenCasePayload`는 이미 `expectedIntentCode`, `expectedWorkflowCode`, `expectedCurrentState`, `expectedActionType`, `expectedSlotValues`를 지원한다.
+- 이번 변경은 `frontend/src/features/simulation/api/simulationApi.ts`의 endpoint 계약을 바꾸지 않고, `frontend/src/pages/workspace/ui/WorkspaceSimulationPage.tsx`에서 저장 payload를 운영자가 확인한 기대값으로 구성한다.
+
+## Data Flow
+
+```text
+SimulationSessionDetail
+  ├─ matchedWorkflow, slotValues
+  │   └─ 현재 실행 결과 영역 표시
+  ├─ simulationTarget.versionId
+  │   └─ replayVersionId 기본값 우선 주입
+  └─ expected form state
+      └─ createGoldenCase payload
+```
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `frontend/src/pages/workspace/ui/WorkspaceSimulationPage.tsx` | update | Golden Case 생성 폼에 현재/기대 결과 분리, 기대값 편집, target version 기본값 적용 |
+| `frontend/src/pages/workspace/ui/simulation/workspace-simulation-page.module.css` | update | Golden Case current/expected 영역과 slot JSON 입력 레이아웃 추가 |
+| `frontend/src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx` | update | 기대값 수정 payload와 target version replay 기본값 검증 |
+
+## State Management
+
+### Server State
+
+- 기존 `simulationApi.listGoldenCases`, `simulationApi.createGoldenCase`, `simulationApi.replayGoldenCase` 호출 흐름을 유지한다.
+- Golden Case 저장 성공 후 기존처럼 목록을 다시 조회한다.
+
+### Client State
+
+- 현재 runtime snapshot은 `detail.matchedWorkflow`, `detail.slotValues`에서 읽기 전용으로 표시한다.
+- 기대 결과는 별도 local state로 관리하고, 세션 상세가 바뀌면 현재 snapshot을 제안값으로 다시 초기화한다.
+- `replayVersionId`는 `simulationTarget.versionId`가 있으면 이를 우선 사용하고, 없으면 `detail.matchedWorkflow.domainPackVersionId`를 사용한다.
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+|------|------|------|------|
+| 컴포넌트 테스트 | Golden Case 생성 폼 조작과 API payload 검증 | Vitest + React Testing Library | 기존 `WorkspaceSimulationPage.test.tsx` 확장 |
+| 정적 검증 | TypeScript/format/build 확인 | frontend package scripts | 실행 가능한 범위에서 수행 |
+
+### Test Scenarios
+
+#### Happy Path
+
+| # | 시나리오 | 사전 조건 | 조작 | 기대 결과 |
+|---|---------|---------|------|----------|
+| 1 | 현재 실행 결과와 기대 결과 분리 표시 | matched workflow와 slot 값이 있는 세션 | 시뮬레이션 페이지 진입 | 현재 결과 summary와 기대값 입력 폼이 모두 표시된다 |
+| 2 | 기대값 수정 후 Golden Case 저장 | 고객 메시지 1개 이상 | intent/workflow/state/action/slot 기대값 수정 후 등록 | createGoldenCase payload가 수정한 기대값을 사용한다 |
+| 3 | target version 기본 replay | query 또는 route state에 versionId 존재 | replay 실행 | replay payload가 target version을 domainPackVersionId로 사용한다 |
+
+#### Error & Edge Cases
+
+| # | 시나리오 | 조작 | 기대 결과 |
+|---|---------|------|----------|
+| 1 | 고객 메시지 없음 | 등록 클릭 | 기존 안내 토스트로 저장을 차단한다 |
+| 2 | 필수 기대값 비어 있음 | intent/workflow/action 중 하나를 비운 뒤 등록 | 저장을 차단하고 기대값 확인 안내를 표시한다 |
+| 3 | required slots JSON 오류 | 잘못된 JSON 입력 후 등록 | 저장을 차단하고 JSON 형식 안내를 표시한다 |
+
+#### 반응형 & 접근성
+
+| # | 확인 항목 | 기대 결과 |
+|---|---------|----------|
+| 1 | 좁은 우측 패널 | current/expected 영역이 세로로 쌓이고 텍스트가 넘치지 않는다 |
+| 2 | 입력 라벨 | intent/workflow/state/action/slot/replay version 입력은 label 또는 aria-label로 접근 가능하다 |
+| 3 | 버튼 상태 | 생성 중 또는 세션 미선택 상태에서 등록 버튼이 disabled 된다 |
+
+## Open Questions
+
+- exact expected response text 저장은 별도 backend/API 필드가 필요하므로, 후속 이슈에서 계약 확장을 판단한다.

--- a/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx
@@ -330,7 +330,7 @@ describe("WorkspaceSimulationPage", () => {
     expect(await screen.findByText("환불하고 싶어요")).toBeInTheDocument();
     expect(screen.getByText("환불 문의")).toBeInTheDocument();
     expect(screen.getByText("환불 처리")).toBeInTheDocument();
-    expect(screen.getByText("collect_order_no")).toBeInTheDocument();
+    expect(screen.getAllByText("collect_order_no").length).toBeGreaterThan(0);
     expect(screen.getByText("A-100")).toBeInTheDocument();
   });
 
@@ -847,29 +847,81 @@ describe("WorkspaceSimulationPage", () => {
     expect(toast.success).toHaveBeenCalledWith("개선 후보를 반려했습니다.");
   });
 
-  it("현재 runtime snapshot을 검증 케이스로 저장한다", async () => {
+  it("현재 실행 결과와 구분한 기대 결과를 검증 케이스로 저장한다", async () => {
     renderPage();
 
     await screen.findByText("환불하고 싶어요");
+    expect(screen.getByText("현재 실행 결과")).toBeInTheDocument();
+    expect(screen.getByText("기대 결과")).toBeInTheDocument();
     fireEvent.change(await screen.findByLabelText("검증 케이스 이름"), {
       target: { value: "환불 주문번호 검증" },
     });
+    fireEvent.change(screen.getByLabelText("기대 intent"), {
+      target: { value: "refund_order_number_required" },
+    });
+    fireEvent.change(screen.getByLabelText("기대 workflow"), {
+      target: { value: "refund_required_slot_workflow" },
+    });
+    fireEvent.change(screen.getByLabelText("기대 state"), {
+      target: { value: "ask_order_no" },
+    });
     fireEvent.change(await screen.findByLabelText("기대 action"), {
       target: { value: "ASK_SLOT" },
+    });
+    fireEvent.change(screen.getByLabelText("필수 slot JSON"), {
+      target: { value: '{"orderNo":"B-200"}' },
     });
     fireEvent.click(screen.getByRole("button", { name: "등록" }));
 
     await waitFor(() => {
       expect(mockedSimulationApi.createGoldenCase).toHaveBeenCalledWith(1, 10, {
         name: "환불 주문번호 검증",
-        expectedIntentCode: "refund_request",
-        expectedWorkflowCode: "refund_workflow",
-        expectedCurrentState: "collect_order_no",
+        expectedIntentCode: "refund_order_number_required",
+        expectedWorkflowCode: "refund_required_slot_workflow",
+        expectedCurrentState: "ask_order_no",
         expectedActionType: "ASK_SLOT",
-        expectedSlotValues: { orderNo: "A-100" },
+        expectedSlotValues: { orderNo: "B-200" },
       });
     });
     expect(toast.success).toHaveBeenCalledWith("검증 케이스를 저장했습니다.");
+  });
+
+  it("기대 intent, workflow, action 확인 전에는 검증 케이스를 저장하지 않는다", async () => {
+    renderPage();
+
+    await screen.findByText("환불하고 싶어요");
+    await waitFor(() => {
+      expect(screen.getByLabelText("기대 intent")).toHaveValue("refund_request");
+    });
+    fireEvent.change(screen.getByLabelText("기대 intent"), {
+      target: { value: "" },
+    });
+    fireEvent.change(screen.getByLabelText("기대 action"), {
+      target: { value: "ASK_SLOT" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "등록" }));
+
+    expect(toast.error).toHaveBeenCalledWith("기대 intent, workflow, action을 확인하세요.");
+    expect(mockedSimulationApi.createGoldenCase).not.toHaveBeenCalled();
+  });
+
+  it("필수 slot JSON이 객체가 아니면 검증 케이스를 저장하지 않는다", async () => {
+    renderPage();
+
+    await screen.findByText("환불하고 싶어요");
+    await waitFor(() => {
+      expect(screen.getByLabelText("기대 intent")).toHaveValue("refund_request");
+    });
+    fireEvent.change(screen.getByLabelText("기대 action"), {
+      target: { value: "ASK_SLOT" },
+    });
+    fireEvent.change(screen.getByLabelText("필수 slot JSON"), {
+      target: { value: '["orderNo"]' },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "등록" }));
+
+    expect(toast.error).toHaveBeenCalledWith("필수 slot은 JSON 객체로 입력하세요.");
+    expect(mockedSimulationApi.createGoldenCase).not.toHaveBeenCalled();
   });
 
   it("저장된 검증 케이스를 선택 version으로 replay한다", async () => {
@@ -894,6 +946,29 @@ describe("WorkspaceSimulationPage", () => {
       });
     });
     expect(toast.success).toHaveBeenCalledWith("검증 케이스 replay가 통과했습니다.");
+  });
+
+  it("query target version을 replay version 기본값으로 사용한다", async () => {
+    mockedSimulationApi.listGoldenCases.mockResolvedValue({
+      content: [goldenCase],
+      page: 0,
+      size: 20,
+      totalElements: 1,
+      totalPages: 1,
+    });
+    renderPage("/workspaces/1/simulation?packId=11&versionId=22&workflowId=100");
+
+    await screen.findByText("환불하고 싶어요");
+    await waitFor(() => {
+      expect(screen.getByLabelText("Replay version")).toHaveValue("22");
+    });
+    fireEvent.click(await screen.findByRole("button", { name: "환불 검증 replay" }));
+
+    await waitFor(() => {
+      expect(mockedSimulationApi.replayGoldenCase).toHaveBeenCalledWith(1, 950, {
+        domainPackVersionId: 22,
+      });
+    });
   });
 
   it("최근 replay 실패 요약을 검증 케이스 목록에 표시한다", async () => {

--- a/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.tsx
@@ -333,6 +333,25 @@ function optionalText(value?: string | null): string | undefined {
   return normalized ? normalized : undefined;
 }
 
+function displayText(value?: string | number | null): string {
+  if (value === null || value === undefined || value === "") return "미확인";
+  return String(value);
+}
+
+function stringifySlotValues(values?: Record<string, unknown> | null): string {
+  return JSON.stringify(values ?? {}, null, 2);
+}
+
+function parseSlotValuesInput(value: string): Record<string, unknown> | null {
+  const trimmed = value.trim();
+  if (!trimmed) return {};
+  const parsed = JSON.parse(trimmed);
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return null;
+  }
+  return parsed as Record<string, unknown>;
+}
+
 export function WorkspaceSimulationPage() {
   const { workspaceId } = useParams();
   const location = useLocation();
@@ -387,7 +406,11 @@ export function WorkspaceSimulationPage() {
   const [feedbackDescription, setFeedbackDescription] = useState("");
   const [feedbackExpectedBehavior, setFeedbackExpectedBehavior] = useState("");
   const [goldenCaseName, setGoldenCaseName] = useState("");
+  const [expectedIntentCode, setExpectedIntentCode] = useState("");
+  const [expectedWorkflowCode, setExpectedWorkflowCode] = useState("");
+  const [expectedCurrentState, setExpectedCurrentState] = useState("");
   const [expectedActionType, setExpectedActionType] = useState("");
+  const [expectedSlotValuesJson, setExpectedSlotValuesJson] = useState("{}");
   const [replayVersionId, setReplayVersionId] = useState("");
   const [isLoadingSessions, setIsLoadingSessions] = useState(false);
   const [isLoadingDetail, setIsLoadingDetail] = useState(false);
@@ -552,17 +575,23 @@ export function WorkspaceSimulationPage() {
   useEffect(() => {
     if (detail?.session) {
       setGoldenCaseName(`${customerName(detail.session)} 검증 케이스`);
+      setExpectedIntentCode(detail.matchedWorkflow?.intentCode ?? "");
+      setExpectedWorkflowCode(detail.matchedWorkflow?.workflowCode ?? "");
+      setExpectedCurrentState(detail.matchedWorkflow?.currentState ?? "");
+      setExpectedSlotValuesJson(stringifySlotValues(detail.slotValues));
       setReplayVersionId(
-        detail.matchedWorkflow?.domainPackVersionId
-          ? String(detail.matchedWorkflow.domainPackVersionId)
-          : "",
+        String(simulationTarget?.versionId ?? detail.matchedWorkflow?.domainPackVersionId ?? ""),
       );
     } else {
       setGoldenCaseName("");
+      setExpectedIntentCode("");
+      setExpectedWorkflowCode("");
+      setExpectedCurrentState("");
+      setExpectedSlotValuesJson("{}");
       setReplayVersionId("");
     }
     setExpectedActionType("");
-  }, [detail?.session, detail?.matchedWorkflow?.domainPackVersionId]);
+  }, [detail, simulationTarget?.versionId]);
 
   useEffect(() => {
     if (parsedWorkspaceId === null) return;
@@ -882,15 +911,35 @@ export function WorkspaceSimulationPage() {
       toast.error("고객 메시지가 있어야 검증 케이스로 저장할 수 있습니다.");
       return;
     }
+    const expectedIntent = expectedIntentCode.trim();
+    const expectedWorkflow = expectedWorkflowCode.trim();
+    const expectedState = expectedCurrentState.trim();
+    const expectedAction = expectedActionType.trim();
+    if (!expectedIntent || !expectedWorkflow || !expectedAction) {
+      toast.error("기대 intent, workflow, action을 확인하세요.");
+      return;
+    }
+    let expectedSlotValues: Record<string, unknown>;
+    try {
+      const parsedSlotValues = parseSlotValuesInput(expectedSlotValuesJson);
+      if (parsedSlotValues === null) {
+        toast.error("필수 slot은 JSON 객체로 입력하세요.");
+        return;
+      }
+      expectedSlotValues = parsedSlotValues;
+    } catch {
+      toast.error("필수 slot JSON 형식을 확인하세요.");
+      return;
+    }
     setIsCreatingGoldenCase(true);
     try {
       await simulationApi.createGoldenCase(parsedWorkspaceId, detail.session.id, {
         name: optionalText(goldenCaseName),
-        expectedIntentCode: optionalText(matched?.intentCode),
-        expectedWorkflowCode: optionalText(matched?.workflowCode),
-        expectedCurrentState: optionalText(matched?.currentState),
-        expectedActionType: optionalText(expectedActionType),
-        expectedSlotValues: detail.slotValues ?? {},
+        expectedIntentCode: expectedIntent,
+        expectedWorkflowCode: expectedWorkflow,
+        expectedCurrentState: optionalText(expectedState),
+        expectedActionType: expectedAction,
+        expectedSlotValues,
       });
       toast.success("검증 케이스를 저장했습니다.");
       await reloadGoldenCases().catch(() => undefined);
@@ -1208,21 +1257,87 @@ export function WorkspaceSimulationPage() {
                     aria-label="검증 케이스 이름"
                   />
                 </label>
-                <label className={styles.feedbackField}>
-                  <span>기대 action</span>
-                  <NativeSelect
-                    value={expectedActionType}
-                    onChange={(event) => setExpectedActionType(event.target.value)}
-                    aria-label="기대 action"
-                  >
-                    <NativeSelectOption value="">현재 replay에서 비교 안 함</NativeSelectOption>
-                    {ACTION_TYPES.map((type) => (
-                      <NativeSelectOption key={type} value={type}>
-                        {type}
-                      </NativeSelectOption>
-                    ))}
-                  </NativeSelect>
-                </label>
+                <div className={styles.goldenCaseSnapshot}>
+                  <div className={styles.feedbackPanelHeader}>
+                    <h4>현재 실행 결과</h4>
+                    <span>제안값</span>
+                  </div>
+                  <dl>
+                    <div>
+                      <dt>Intent</dt>
+                      <dd>{displayText(matched?.intentCode ?? matched?.intentName)}</dd>
+                    </div>
+                    <div>
+                      <dt>Workflow</dt>
+                      <dd>{displayText(matched?.workflowCode ?? matched?.workflowName)}</dd>
+                    </div>
+                    <div>
+                      <dt>State</dt>
+                      <dd>{displayText(matched?.currentState)}</dd>
+                    </div>
+                    <div>
+                      <dt>Action</dt>
+                      <dd>직접 선택</dd>
+                    </div>
+                  </dl>
+                </div>
+                <div className={styles.goldenCaseExpected}>
+                  <div className={styles.feedbackPanelHeader}>
+                    <h4>기대 결과</h4>
+                    <span>저장 전 확인</span>
+                  </div>
+                  <label className={styles.feedbackField}>
+                    <span>기대 intent</span>
+                    <input
+                      value={expectedIntentCode}
+                      onChange={(event) => setExpectedIntentCode(event.target.value)}
+                      maxLength={255}
+                      aria-label="기대 intent"
+                    />
+                  </label>
+                  <label className={styles.feedbackField}>
+                    <span>기대 workflow</span>
+                    <input
+                      value={expectedWorkflowCode}
+                      onChange={(event) => setExpectedWorkflowCode(event.target.value)}
+                      maxLength={255}
+                      aria-label="기대 workflow"
+                    />
+                  </label>
+                  <label className={styles.feedbackField}>
+                    <span>기대 state</span>
+                    <input
+                      value={expectedCurrentState}
+                      onChange={(event) => setExpectedCurrentState(event.target.value)}
+                      maxLength={255}
+                      aria-label="기대 state"
+                    />
+                  </label>
+                  <label className={styles.feedbackField}>
+                    <span>기대 action</span>
+                    <NativeSelect
+                      value={expectedActionType}
+                      onChange={(event) => setExpectedActionType(event.target.value)}
+                      aria-label="기대 action"
+                    >
+                      <NativeSelectOption value="">선택하세요</NativeSelectOption>
+                      {ACTION_TYPES.map((type) => (
+                        <NativeSelectOption key={type} value={type}>
+                          {type}
+                        </NativeSelectOption>
+                      ))}
+                    </NativeSelect>
+                  </label>
+                  <label className={styles.feedbackField}>
+                    <span>필수 slot JSON</span>
+                    <textarea
+                      value={expectedSlotValuesJson}
+                      onChange={(event) => setExpectedSlotValuesJson(event.target.value)}
+                      rows={4}
+                      aria-label="필수 slot JSON"
+                    />
+                  </label>
+                </div>
                 <label className={styles.feedbackField}>
                   <span>Replay version</span>
                   <input

--- a/frontend/src/pages/workspace/ui/simulation/workspace-simulation-page.module.css
+++ b/frontend/src/pages/workspace/ui/simulation/workspace-simulation-page.module.css
@@ -627,6 +627,51 @@
   list-style: none;
 }
 
+.goldenCaseSnapshot,
+.goldenCaseExpected {
+  display: grid;
+  gap: var(--s-3);
+  border: 1px solid var(--line);
+  border-radius: var(--r-3);
+  background: var(--paper);
+  padding: var(--s-3);
+}
+
+.goldenCaseSnapshot dl {
+  display: grid;
+  gap: var(--s-2);
+  margin: 0;
+}
+
+.goldenCaseSnapshot dl div {
+  display: grid;
+  gap: 3px;
+}
+
+.goldenCaseSnapshot dt {
+  color: var(--ink-3);
+  font-size: 10px;
+  font-weight: 540;
+  text-transform: uppercase;
+}
+
+.goldenCaseSnapshot dd {
+  margin: 0;
+  color: var(--ink);
+  font-size: 12px;
+  font-weight: 540;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.goldenCaseSnapshot h4,
+.goldenCaseExpected h4 {
+  margin: 0;
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 540;
+}
+
 .goldenCaseList li {
   display: grid;
   gap: var(--s-2);


### PR DESCRIPTION
Closes #806

## 변경 사항

- 이슈 806 요구사항과 acceptance criteria를 `.agent/specs/806.md`에 정리했습니다.
- Golden Case 생성 패널에서 현재 실행 결과와 운영자가 저장할 기대 결과를 분리해 표시합니다.
- 운영자가 expected intent, workflow, state, action, slot JSON을 저장 전에 확인하거나 수정할 수 있게 했습니다.
- Golden Case 저장 payload가 matched runtime snapshot이 아니라 폼에서 확인한 기대값을 사용하도록 바꿨습니다.
- replay version 기본값은 query/route state의 시뮬레이션 target version을 우선하고, 없으면 현재 matched domain pack version을 사용합니다.
- 현재 API 계약에 expected response text 필드가 없어 exact response copy 저장은 후속 계약 확장 대상으로 명시하고, 이번 변경은 action type과 기존 expected fields 범위에서 처리했습니다.

## 검증

- `pnpm --dir frontend test -- WorkspaceSimulationPage.test.tsx` (API/FSD audits passed, 1 file, 33 tests)
- `pnpm --dir frontend exec eslint src/pages/workspace/ui/WorkspaceSimulationPage.tsx src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx`
- `pnpm --dir frontend exec vp fmt --check src/pages/workspace/ui/WorkspaceSimulationPage.tsx src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx src/pages/workspace/ui/simulation/workspace-simulation-page.module.css`
- `git diff --check`

## 참고

- 구현 전 issue 806, `WorkspaceSimulationPage`, `simulationApi` Golden Case payload contract, generated Golden Case request schema, `useListAllWorkspaceWorkflows`, `frontend/DESIGN.md`, frontend FSD/test rules를 확인했습니다.
- spec review 2회 수행: issue fidelity 관점에서 현재 결과/기대 결과 분리, expected intent/workflow/state/action/slot 확인, target version 기본값, expected response 계약 부재를 매핑했고, repository compliance 관점에서 파일명/브랜치/FSD 경계/참조 경로를 확인했습니다.
- self-review 3회 수행: Round 1에서 empty conversation guard 순서가 바뀐 점을 발견해 기존 고객 메시지 필수 안내가 먼저 유지되도록 수정했습니다. Round 2에서 API 계약 불변, FSD import 방향, generated-code 미수정, query target version 흐름을 확인했습니다. Round 3에서 테스트 커버리지, 접근성 label, JSON validation, stale path, 변경 파일 범위, whitespace, 검증 명령 기록을 확인했습니다.
- `pnpm --dir frontend lint`와 pre-commit hook은 API/FSD audit 통과 후 이번 변경과 무관한 기존 frontend ESLint baseline 45건으로 실패합니다. 변경 파일 대상 ESLint, focused tests, formatter check, diff check는 통과했습니다. hook 실패가 repository-wide baseline 때문이라 변경 파일 대상 검증을 근거로 hook을 우회해 커밋했습니다.