### PR TITLE
chore(frontend): 대시보드 빈 안내 섹션이 표시되지 않도록 보장

### DIFF
--- a/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx
@@ -377,29 +377,10 @@ describe("WorkspaceDashboardPage", () => {
 
     renderPage();
 
-    expect(await screen.findByTestId("dashboard-empty")).toBeInTheDocument();
-    expect(screen.getByText("계측 필요")).toBeInTheDocument();
+    expect(await screen.findByText("계측 필요")).toBeInTheDocument();
+    expect(screen.queryByTestId("dashboard-empty")).not.toBeInTheDocument();
     expect(screen.getAllByText("--").length).toBeGreaterThanOrEqual(3);
     expect(screen.getAllByText("전 기간 --").length).toBeGreaterThanOrEqual(1);
-    expect(screen.getByTestId("dashboard-upload-cta")).toHaveAttribute(
-      "href",
-      "/workspaces/1/upload",
-    );
-    expect(screen.getByTestId("dashboard-pack-cta")).toHaveAttribute(
-      "href",
-      "/workspaces/1/domain-packs",
-    );
-    expect(screen.getByRole("link", { name: /지식팩 검토/ })).toBeInTheDocument();
-    expect(screen.getByTestId("dashboard-simulation-cta")).toHaveAttribute(
-      "href",
-      "/workspaces/1/simulation",
-    );
-    expect(screen.getByRole("link", { name: /시뮬레이션 시작/ })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /공개 데모 체험/ })).toBeInTheDocument();
-    expect(screen.getByTestId("dashboard-customer-preview-cta")).toHaveAttribute(
-      "href",
-      "/demo/chat/1",
-    );
     expect(screen.getByTestId("recommendation-empty")).toHaveTextContent("현재 큰 이상 없음");
   });
 
@@ -436,21 +417,21 @@ describe("WorkspaceDashboardPage", () => {
   it("loading, error, partial 상태 패널이 같은 shell 영역에서 렌더링된다", () => {
     const { rerender } = render(
       <MemoryRouter>
-        <DashboardStatePanel state="loading" workspaceId={1} />
+        <DashboardStatePanel state="loading" />
       </MemoryRouter>,
     );
     expect(screen.getByTestId("dashboard-loading")).toBeInTheDocument();
 
     rerender(
       <MemoryRouter>
-        <DashboardStatePanel state="error" workspaceId={1} />
+        <DashboardStatePanel state="error" />
       </MemoryRouter>,
     );
     expect(screen.getByTestId("dashboard-error")).toBeInTheDocument();
 
     rerender(
       <MemoryRouter>
-        <DashboardStatePanel state="partial" workspaceId={1} />
+        <DashboardStatePanel state="partial" />
       </MemoryRouter>,
     );
     expect(screen.getByTestId("dashboard-partial")).toBeInTheDocument();

--- a/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx
@@ -1,13 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link, Navigate, useOutletContext, useParams } from "react-router-dom";
-import {
-  ArrowRightIcon,
-  CheckCircle2Icon,
-  FileUpIcon,
-  FlaskConicalIcon,
-  MonitorSmartphoneIcon,
-  RefreshCwIcon,
-} from "lucide-react";
+import { ArrowRightIcon, CheckCircle2Icon, RefreshCwIcon } from "lucide-react";
 
 import { consultationApi } from "@/features/consultation/api/consultationApi";
 import type {
@@ -23,11 +16,7 @@ import {
   type WorkspaceDashboardActionRecommendations,
 } from "@/features/workspace-dashboard-health/api/workspaceDashboardHealthApi";
 import type { ShellContext } from "@/shared/ui/ostone/chrome";
-import {
-  buildDemoChatPath,
-  buildWorkspaceSimulationPath,
-  PUBLIC_DEMO_CHAT_LABEL,
-} from "@/shared/lib/demoRoutes";
+import { buildWorkspaceSimulationPath } from "@/shared/lib/demoRoutes";
 import { parseRouteId } from "@/shared/lib/parseRouteId";
 import { Button } from "@/shared/ui/button";
 import { LoadingSpinner } from "@/shared/ui/ostone/atoms/LoadingSpinner";
@@ -51,8 +40,7 @@ interface FilterOption<T extends string = string> {
 }
 
 interface DashboardStatePanelProps {
-  state: DashboardDataState;
-  workspaceId: number;
+  state: Exclude<DashboardDataState, "empty">;
 }
 
 interface DashboardMetricCardProps {
@@ -757,7 +745,7 @@ function DashboardFilters({
   );
 }
 
-export function DashboardStatePanel({ state, workspaceId }: DashboardStatePanelProps) {
+export function DashboardStatePanel({ state }: DashboardStatePanelProps) {
   if (state === "loading") {
     return (
       <section className={styles.statePanel} data-testid="dashboard-loading" aria-live="polite">
@@ -775,61 +763,17 @@ export function DashboardStatePanel({ state, workspaceId }: DashboardStatePanelP
     );
   }
 
-  if (state === "partial") {
-    return (
-      <section className={styles.partialPanel} data-testid="dashboard-partial">
-        <div>
-          <span className={styles.panelEyebrow}>PARTIAL DATA</span>
-          <h2>일부 운영 데이터만 확인됩니다.</h2>
-          <p>
-            선택 기간에 수집된 상담 로그 기준으로 확인 가능한 지표를 먼저 표시합니다. 값이 없는
-            항목은 해당 운영 기록이 쌓이면 계산됩니다.
-          </p>
-        </div>
-        <RefreshCwIcon aria-hidden="true" className={styles.panelIcon} />
-      </section>
-    );
-  }
-
   return (
-    <section className={styles.emptyPanel} data-testid="dashboard-empty">
-      <div className={styles.emptyCopy}>
-        <span className={styles.panelEyebrow}>GET STARTED</span>
-        <h2>아직 대시보드에 표시할 운영 데이터가 없습니다.</h2>
+    <section className={styles.partialPanel} data-testid="dashboard-partial">
+      <div>
+        <span className={styles.panelEyebrow}>PARTIAL DATA</span>
+        <h2>일부 운영 데이터만 확인됩니다.</h2>
         <p>
-          상담 로그를 업로드하고 운영 지식팩 검토를 마친 뒤, 시뮬레이션으로 워크플로우 흐름을
-          확인하세요.
+          선택 기간에 수집된 상담 로그 기준으로 확인 가능한 지표를 먼저 표시합니다. 값이 없는 항목은
+          해당 운영 기록이 쌓이면 계산됩니다.
         </p>
       </div>
-      <div className={styles.ctaGrid}>
-        <Button asChild variant="default">
-          <Link to={`/workspaces/${workspaceId}/upload`} data-testid="dashboard-upload-cta">
-            <FileUpIcon aria-hidden="true" />
-            상담 업로드
-          </Link>
-        </Button>
-        <Button asChild variant="outline">
-          <Link to={`/workspaces/${workspaceId}/domain-packs`} data-testid="dashboard-pack-cta">
-            <CheckCircle2Icon aria-hidden="true" />
-            지식팩 검토
-          </Link>
-        </Button>
-        <Button asChild variant="outline">
-          <Link
-            to={buildWorkspaceSimulationPath(workspaceId)}
-            data-testid="dashboard-simulation-cta"
-          >
-            <FlaskConicalIcon aria-hidden="true" />
-            시뮬레이션 시작
-          </Link>
-        </Button>
-        <Button asChild variant="outline">
-          <Link to={buildDemoChatPath(workspaceId)} data-testid="dashboard-customer-preview-cta">
-            <MonitorSmartphoneIcon aria-hidden="true" />
-            {PUBLIC_DEMO_CHAT_LABEL}
-          </Link>
-        </Button>
-      </div>
+      <RefreshCwIcon aria-hidden="true" className={styles.panelIcon} />
     </section>
   );
 }
@@ -1077,7 +1021,7 @@ export function WorkspaceDashboardPage() {
         state={workflowRankingState}
         error={workflowRankingsError}
       />
-      {dataState ? <DashboardStatePanel state={dataState} workspaceId={parsedWorkspaceId} /> : null}
+      {dataState && dataState !== "empty" ? <DashboardStatePanel state={dataState} /> : null}
     </div>
   );
 }

--- a/frontend/src/pages/workspace/ui/workspace-dashboard-page.module.css
+++ b/frontend/src/pages/workspace/ui/workspace-dashboard-page.module.css
@@ -696,7 +696,6 @@
 }
 
 .statePanel,
-.emptyPanel,
 .partialPanel {
   min-height: 280px;
   border: 1px dashed var(--line);
@@ -719,7 +718,6 @@
   line-height: 1.6;
 }
 
-.emptyPanel,
 .partialPanel {
   display: flex;
   align-items: center;
@@ -728,11 +726,6 @@
   padding: var(--s-8);
 }
 
-.emptyCopy {
-  max-width: 620px;
-}
-
-.emptyCopy h2,
 .partialPanel h2 {
   margin: var(--s-2) 0 0;
   color: var(--ink);
@@ -741,26 +734,11 @@
   letter-spacing: 0;
 }
 
-.emptyCopy p,
 .partialPanel p {
   margin: var(--s-2) 0 0;
   color: var(--ink-2);
   font-size: 14px;
   line-height: 1.7;
-}
-
-.ctaGrid {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-  gap: var(--s-2);
-}
-
-/* 아이콘 포함 CTA의 좁은 좌우 패딩(svg 시 12px)을 넉넉하게 — 레이블과 테두리 사이 여백 확보 */
-.ctaGrid > a,
-.ctaGrid > button {
-  min-height: 40px;
-  padding-inline: var(--s-5);
 }
 
 .panelIcon {
@@ -771,7 +749,6 @@
 
 @media (max-width: 960px) {
   .pageHeader,
-  .emptyPanel,
   .partialPanel {
     align-items: flex-start;
     flex-direction: column;
@@ -793,10 +770,6 @@
 
   .coverageHeader {
     flex-direction: column;
-  }
-
-  .ctaGrid {
-    justify-content: flex-start;
   }
 }
 


### PR DESCRIPTION
## 변경 사항

- 대시보드에 운영 데이터가 없을 때 표시되던 `GET STARTED` 안내 섹션과 상담 업로드/지식팩 검토/시뮬레이션/공개 데모 CTA를 표시하지 않도록 했습니다.
- loading, error, partial 상태 패널은 유지하고, empty 상태에서는 섹션별 empty UI만 남도록 렌더링 조건을 정리했습니다.
- 제거된 empty panel 전용 스타일과 테스트 기대값을 함께 정리했습니다.

## 검증

- `pnpm --dir frontend test -- src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx`
- `pnpm --dir frontend exec vp fmt --check src/pages/workspace/ui/WorkspaceDashboardPage.tsx src/pages/workspace/ui/workspace-dashboard-page.module.css src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx`
- `pnpm --dir frontend exec eslint src/pages/workspace/ui/WorkspaceDashboardPage.tsx src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx`
- `pnpm --dir frontend build` (기존 chunk-size warning만 표시)
- `git diff --check`

## 참고

- `pnpm --dir frontend lint`는 API/FSD audit 통과 후 이번 변경과 무관한 기존 frontend ESLint baseline 45건으로 실패해 pre-commit hook은 우회했습니다. 변경 파일 대상 ESLint, focused test, production build, format check, diff check는 통과했습니다.
- Playwright 대시보드 E2E는 `workspace-core.spec.ts --grep "When they open the dashboard"`로 두 번 시도했지만 CLI만 실행되고 build/preview 자식 프로세스 없이 무출력 대기 상태가 지속되어 중단했습니다. 제거한 `dashboard-empty` 계열 셀렉터/문구를 참조하는 E2E는 검색 결과 없었습니다.