### PR TITLE
fix(infra): build LLM service ARN for Airflow policy

### DIFF
--- a/infra/terraform/iam.tf
+++ b/infra/terraform/iam.tf
@@ -315,7 +315,9 @@ data "aws_iam_policy_document" "ecs_airflow_task" {
       "ecs:DescribeServices",
       "ecs:UpdateService"
     ]
-    resources = [aws_ecs_service.ml_llm.arn]
+    resources = [
+      "arn:aws:ecs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:service/${aws_ecs_cluster.main.name}/${aws_ecs_service.ml_llm.name}"
+    ]
   }
 
   statement {


### PR DESCRIPTION
## Summary

- Replace unsupported `aws_ecs_service.ml_llm.arn` access with an explicit ECS service ARN built from region, account, cluster name, and service name.
- Keep the Airflow task role LLM lifecycle permissions scoped to the single `ml-llm` ECS service.

## Why

`terraform apply` failed because the AWS provider schema for `aws_ecs_service` in this project does not expose an `arn` attribute:

```text
Unsupported attribute: aws_ecs_service.ml_llm.arn
```

## Validation

- `terraform fmt -check infra/terraform/iam.tf`
- `terraform -chdir=infra/terraform validate`
