### PR TITLE
fix(ml): start LLM before domain checkpoint generation

### DIFF
--- a/infra/terraform/ecs-airflow.tf
+++ b/infra/terraform/ecs-airflow.tf
@@ -46,6 +46,22 @@ locals {
       value = "airflow"
     },
     {
+      name  = "AIRFLOW__DATABASE__SQL_ALCHEMY_POOL_SIZE"
+      value = "10"
+    },
+    {
+      name  = "AIRFLOW__DATABASE__SQL_ALCHEMY_MAX_OVERFLOW"
+      value = "20"
+    },
+    {
+      name  = "AIRFLOW__DATABASE__SQL_ALCHEMY_POOL_RECYCLE"
+      value = "1800"
+    },
+    {
+      name  = "AIRFLOW__DATABASE__SQL_ALCHEMY_POOL_PRE_PING"
+      value = "True"
+    },
+    {
       name  = "AIRFLOW__API__BASE_URL"
       value = "https://airflow.${var.domain_name}"
     },


### PR DESCRIPTION
## Summary
- Start the Airflow-managed LLM ECS service before the initial `domain_candidate_generation` task, because that stage calls the OpenAI-compatible local LLM endpoint.
- Stop the initial LLM service immediately after domain candidate generation so the GPU instance is not held while waiting for human domain confirmation.
- Increase Airflow SQLAlchemy metadata DB pool limits and enable pool recycle/pre-ping to avoid XCom/heartbeat failures under API/UI load.

## Root Cause
Pipeline job 43 reached the domain confirmation checkpoint, but the only candidate shown in the UI was `혼합 또는 미확정` with `0%` confidence. The generated artifact contained a `generationError`: the domain candidate stage received `503 Service Temporarily Unavailable` from the internal LLM ALB. The DAG was starting the LLM ECS service only after `flow_splitting`, while the initial `domain_candidate_generation` stage already depended on the LLM endpoint.

Earlier in the same run, Airflow also showed SQLAlchemy metadata DB pool exhaustion while persisting XCom/heartbeats. RDS itself had low CPU and low connection count, so the practical fix is to raise Airflow's app-side pool limits.

## Validation
- `terraform fmt -check infra/terraform/ecs-airflow.tf`
- `terraform -chdir=infra/terraform validate`
- `git diff --check`
- `cd ml && uv run ruff format --check src/dags/domain_pack_generation.py tests/test_domain_pack_generation_dag.py`
- `cd ml && uv run ruff check src/dags/domain_pack_generation.py tests/test_domain_pack_generation_dag.py`
- `cd ml && uv run pytest tests/test_domain_pack_generation_dag.py tests/test_llm_service_lifecycle.py`