### PR TITLE
fix(frontend): 상담 로그 수집에서 파이프라인 검토 진입을 보장

### DIFF
--- a/frontend/e2e/support/app-mocks.ts
+++ b/frontend/e2e/support/app-mocks.ts
@@ -47,7 +47,7 @@ export interface AppApiMockOptions {
   readonly uploadLatestPipelineJob?: "default" | "none";
   readonly uploadTransferDelayMs?: number;
   readonly domainPackGenerationFailureAttempts?: number;
-  readonly dashboardKnowledgePackHealth?: "default" | "error";
+  readonly dashboardKnowledgePackHealth?: "default" | "error" | "open-review";
   readonly generatedPipelineJob?: "domain-confirmation" | "running";
   readonly workspaceOneFreeOnboardingStatus?: FreeOnboardingStatus;
   readonly workspaceOneSubscriptionStatus?: WorkspaceOneSubscriptionStatus | null;
@@ -1454,6 +1454,8 @@ async function fulfillWorkspaceOperations(
         lastErrorMessage: null,
       },
       pendingReviewCount: 1,
+      latestOpenReviewPipelineJobId:
+        options.dashboardKnowledgePackHealth === "open-review" ? PIPELINE_JOB_ID : null,
     });
     return true;
   }

--- a/frontend/e2e/upload-domain-pack-generation.spec.ts
+++ b/frontend/e2e/upload-domain-pack-generation.spec.ts
@@ -181,6 +181,34 @@ test.describe("Upload completed Domain Pack draft generation", () => {
   }
 
   test.describe("Given a completed consultation log upload without an automatic pipeline job", () => {
+    test("When an open pipeline review exists, Then upload exposes review navigation", async ({
+      page,
+    }) => {
+      await installUploadGenerationMocks(page, {
+        dashboardKnowledgePackHealth: "open-review",
+      });
+
+      await page.goto("/workspaces/1/upload");
+
+      await expect(page.getByText("검토 대기", { exact: true })).toBeVisible();
+      await expect(page.getByText("검토 대기 항목 1개가 남아 있습니다.")).toBeVisible();
+
+      await page.getByRole("button", { name: "검토 화면으로 이동" }).click();
+
+      await expect(page).toHaveURL(
+        /\/workspaces\/1\/pipeline-jobs\/900\/review/,
+      );
+      await expect(page.getByText("상담 도메인을 확정합니다.")).toBeVisible();
+      expect(seen).toContain(
+        "GET /workspaces/1/dashboard/knowledge-pack-health",
+      );
+      expect(seen).toContain(
+        "GET /workspaces/1/pipeline-jobs/900/review-checkpoint",
+      );
+      expect(seen).not.toContain(uploadInitRequest);
+      expect(seen).not.toContain(uploadCompleteRequest);
+    });
+
     test(
       "When the operator uploads a valid ZIP, Then progress, completion, and the next Domain Pack action are visible",
       { tag: "@critical" },

--- a/frontend/src/features/log-upload/ui/LogUploadForm.test.tsx
+++ b/frontend/src/features/log-upload/ui/LogUploadForm.test.tsx
@@ -223,6 +223,26 @@ describe("LogUploadForm", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows open review CTA on the upload screen", () => {
+    render(
+      <LogUploadForm
+        workspaceId={2}
+        openReviewCta={{
+          path: "/workspaces/2/pipeline-jobs/43/review",
+          pendingReviewCount: 2,
+        }}
+      />,
+      { wrapper: MemoryRouter },
+    );
+
+    expect(screen.getByText("검토 대기")).toBeInTheDocument();
+    expect(screen.getByText("검토 대기 항목 2개가 남아 있습니다.")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /검토 화면으로 이동/ }));
+
+    expect(mockNavigate).toHaveBeenCalledWith("/workspaces/2/pipeline-jobs/43/review");
+  });
+
   it("blocks upload when free onboarding is consumed without active subscription", () => {
     render(
       <LogUploadForm

--- a/frontend/src/features/log-upload/ui/LogUploadForm.tsx
+++ b/frontend/src/features/log-upload/ui/LogUploadForm.tsx
@@ -1,6 +1,7 @@
 import React, { useId, useRef, useState } from "react";
 import { toast } from "sonner";
 import { useNavigate, useSearchParams } from "react-router-dom";
+import { ListChecksIcon } from "lucide-react";
 
 import { FileUploader } from "../../../shared/ui/file-upload/FileUploader";
 import { Button } from "../../../shared/ui/button/Button";
@@ -57,12 +58,18 @@ export interface PaidUploadCooldown {
   readonly nextAvailableAt?: string | null;
 }
 
+export interface OpenReviewCta {
+  readonly path: string;
+  readonly pendingReviewCount: number;
+}
+
 interface LogUploadFormProps {
   workspaceId?: number;
   freeOnboardingStatus?: FreeOnboardingStatus;
   hasActiveSubscription?: boolean;
   isEntitlementLoading?: boolean;
   paidUploadCooldown?: PaidUploadCooldown;
+  openReviewCta?: OpenReviewCta | null;
 }
 
 interface GenerationRequestToken {
@@ -127,6 +134,7 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({
   hasActiveSubscription = false,
   isEntitlementLoading = false,
   paidUploadCooldown,
+  openReviewCta,
 }) => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -508,6 +516,26 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({
           </div>
         )}
       </div>
+
+      {openReviewCta ? (
+        <div className={styles.openReviewNotice}>
+          <div>
+            <span className={styles.statusLabel}>검토 대기</span>
+            <p>
+              {openReviewCta.pendingReviewCount > 0
+                ? `검토 대기 항목 ${openReviewCta.pendingReviewCount}개가 남아 있습니다.`
+                : "검토가 필요한 파이프라인이 열려 있습니다."}
+            </p>
+          </div>
+          <Button
+            variant="secondary"
+            onClick={() => navigate(openReviewCta.path)}
+          >
+            <ListChecksIcon aria-hidden="true" size={16} />
+            {CTA_GO_REVIEW}
+          </Button>
+        </div>
+      ) : null}
 
       <div className={styles.uploadArea}>
         <FileUploader

--- a/frontend/src/features/log-upload/ui/log-upload-form.module.css
+++ b/frontend/src/features/log-upload/ui/log-upload-form.module.css
@@ -52,6 +52,26 @@
   margin-top: 4px;
 }
 
+.openReviewNotice {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 24px;
+  padding: 16px 20px;
+  background: #ffffff;
+  border: 1px solid rgba(0, 0, 0, 0.16);
+  border-radius: var(--radius-md);
+}
+
+.openReviewNotice p {
+  margin: 4px 0 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  line-height: 1.5;
+  letter-spacing: 0;
+}
+
 .uploadArea {
   margin-bottom: 24px;
 }
@@ -133,6 +153,7 @@
 }
 
 .onboardingStatus .statusLabel,
+.openReviewNotice .statusLabel,
 .uploadSummary .statusLabel,
 .generationPanel .statusLabel {
   color: var(--text-color);
@@ -175,6 +196,10 @@
   .filePreview {
     flex-direction: column;
     gap: 16px;
+  }
+  .openReviewNotice {
+    align-items: stretch;
+    flex-direction: column;
   }
   .fileInfo {
     width: 100%;

--- a/frontend/src/features/workspace-dashboard-health/api/workspaceDashboardHealthApi.ts
+++ b/frontend/src/features/workspace-dashboard-health/api/workspaceDashboardHealthApi.ts
@@ -68,7 +68,8 @@ export interface WorkspaceDashboardActionRecommendationParams {
 
 export const workspaceDashboardHealthKeys = {
   all: ["workspace-dashboard-health"] as const,
-  detail: (workspaceId: number) => [...workspaceDashboardHealthKeys.all, workspaceId] as const,
+  detail: (workspaceId?: number | null) =>
+    [...workspaceDashboardHealthKeys.all, workspaceId ?? "unknown"] as const,
 };
 
 export const workspaceDashboardActionRecommendationKeys = {
@@ -77,11 +78,12 @@ export const workspaceDashboardActionRecommendationKeys = {
     [...workspaceDashboardActionRecommendationKeys.all, workspaceId, params] as const,
 };
 
-export function useWorkspaceDashboardHealth(workspaceId: number) {
+export function useWorkspaceDashboardHealth(workspaceId?: number | null) {
   return useQuery({
     queryKey: workspaceDashboardHealthKeys.detail(workspaceId),
+    enabled: workspaceId != null,
     queryFn: async ({ signal }) => {
-      const response = await getGeneratedKnowledgePackHealth(workspaceId, {
+      const response = await getGeneratedKnowledgePackHealth(workspaceId as number, {
         signal,
       });
       return requireApiData<WorkspaceDashboardHealth>(

--- a/frontend/src/features/workspace-dashboard-health/index.ts
+++ b/frontend/src/features/workspace-dashboard-health/index.ts
@@ -1,1 +1,5 @@
 export { KnowledgePackHealthPanel } from "./ui/KnowledgePackHealthPanel";
+export {
+  useWorkspaceDashboardHealth,
+  type WorkspaceDashboardHealth,
+} from "./api/workspaceDashboardHealthApi";

--- a/frontend/src/pages/upload/ui/WorkspaceUploadPage.test.tsx
+++ b/frontend/src/pages/upload/ui/WorkspaceUploadPage.test.tsx
@@ -5,6 +5,7 @@ import { WorkspaceUploadPage } from "./WorkspaceUploadPage";
 
 const mockUseGetWorkspace = vi.fn();
 const mockUseSubscription = vi.fn();
+const mockUseWorkspaceDashboardHealth = vi.fn();
 const mockWorkspaceRefetch = vi.fn();
 const mockSubscriptionRefetch = vi.fn();
 
@@ -15,19 +16,23 @@ vi.mock("../../../features/log-upload/ui/LogUploadForm", () => ({
     hasActiveSubscription,
     isEntitlementLoading,
     paidUploadCooldown,
+    openReviewCta,
   }: {
     workspaceId?: number;
     freeOnboardingStatus?: string;
     hasActiveSubscription?: boolean;
     isEntitlementLoading?: boolean;
     paidUploadCooldown?: { isBlocked?: boolean; nextAvailableAt?: string | null };
+    openReviewCta?: { path: string; pendingReviewCount: number } | null;
   }) => (
     <div data-testid="upload-form">
       workspace:{workspaceId} onboarding:{freeOnboardingStatus} active:
       {String(hasActiveSubscription)} loading:{String(isEntitlementLoading)}{" "}
       cooldown:
       {String(paidUploadCooldown?.isBlocked)} next:
-      {paidUploadCooldown?.nextAvailableAt ?? "none"}
+      {paidUploadCooldown?.nextAvailableAt ?? "none"} review:
+      {openReviewCta?.path ?? "none"} pending:
+      {openReviewCta?.pendingReviewCount ?? "none"}
     </div>
   ),
 }));
@@ -43,6 +48,11 @@ vi.mock("@/entities/billing", () => ({
   useSubscription: (...args: unknown[]) => mockUseSubscription(...args),
   isSubscriptionEngaged: (status: string | undefined) =>
     status === "ACTIVE" || status === "PAST_DUE",
+}));
+
+vi.mock("@/features/workspace-dashboard-health", () => ({
+  useWorkspaceDashboardHealth: (...args: unknown[]) =>
+    mockUseWorkspaceDashboardHealth(...args),
 }));
 
 function renderRoute(initialEntry: string) {
@@ -77,6 +87,10 @@ describe("WorkspaceUploadPage", () => {
       isLoading: false,
       refetch: mockSubscriptionRefetch,
     });
+    mockUseWorkspaceDashboardHealth.mockReturnValue({
+      data: null,
+      isLoading: false,
+    });
   });
 
   afterEach(() => {
@@ -93,7 +107,23 @@ describe("WorkspaceUploadPage", () => {
     renderRoute("/workspaces/1/upload");
 
     expect(screen.getByTestId("upload-form")).toHaveTextContent(
-      "workspace:1 onboarding:AVAILABLE active:false loading:false cooldown:false next:none",
+      "workspace:1 onboarding:AVAILABLE active:false loading:false cooldown:false next:none review:none pending:none",
+    );
+  });
+
+  it("passes open review pipeline CTA to the upload form", () => {
+    mockUseWorkspaceDashboardHealth.mockReturnValue({
+      data: {
+        pendingReviewCount: 3,
+        latestOpenReviewPipelineJobId: 43,
+      },
+      isLoading: false,
+    });
+
+    renderRoute("/workspaces/2/upload");
+
+    expect(screen.getByTestId("upload-form")).toHaveTextContent(
+      "review:/workspaces/2/pipeline-jobs/43/review pending:3",
     );
   });
 
@@ -112,7 +142,7 @@ describe("WorkspaceUploadPage", () => {
     renderRoute("/workspaces/1/upload");
 
     expect(screen.getByTestId("upload-form")).toHaveTextContent(
-      "workspace:1 onboarding:CONSUMED active:true loading:false cooldown:false next:none",
+      "workspace:1 onboarding:CONSUMED active:true loading:false cooldown:false next:none review:none pending:none",
     );
   });
 
@@ -136,7 +166,7 @@ describe("WorkspaceUploadPage", () => {
     renderRoute("/workspaces/1/upload");
 
     expect(screen.getByTestId("upload-form")).toHaveTextContent(
-      "workspace:1 onboarding:AVAILABLE active:true loading:false cooldown:true next:2026-06-04T10:30:00+09:00",
+      "workspace:1 onboarding:AVAILABLE active:true loading:false cooldown:true next:2026-06-04T10:30:00+09:00 review:none pending:none",
     );
   });
 
@@ -160,7 +190,7 @@ describe("WorkspaceUploadPage", () => {
     renderRoute("/workspaces/1/upload");
 
     expect(screen.getByTestId("upload-form")).toHaveTextContent(
-      "workspace:1 onboarding:CONSUMED active:false loading:false cooldown:false next:none",
+      "workspace:1 onboarding:CONSUMED active:false loading:false cooldown:false next:none review:none pending:none",
     );
 
     act(() => {

--- a/frontend/src/pages/upload/ui/WorkspaceUploadPage.tsx
+++ b/frontend/src/pages/upload/ui/WorkspaceUploadPage.tsx
@@ -9,6 +9,7 @@ import {
   LogUploadForm,
   type FreeOnboardingStatus,
 } from "../../../features/log-upload/ui/LogUploadForm";
+import { useWorkspaceDashboardHealth } from "@/features/workspace-dashboard-health";
 import { selectApiData } from "@/shared/api";
 import { useGetWorkspace } from "@/shared/api/generated/endpoints/workspace-controller/workspace-controller";
 import { parseRouteId } from "@/shared/lib/parseRouteId";
@@ -60,6 +61,7 @@ export function WorkspaceUploadPage() {
     query: { enabled: parsedWorkspaceId !== null },
   });
   const subscriptionQuery = useSubscription(parsedWorkspaceId);
+  const dashboardHealthQuery = useWorkspaceDashboardHealth(parsedWorkspaceId);
 
   const workspace =
     (selectApiData(workspaceQuery.data) as
@@ -69,6 +71,15 @@ export function WorkspaceUploadPage() {
     (subscriptionQuery.data as SubscriptionResponse | null) ?? null;
   const hasActiveSubscription = isSubscriptionEngaged(subscription?.status);
   const paidUploadCooldown = resolvePaidUploadCooldown(subscription);
+  const latestOpenReviewPipelineJobId =
+    dashboardHealthQuery.data?.latestOpenReviewPipelineJobId ?? null;
+  const openReviewCta =
+    parsedWorkspaceId !== null && latestOpenReviewPipelineJobId !== null
+      ? {
+          path: `/workspaces/${parsedWorkspaceId}/pipeline-jobs/${latestOpenReviewPipelineJobId}/review`,
+          pendingReviewCount: dashboardHealthQuery.data?.pendingReviewCount ?? 0,
+        }
+      : null;
   const refetchWorkspace = workspaceQuery.refetch;
   const refetchSubscription = subscriptionQuery.refetch;
   const isEntitlementLoading = Boolean(
@@ -118,6 +129,7 @@ export function WorkspaceUploadPage() {
         hasActiveSubscription={hasActiveSubscription}
         isEntitlementLoading={isEntitlementLoading}
         paidUploadCooldown={paidUploadCooldown}
+        openReviewCta={openReviewCta}
       />
     </div>
   );


### PR DESCRIPTION
## 변경 사항

- 상담 로그 수집 화면에서 열린 pipeline review job이 있으면 `검토 대기` 안내와 `검토 화면으로 이동` CTA를 표시합니다.
- upload 페이지가 workspace dashboard health의 `latestOpenReviewPipelineJobId`를 읽어 `/workspaces/{workspaceId}/pipeline-jobs/{pipelineJobId}/review` 경로를 폼에 전달하도록 했습니다.
- dashboard health hook을 nullable workspace id에서도 안전하게 사용할 수 있도록 query enabled 조건과 query key를 정리했습니다.
- upload E2E mock에 열린 review 상태를 추가하고, upload 화면에서 review 화면으로 돌아가는 경로를 검증했습니다.

## 검증

- `pnpm --dir frontend test -- WorkspaceUploadPage.test.tsx LogUploadForm.test.tsx`
- `pnpm --dir frontend exec eslint e2e/upload-domain-pack-generation.spec.ts e2e/support/app-mocks.ts src/pages/upload/ui/WorkspaceUploadPage.tsx src/pages/upload/ui/WorkspaceUploadPage.test.tsx src/features/log-upload/ui/LogUploadForm.tsx src/features/log-upload/ui/LogUploadForm.test.tsx src/features/workspace-dashboard-health/api/workspaceDashboardHealthApi.ts src/features/workspace-dashboard-health/index.ts`
- `pnpm --dir frontend exec playwright test e2e/upload-domain-pack-generation.spec.ts --config=playwright.upload-review-entry.config.ts --grep "open pipeline review exists"` (임시 4174 포트 config 사용 후 제거)
- `git diff --check`

## 참고

- 기본 Playwright config는 현재 로컬 3000 포트에 다른 서버가 떠 있어 대기 상태가 되어 중단했고, 충돌 없는 4174 포트 임시 config로 새 E2E를 실제 실행했습니다.
- `pnpm --dir frontend lint`와 pre-commit hook은 API/FSD audit 통과 후 이번 변경과 무관한 기존 frontend ESLint baseline 45건으로 실패합니다. 변경 파일 대상 ESLint, focused tests, focused E2E, diff check는 통과했습니다.