### PR TITLE
fix(ml): require LLM for review checkpoint generation

### DIFF
--- a/infra/terraform/ecs-llm.tf
+++ b/infra/terraform/ecs-llm.tf
@@ -26,7 +26,7 @@ resource "aws_lb_target_group" "ml_llm" {
     path                = "/health"
     port                = "traffic-port"
     protocol            = "HTTP"
-    matcher             = "200-499"
+    matcher             = "200"
   }
 
   tags = local.common_tags

--- a/ml/src/dags/domain_pack_generation.py
+++ b/ml/src/dags/domain_pack_generation.py
@@ -55,6 +55,18 @@ def _run_mode() -> str:
     return normalized
 
 
+def _start_initial_llm_service() -> Mapping[str, object]:
+    if _run_mode() != RUN_MODE_INITIAL:
+        return {"enabled": False, "reason": "not_initial_run"}
+    return start_llm_ecs_service()
+
+
+def _stop_initial_llm_service() -> Mapping[str, object]:
+    if _run_mode() != RUN_MODE_INITIAL:
+        return {"enabled": False, "reason": "not_initial_run"}
+    return stop_llm_ecs_service()
+
+
 def _conf_value(key: str) -> str | None:
     context = get_current_context()
     return _context_value(context, key)
@@ -391,6 +403,15 @@ def domain_pack_generation() -> None:  # pragma: no cover - Airflow imports this
             upstream_manifest_path=representation_result["artifact_manifest_path"],
         )
 
+    @task(task_id="start_initial_llm_service")
+    def start_initial_llm_service(representation_result: dict[str, str]) -> dict[str, str]:
+        _start_initial_llm_service()
+        return representation_result
+
+    @task(task_id="stop_initial_llm_service", trigger_rule="all_done")
+    def stop_initial_llm_service() -> dict[str, object]:
+        return dict(_stop_initial_llm_service())
+
     @task(task_id="domain_confirmation_checkpoint")
     def domain_confirmation_checkpoint(domain_candidate_result: dict[str, str]) -> dict[str, str]:
         if _run_mode() != RUN_MODE_INITIAL:
@@ -475,7 +496,8 @@ def domain_pack_generation() -> None:  # pragma: no cover - Airflow imports this
     ingestion_task = ingestion()
     preprocessing_task = preprocessing(ingestion_task)
     representation_task = representation(preprocessing_task)
-    domain_candidate_task = domain_candidate_generation(representation_task)
+    start_initial_llm_task = start_initial_llm_service(representation_task)
+    domain_candidate_task = domain_candidate_generation(start_initial_llm_task)
     domain_confirmation_task = domain_confirmation_checkpoint(domain_candidate_task)
     intent_discovery_task = intent_discovery(domain_confirmation_task)
     flow_splitting_task = flow_splitting(intent_discovery_task)
@@ -483,11 +505,14 @@ def domain_pack_generation() -> None:  # pragma: no cover - Airflow imports this
     feedback_candidate_task = feedback_candidate_generation(start_llm_task)
     human_feedback_task = human_feedback_checkpoint(feedback_candidate_task)
     draft_generation_task = draft_generation(human_feedback_task)
+    stop_initial_llm_task = stop_initial_llm_service()
     stop_llm_task = stop_llm_service()
     evaluation_task = evaluation(draft_generation_task)
     publish_candidate_task = publish_candidate(evaluation_task)
 
-    ingestion_task >> preprocessing_task >> representation_task >> domain_candidate_task >> domain_confirmation_task
+    ingestion_task >> preprocessing_task >> representation_task >> start_initial_llm_task >> domain_candidate_task
+    domain_candidate_task >> domain_confirmation_task
+    domain_candidate_task >> stop_initial_llm_task
     (
         domain_confirmation_task
         >> intent_discovery_task

--- a/ml/src/dags/domain_pack_generation.py
+++ b/ml/src/dags/domain_pack_generation.py
@@ -67,6 +67,10 @@ def _stop_initial_llm_service() -> Mapping[str, object]:
     return stop_llm_ecs_service()
 
 
+def _set_task_dependency(upstream: Any, downstream: Any) -> None:
+    upstream >> downstream
+
+
 def _conf_value(key: str) -> str | None:
     context = get_current_context()
     return _context_value(context, key)
@@ -510,22 +514,24 @@ def domain_pack_generation() -> None:  # pragma: no cover - Airflow imports this
     evaluation_task = evaluation(draft_generation_task)
     publish_candidate_task = publish_candidate(evaluation_task)
 
-    ingestion_task >> preprocessing_task >> representation_task >> start_initial_llm_task >> domain_candidate_task
-    domain_candidate_task >> domain_confirmation_task
-    start_initial_llm_task >> stop_initial_llm_task
-    domain_candidate_task >> stop_initial_llm_task
-    (
-        domain_confirmation_task
-        >> intent_discovery_task
-        >> flow_splitting_task
-        >> start_llm_task
-        >> feedback_candidate_task
-    )
-    feedback_candidate_task >> human_feedback_task >> draft_generation_task
-    start_llm_task >> stop_llm_task
-    human_feedback_task >> stop_llm_task
-    draft_generation_task >> stop_llm_task
-    draft_generation_task >> evaluation_task >> publish_candidate_task
+    _set_task_dependency(ingestion_task, preprocessing_task)
+    _set_task_dependency(preprocessing_task, representation_task)
+    _set_task_dependency(representation_task, start_initial_llm_task)
+    _set_task_dependency(start_initial_llm_task, domain_candidate_task)
+    _set_task_dependency(domain_candidate_task, domain_confirmation_task)
+    _set_task_dependency(start_initial_llm_task, stop_initial_llm_task)
+    _set_task_dependency(domain_candidate_task, stop_initial_llm_task)
+    _set_task_dependency(domain_confirmation_task, intent_discovery_task)
+    _set_task_dependency(intent_discovery_task, flow_splitting_task)
+    _set_task_dependency(flow_splitting_task, start_llm_task)
+    _set_task_dependency(start_llm_task, feedback_candidate_task)
+    _set_task_dependency(feedback_candidate_task, human_feedback_task)
+    _set_task_dependency(human_feedback_task, draft_generation_task)
+    _set_task_dependency(start_llm_task, stop_llm_task)
+    _set_task_dependency(human_feedback_task, stop_llm_task)
+    _set_task_dependency(draft_generation_task, stop_llm_task)
+    _set_task_dependency(draft_generation_task, evaluation_task)
+    _set_task_dependency(evaluation_task, publish_candidate_task)
 
 
 domain_pack_generation()

--- a/ml/src/dags/domain_pack_generation.py
+++ b/ml/src/dags/domain_pack_generation.py
@@ -512,6 +512,7 @@ def domain_pack_generation() -> None:  # pragma: no cover - Airflow imports this
 
     ingestion_task >> preprocessing_task >> representation_task >> start_initial_llm_task >> domain_candidate_task
     domain_candidate_task >> domain_confirmation_task
+    start_initial_llm_task >> stop_initial_llm_task
     domain_candidate_task >> stop_initial_llm_task
     (
         domain_confirmation_task
@@ -521,6 +522,7 @@ def domain_pack_generation() -> None:  # pragma: no cover - Airflow imports this
         >> feedback_candidate_task
     )
     feedback_candidate_task >> human_feedback_task >> draft_generation_task
+    start_llm_task >> stop_llm_task
     human_feedback_task >> stop_llm_task
     draft_generation_task >> stop_llm_task
     draft_generation_task >> evaluation_task >> publish_candidate_task

--- a/ml/src/pipeline/llm_service_lifecycle.py
+++ b/ml/src/pipeline/llm_service_lifecycle.py
@@ -167,14 +167,14 @@ def _health_ready(config: LlmServiceLifecycleConfig) -> tuple[bool, str]:
     try:
         with urllib.request.urlopen(config.health_url, timeout=config.health_request_timeout_seconds) as response:
             status = int(response.status)
-            return 200 <= status < 500, f"http_status={status}"
+            return 200 <= status < 300, f"http_status={status}"
     except urllib.error.HTTPError as exc:
         status = int(exc.code)
         reason = str(exc.reason or exc.msg or "").strip()
         detail = f"http_error={status}"
         if reason:
             detail = f"{detail} {reason}"
-        return 200 <= status < 500, detail
+        return 200 <= status < 300, detail
     except OSError as exc:
         return False, str(exc) or type(exc).__name__
 

--- a/ml/src/pipeline/stages/domain_candidate_generation/main.py
+++ b/ml/src/pipeline/stages/domain_candidate_generation/main.py
@@ -13,6 +13,7 @@ import httpx
 
 from pipeline.common.artifacts import ensure_stage_directory, write_stage_manifest
 from pipeline.common.config import PipelineRuntimeConfig
+from pipeline.common.exceptions import PipelineStageError
 from pipeline.stages.intent_discovery.io import read_preprocessed_artifact
 from pipeline.stages.preprocessing.io import read_stage_context
 from pipeline.stages.preprocessing.types import ProcessedConversation
@@ -64,6 +65,8 @@ def run(upstream_manifest_path: str | None = None) -> dict[str, object]:
     try:
         candidates = _generate_llm_candidates(runtime_config, sampled, fallback_terms, sample_hash)
     except (httpx.HTTPError, ValueError, KeyError, TypeError) as exc:
+        if not _allow_generation_fallback(runtime_config):
+            raise PipelineStageError("Domain candidate LLM generation failed.") from exc
         generation_error = {"type": type(exc).__name__, "message": str(exc)}
         candidates = []
 
@@ -256,6 +259,15 @@ def _llm_timeout() -> float:
     except ValueError:
         return 20.0
     return max(1.0, min(120.0, parsed))
+
+
+def _allow_generation_fallback(runtime_config: PipelineRuntimeConfig) -> bool:
+    raw = os.getenv("PIPELINE_DOMAIN_CANDIDATE_ALLOW_LLM_FALLBACK", "").strip().lower()
+    if raw in {"1", "true", "yes", "y", "on"}:
+        return True
+    if raw in {"0", "false", "no", "n", "off"}:
+        return False
+    return not bool(runtime_config.llm_runtime_base_url)
 
 
 def _sample_hash(sampled: list[ProcessedConversation]) -> str:

--- a/ml/src/pipeline/stages/draft_generation/description_enrichment.py
+++ b/ml/src/pipeline/stages/draft_generation/description_enrichment.py
@@ -11,6 +11,7 @@ from typing import Any
 import httpx
 
 from pipeline.common.config import PipelineRuntimeConfig
+from pipeline.common.exceptions import PipelineStageError
 
 MAX_EVIDENCE_ITEMS = 6
 MAX_EVIDENCE_CHARS = 300
@@ -148,6 +149,8 @@ def _enrich_entity_field(
         parsed = _parse_response(response.json())
     except (httpx.HTTPError, json.JSONDecodeError, ValueError, TypeError, KeyError) as exc:
         _increment(summary, "requestFailureCount")
+        if runtime_config.llm_runtime_base_url:
+            raise PipelineStageError("Description LLM enrichment failed.") from exc
         _record_fallback(summary, field_name)
         if logger is not None:
             logger.warning(

--- a/ml/src/pipeline/stages/feedback_candidate_generation/review_question_enrichment.py
+++ b/ml/src/pipeline/stages/feedback_candidate_generation/review_question_enrichment.py
@@ -10,6 +10,7 @@ from typing import Any
 import httpx
 
 from pipeline.common.config import PipelineRuntimeConfig
+from pipeline.common.exceptions import PipelineStageError
 
 MAX_EVIDENCE_ITEMS = 8
 MAX_EVIDENCE_CHARS = 420
@@ -117,6 +118,8 @@ def _enrich_question(
         parsed = _parse_response(response.json())
     except (httpx.HTTPError, ValueError, TypeError, KeyError) as exc:
         _increment(summary, "requestFailureCount")
+        if runtime_config.llm_runtime_base_url:
+            raise PipelineStageError("Review question LLM enrichment failed.") from exc
         _record_fallback(question, summary, "request_failure")
         if logger is not None:
             logger.warning(

--- a/ml/tests/stages/test_domain_candidate_generation_main.py
+++ b/ml/tests/stages/test_domain_candidate_generation_main.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import pytest
 
+from pipeline.common.exceptions import PipelineStageError
 from pipeline.stages.domain_candidate_generation import main
 from pipeline.stages.preprocessing.types import FLOW_SIGNATURE_DIM, ProcessedConversation
 
@@ -92,6 +93,79 @@ def test_sampling_and_runtime_knobs_are_bounded(monkeypatch: pytest.MonkeyPatch)
     monkeypatch.setenv("PIPELINE_DOMAIN_CANDIDATE_LLM_TIMEOUT_SECONDS", "not-a-number")
     assert main._sample_size() == main.MAX_SAMPLE_SIZE
     assert main._llm_timeout() == 20.0
+
+
+def test_generation_fallback_is_allowed_when_llm_runtime_is_not_configured() -> None:
+    runtime_config = type("RuntimeConfig", (), {"llm_runtime_base_url": None})()
+
+    assert main._allow_generation_fallback(runtime_config)
+
+
+def test_generation_fallback_is_rejected_when_llm_runtime_is_configured() -> None:
+    runtime_config = type("RuntimeConfig", (), {"llm_runtime_base_url": "http://llm.local/v1"})()
+
+    assert not main._allow_generation_fallback(runtime_config)
+
+
+def test_generation_fallback_can_be_explicitly_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime_config = type("RuntimeConfig", (), {"llm_runtime_base_url": "http://llm.local/v1"})()
+    monkeypatch.setenv("PIPELINE_DOMAIN_CANDIDATE_ALLOW_LLM_FALLBACK", "true")
+
+    assert main._allow_generation_fallback(runtime_config)
+
+
+def test_run_raises_when_configured_llm_generation_fails(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    runtime_config = type(
+        "RuntimeConfig",
+        (),
+        {
+            "artifact_root": tmp_path,
+            "backend_base_url": "http://backend:8080",
+            "callback_enabled": False,
+            "artifact_store": "local",
+            "artifact_bucket": None,
+            "artifact_prefix": "",
+            "llm_runtime_base_url": "http://llm.local/v1",
+            "llm_runtime_api_key": None,
+            "llm_model_name": "model-a",
+        },
+    )()
+
+    monkeypatch.setattr(main.PipelineRuntimeConfig, "from_env", lambda: runtime_config)
+    monkeypatch.setattr(
+        main,
+        "read_stage_context",
+        lambda _path, stage_name: type(
+            "StageContext",
+            (),
+            {
+                "dag_id": "dag",
+                "run_id": "run1",
+                "stage_name": stage_name,
+                "workspace_id": "workspace-1",
+                "dataset_id": "dataset-1",
+                "pipeline_job_id": "job-1",
+            },
+        )(),
+    )
+    monkeypatch.setattr(
+        main, "read_preprocessed_artifact", lambda _config, _context: ([_conversation("c1", "예약")], [])
+    )
+    monkeypatch.setattr(
+        main,
+        "_generate_llm_candidates",
+        lambda *_args: (_ for _ in ()).throw(ValueError("bad llm response")),
+    )
+
+    def fake_stage_directory(_context: object, _config: object):
+        stage_dir = tmp_path / "dag" / "run1" / "domain_candidate_generation"
+        stage_dir.mkdir(parents=True)
+        return stage_dir
+
+    monkeypatch.setattr(main, "ensure_stage_directory", fake_stage_directory)
+
+    with pytest.raises(PipelineStageError, match="Domain candidate LLM generation failed"):
+        main.run("/tmp/upstream/manifest.json")
 
 
 def test_prompt_and_terms_are_stable() -> None:

--- a/ml/tests/stages/test_domain_candidate_generation_main.py
+++ b/ml/tests/stages/test_domain_candidate_generation_main.py
@@ -114,6 +114,13 @@ def test_generation_fallback_can_be_explicitly_enabled(monkeypatch: pytest.Monke
     assert main._allow_generation_fallback(runtime_config)
 
 
+def test_generation_fallback_can_be_explicitly_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime_config = type("RuntimeConfig", (), {"llm_runtime_base_url": None})()
+    monkeypatch.setenv("PIPELINE_DOMAIN_CANDIDATE_ALLOW_LLM_FALLBACK", "false")
+
+    assert not main._allow_generation_fallback(runtime_config)
+
+
 def test_run_raises_when_configured_llm_generation_fails(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
     runtime_config = type(
         "RuntimeConfig",

--- a/ml/tests/stages/test_draft_generation_description_enrichment.py
+++ b/ml/tests/stages/test_draft_generation_description_enrichment.py
@@ -6,8 +6,10 @@ from pathlib import Path
 from typing import Any
 
 import httpx
+import pytest
 
 from pipeline.common.config import PipelineRuntimeConfig
+from pipeline.common.exceptions import PipelineStageError
 from pipeline.stages.draft_generation import description_enrichment
 from pipeline.stages.draft_generation.description_enrichment import enrich_candidate_descriptions
 
@@ -251,12 +253,8 @@ def test_description_enrichment_handles_request_failure(monkeypatch, tmp_path: P
     )
     candidate = _candidate()
 
-    summary = enrich_candidate_descriptions(candidate, _runtime_config(tmp_path), logger=logging.getLogger(__name__))
-
-    assert summary is not None
-    assert summary["requestFailureCount"] == 2
-    assert summary["fallbackCount"] == 2
-    assert candidate["intentDraft"]["intents"][0]["description"] == "결제 문의 클러스터"
+    with pytest.raises(PipelineStageError, match="Description LLM enrichment failed"):
+        enrich_candidate_descriptions(candidate, _runtime_config(tmp_path), logger=logging.getLogger(__name__))
 
 
 def test_description_enrichment_counts_schema_failures(monkeypatch, tmp_path: Path) -> None:

--- a/ml/tests/stages/test_feedback_candidate_generation_main.py
+++ b/ml/tests/stages/test_feedback_candidate_generation_main.py
@@ -5,8 +5,10 @@ from pathlib import Path
 from typing import Any, cast
 
 import httpx
+import pytest
 
 from pipeline.common.config import PipelineRuntimeConfig
+from pipeline.common.exceptions import PipelineStageError
 from pipeline.stages.feedback_candidate_generation import review_question_enrichment
 from pipeline.stages.feedback_candidate_generation.main import run
 
@@ -142,11 +144,8 @@ def test_review_question_enrichment_handles_request_failure(monkeypatch, tmp_pat
         _fake_client_factory(httpx.ConnectError("connection failed")),
     )
 
-    summary = review_question_enrichment.enrich_review_questions([question], _runtime_config(tmp_path))
-
-    assert summary["requestFailureCount"] == 1
-    assert summary["fallbackCount"] == 1
-    assert question["enrichmentStatus"] == "fallback"
+    with pytest.raises(PipelineStageError, match="Review question LLM enrichment failed"):
+        review_question_enrichment.enrich_review_questions([question], _runtime_config(tmp_path))
 
 
 def test_review_question_enrichment_keeps_abstain_as_low_priority(monkeypatch, tmp_path: Path) -> None:

--- a/ml/tests/test_domain_pack_generation_dag.py
+++ b/ml/tests/test_domain_pack_generation_dag.py
@@ -239,6 +239,23 @@ def test_initial_llm_lifecycle_stops_only_for_initial_run(monkeypatch: pytest.Mo
     assert calls == ["stop"]
 
 
+def test_set_task_dependency_links_airflow_task_like_objects(monkeypatch: pytest.MonkeyPatch) -> None:
+    dag_module = _import_dag_module(monkeypatch)
+    linked: list[tuple[str, str]] = []
+
+    class FakeTask:
+        def __init__(self, task_id: str) -> None:
+            self.task_id = task_id
+
+        def __rshift__(self, downstream: "FakeTask") -> "FakeTask":
+            linked.append((self.task_id, downstream.task_id))
+            return downstream
+
+    dag_module._set_task_dependency(FakeTask("start"), FakeTask("stop"))
+
+    assert linked == [("start", "stop")]
+
+
 @pytest.mark.parametrize("value", ["true", "TRUE", " 1 ", "yes", "Y", "on"])
 def test_conf_bool_accepts_true_values(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
     dag_module = _import_dag_module(monkeypatch)

--- a/ml/tests/test_domain_pack_generation_dag.py
+++ b/ml/tests/test_domain_pack_generation_dag.py
@@ -207,6 +207,38 @@ def test_run_evaluation_stage_delegates_to_evaluation_run(monkeypatch: pytest.Mo
     assert calls == ["/tmp/upstream.json"]
 
 
+def test_initial_llm_lifecycle_starts_only_for_initial_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    dag_module = _import_dag_module(monkeypatch)
+    calls: list[str] = []
+
+    monkeypatch.setattr(dag_module, "_run_mode", lambda: dag_module.RUN_MODE_INITIAL)
+    monkeypatch.setattr(dag_module, "start_llm_ecs_service", lambda: calls.append("start") or {"enabled": True})
+
+    assert dag_module._start_initial_llm_service() == {"enabled": True}
+    assert calls == ["start"]
+
+    monkeypatch.setattr(dag_module, "_run_mode", lambda: dag_module.RUN_MODE_DOMAIN_CONFIRMED_REPLAY)
+
+    assert dag_module._start_initial_llm_service() == {"enabled": False, "reason": "not_initial_run"}
+    assert calls == ["start"]
+
+
+def test_initial_llm_lifecycle_stops_only_for_initial_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    dag_module = _import_dag_module(monkeypatch)
+    calls: list[str] = []
+
+    monkeypatch.setattr(dag_module, "_run_mode", lambda: dag_module.RUN_MODE_INITIAL)
+    monkeypatch.setattr(dag_module, "stop_llm_ecs_service", lambda: calls.append("stop") or {"enabled": True})
+
+    assert dag_module._stop_initial_llm_service() == {"enabled": True}
+    assert calls == ["stop"]
+
+    monkeypatch.setattr(dag_module, "_run_mode", lambda: dag_module.RUN_MODE_FEEDBACK_REPLAY)
+
+    assert dag_module._stop_initial_llm_service() == {"enabled": False, "reason": "not_initial_run"}
+    assert calls == ["stop"]
+
+
 @pytest.mark.parametrize("value", ["true", "TRUE", " 1 ", "yes", "Y", "on"])
 def test_conf_bool_accepts_true_values(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
     dag_module = _import_dag_module(monkeypatch)

--- a/ml/tests/test_llm_service_lifecycle.py
+++ b/ml/tests/test_llm_service_lifecycle.py
@@ -154,13 +154,13 @@ def test_health_url_from_runtime_base_url_handles_non_v1_url(monkeypatch: pytest
     assert _health_url_from_runtime_base_url() == "http://llm.local:8000/openai/health"
 
 
-def test_health_ready_accepts_http_error_below_500(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_health_ready_rejects_http_error_below_500(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_urlopen(*_args: object, **_kwargs: object) -> object:
         raise urllib.error.HTTPError("http://llm.local/health", 404, "Not Found", Message(), None)
 
     monkeypatch.setattr("pipeline.llm_service_lifecycle.urllib.request.urlopen", fake_urlopen)
 
-    assert _health_ready(_config()) == (True, "http_error=404 Not Found")
+    assert _health_ready(_config()) == (False, "http_error=404 Not Found")
 
 
 def test_health_ready_rejects_connection_errors(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Start the Airflow-managed LLM ECS service before the initial `domain_candidate_generation` task, then stop it after the domain checkpoint artifact is generated.
- Keep the replay LLM lifecycle for feedback/draft generation, but wire stop tasks directly from start tasks so partial startup failures can still scale the service back down.
- Treat only 2xx LLM health responses as ready and require the ALB target group health check to match `200`.
- Fail configured production LLM paths on request/parsing failures instead of surfacing fallback domain/review/draft output as if it were useful review data.

## Root Cause
Pipeline job 43 reached the domain confirmation checkpoint, but the UI showed only `혼합 또는 미확정` with `0%` confidence. The generated `domain_candidates.json` artifact contains a `generationError`: the domain candidate stage received `503 Service Temporarily Unavailable` from the internal LLM ALB.

The DAG was starting the LLM ECS service only after `flow_splitting`, while the initial `domain_candidate_generation` stage already calls the OpenAI-compatible local LLM endpoint. Because the LLM service stayed at desired/running 0 for that checkpoint stage, the ALB returned 503 and the stage fell back to a mixed/unknown candidate.

A second issue made this easier to miss: readiness checks accepted HTTP 4xx responses, the target group health matcher allowed `200-499`, and multiple LLM-backed review stages could continue with fallback output even when a configured production LLM request failed.

## Validation
- `cd ml && uv run ruff format src/pipeline/llm_service_lifecycle.py src/pipeline/stages/domain_candidate_generation/main.py src/pipeline/stages/feedback_candidate_generation/review_question_enrichment.py src/pipeline/stages/draft_generation/description_enrichment.py src/dags/domain_pack_generation.py tests/test_llm_service_lifecycle.py tests/stages/test_domain_candidate_generation_main.py tests/stages/test_feedback_candidate_generation_main.py tests/stages/test_draft_generation_description_enrichment.py tests/test_domain_pack_generation_dag.py`
- `cd ml && uv run ruff check src/pipeline/llm_service_lifecycle.py src/pipeline/stages/domain_candidate_generation/main.py src/pipeline/stages/feedback_candidate_generation/review_question_enrichment.py src/pipeline/stages/draft_generation/description_enrichment.py src/dags/domain_pack_generation.py tests/test_llm_service_lifecycle.py tests/stages/test_domain_candidate_generation_main.py tests/stages/test_feedback_candidate_generation_main.py tests/stages/test_draft_generation_description_enrichment.py tests/test_domain_pack_generation_dag.py`
- `cd ml && uv run pytest tests/test_llm_service_lifecycle.py tests/stages/test_domain_candidate_generation_main.py tests/stages/test_feedback_candidate_generation_main.py tests/stages/test_draft_generation_description_enrichment.py tests/test_domain_pack_generation_dag.py`
- `cd ml && uv run pytest --cov=src --cov-report=term-missing --cov-report=xml:coverage.xml`
- `terraform fmt -check infra/terraform/ecs-llm.tf`
- `terraform -chdir=infra/terraform validate`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 초기 실행에서만 LLM 서비스의 시작/중지 라이프사이클을 검증하는 테스트와 파이프라인 단계별 예외·폴백 동작을 검증하는 테스트 다수 추가/수정

* **Refactor**
  * 초기 실행 전용 LLM 서비스 시작/중지 흐름을 워크플로우에 분리하고 태스크 의존성을 재배치

* **Bug Fixes**
  * LLM 폴백 허용 조건을 환경설정 기준으로 강화해 구성된 경우 실패 시 단계가 중단되도록 변경
  * 헬스체크 응답 기준 및 로드밸런서 헬스 판정 기준을 더 엄격하게 조정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->