### PR TITLE
fix(frontend): 상담 로그 수집에서 검토 대기 기록을 표로 표시

### DIFF
--- a/frontend/e2e/upload-domain-pack-generation.spec.ts
+++ b/frontend/e2e/upload-domain-pack-generation.spec.ts
@@ -190,8 +190,17 @@ test.describe("Upload completed Domain Pack draft generation", () => {
 
       await page.goto("/workspaces/1/upload");
 
-      await expect(page.getByText("검토 대기", { exact: true })).toBeVisible();
-      await expect(page.getByText("검토 대기 항목 1개가 남아 있습니다.")).toBeVisible();
+      await expect(
+        page.getByRole("heading", { name: "상담 로그 처리 기록" }),
+      ).toBeVisible();
+      await expect(
+        page.getByText("검토가 필요한 최신 상담 로그 처리 기록입니다."),
+      ).toBeVisible();
+      await expect(page.getByRole("cell", { name: /refund-log\.zip/ })).toBeVisible();
+      await expect(page.getByRole("cell", { name: "JOB-900" })).toBeVisible();
+      await expect(
+        page.getByRole("cell", { name: "WAITING_DOMAIN_CONFIRMATION" }),
+      ).toBeVisible();
 
       await page.getByRole("button", { name: "검토 화면으로 이동" }).click();
 

--- a/frontend/src/features/log-upload/ui/LogUploadForm.test.tsx
+++ b/frontend/src/features/log-upload/ui/LogUploadForm.test.tsx
@@ -223,24 +223,78 @@ describe("LogUploadForm", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows open review CTA on the upload screen", () => {
+  it("shows open review record table on the upload screen", () => {
     render(
       <LogUploadForm
         workspaceId={2}
-        openReviewCta={{
+        openReviewRecord={{
           path: "/workspaces/2/pipeline-jobs/43/review",
+          pipelineJobId: 43,
           pendingReviewCount: 2,
+          datasetId: 77,
+          datasetName: "refund-log.zip",
+          status: "WAITING_DOMAIN_CONFIRMATION",
+          requestedAt: "2026-06-04T09:00:00+09:00",
         }}
       />,
       { wrapper: MemoryRouter },
     );
 
-    expect(screen.getByText("검토 대기")).toBeInTheDocument();
-    expect(screen.getByText("검토 대기 항목 2개가 남아 있습니다.")).toBeInTheDocument();
+    expect(screen.getByText("상담 로그 처리 기록")).toBeInTheDocument();
+    expect(screen.getByText("검토 대기 항목 2개 중 최신 1건입니다.")).toBeInTheDocument();
+    expect(screen.getByText("refund-log.zip")).toBeInTheDocument();
+    expect(screen.getByText("JOB-43")).toBeInTheDocument();
+    expect(screen.getByText("WAITING_DOMAIN_CONFIRMATION")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /검토 화면으로 이동/ }));
 
     expect(mockNavigate).toHaveBeenCalledWith("/workspaces/2/pipeline-jobs/43/review");
+  });
+
+  it("shows open review record fallbacks when optional metadata is missing", () => {
+    render(
+      <LogUploadForm
+        workspaceId={2}
+        openReviewRecord={{
+          path: "/workspaces/2/pipeline-jobs/44/review",
+          pipelineJobId: 44,
+          pendingReviewCount: 1,
+          datasetId: 78,
+          status: null,
+          requestedAt: null,
+        }}
+      />,
+      { wrapper: MemoryRouter },
+    );
+
+    expect(
+      screen.getByText("검토가 필요한 최신 상담 로그 처리 기록입니다."),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("dataset 78")).toHaveLength(2);
+    expect(screen.getByText("JOB-44")).toBeInTheDocument();
+    expect(screen.getByText("검토 대기")).toBeInTheDocument();
+    expect(screen.getByText("-")).toBeInTheDocument();
+  });
+
+  it("shows a generic open review record when dataset metadata is unavailable", () => {
+    render(
+      <LogUploadForm
+        workspaceId={2}
+        openReviewRecord={{
+          path: "/workspaces/2/pipeline-jobs/45/review",
+          pipelineJobId: 45,
+          pendingReviewCount: 0,
+          datasetId: null,
+          requestedAt: "not-a-date",
+        }}
+      />,
+      { wrapper: MemoryRouter },
+    );
+
+    expect(screen.getByText("최근 상담 로그")).toBeInTheDocument();
+    expect(screen.getByText("JOB-45")).toBeInTheDocument();
+    expect(screen.getByText("검토 대기")).toBeInTheDocument();
+    expect(screen.getByText("-")).toBeInTheDocument();
   });
 
   it("blocks upload when free onboarding is consumed without active subscription", () => {

--- a/frontend/src/features/log-upload/ui/LogUploadForm.tsx
+++ b/frontend/src/features/log-upload/ui/LogUploadForm.tsx
@@ -58,9 +58,14 @@ export interface PaidUploadCooldown {
   readonly nextAvailableAt?: string | null;
 }
 
-export interface OpenReviewCta {
+export interface OpenReviewRecord {
   readonly path: string;
+  readonly pipelineJobId: number;
   readonly pendingReviewCount: number;
+  readonly datasetId?: number | null;
+  readonly datasetName?: string | null;
+  readonly status?: string | null;
+  readonly requestedAt?: string | null;
 }
 
 interface LogUploadFormProps {
@@ -69,7 +74,7 @@ interface LogUploadFormProps {
   hasActiveSubscription?: boolean;
   isEntitlementLoading?: boolean;
   paidUploadCooldown?: PaidUploadCooldown;
-  openReviewCta?: OpenReviewCta | null;
+  openReviewRecord?: OpenReviewRecord | null;
 }
 
 interface GenerationRequestToken {
@@ -114,6 +119,22 @@ const formatCooldownMessage = (nextAvailableAt?: string | null) => {
   })}`;
 };
 
+const formatReviewDateTime = (value?: string | null) => {
+  if (!value) {
+    return "-";
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "-";
+  }
+
+  return date.toLocaleString("ko-KR", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+};
+
 const readGenerationResponse = (
   response: unknown,
 ): Omit<GenerationStatus & { kind: "success" }, "kind"> => {
@@ -134,7 +155,7 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({
   hasActiveSubscription = false,
   isEntitlementLoading = false,
   paidUploadCooldown,
-  openReviewCta,
+  openReviewRecord,
 }) => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -517,24 +538,60 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({
         )}
       </div>
 
-      {openReviewCta ? (
-        <div className={styles.openReviewNotice}>
-          <div>
-            <span className={styles.statusLabel}>검토 대기</span>
+      {openReviewRecord ? (
+        <section className={styles.reviewHistory} aria-labelledby="review-history-title">
+          <div className={styles.reviewHistoryHeader}>
+            <div>
+              <span className={styles.statusLabel}>처리 기록</span>
+              <h3 id="review-history-title">상담 로그 처리 기록</h3>
+            </div>
             <p>
-              {openReviewCta.pendingReviewCount > 0
-                ? `검토 대기 항목 ${openReviewCta.pendingReviewCount}개가 남아 있습니다.`
-                : "검토가 필요한 파이프라인이 열려 있습니다."}
+              {openReviewRecord.pendingReviewCount > 1
+                ? `검토 대기 항목 ${openReviewRecord.pendingReviewCount}개 중 최신 1건입니다.`
+                : "검토가 필요한 최신 상담 로그 처리 기록입니다."}
             </p>
           </div>
-          <Button
-            variant="secondary"
-            onClick={() => navigate(openReviewCta.path)}
-          >
-            <ListChecksIcon aria-hidden="true" size={16} />
-            {CTA_GO_REVIEW}
-          </Button>
-        </div>
+          <div className={styles.reviewHistoryTableWrap}>
+            <table className={styles.reviewHistoryTable}>
+              <thead>
+                <tr>
+                  <th scope="col">상담 로그</th>
+                  <th scope="col">파이프라인</th>
+                  <th scope="col">상태</th>
+                  <th scope="col">요청 시각</th>
+                  <th scope="col">작업</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>
+                    <strong>
+                      {openReviewRecord.datasetName ??
+                        (openReviewRecord.datasetId == null
+                          ? "최근 상담 로그"
+                          : `dataset ${openReviewRecord.datasetId}`)}
+                    </strong>
+                    {openReviewRecord.datasetId == null ? null : (
+                      <span>dataset {openReviewRecord.datasetId}</span>
+                    )}
+                  </td>
+                  <td>JOB-{openReviewRecord.pipelineJobId}</td>
+                  <td>{openReviewRecord.status ?? "검토 대기"}</td>
+                  <td>{formatReviewDateTime(openReviewRecord.requestedAt)}</td>
+                  <td>
+                    <Button
+                      variant="secondary"
+                      onClick={() => navigate(openReviewRecord.path)}
+                    >
+                      <ListChecksIcon aria-hidden="true" size={16} />
+                      {CTA_GO_REVIEW}
+                    </Button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
       ) : null}
 
       <div className={styles.uploadArea}>

--- a/frontend/src/features/log-upload/ui/log-upload-form.module.css
+++ b/frontend/src/features/log-upload/ui/log-upload-form.module.css
@@ -52,11 +52,7 @@
   margin-top: 4px;
 }
 
-.openReviewNotice {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
+.reviewHistory {
   margin-bottom: 24px;
   padding: 16px 20px;
   background: #ffffff;
@@ -64,12 +60,88 @@
   border-radius: var(--radius-md);
 }
 
-.openReviewNotice p {
+.reviewHistoryHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 14px;
+}
+
+.reviewHistoryHeader h3 {
+  margin: 4px 0 0;
+  color: var(--text-color);
+  font-size: 1rem;
+  font-weight: 540;
+  letter-spacing: 0;
+}
+
+.reviewHistoryHeader p {
   margin: 4px 0 0;
   color: var(--text-muted);
   font-size: 0.9rem;
   line-height: 1.5;
   letter-spacing: 0;
+  text-align: right;
+}
+
+.reviewHistoryTableWrap {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.reviewHistoryTable {
+  width: 100%;
+  min-width: 560px;
+  border-collapse: collapse;
+}
+
+.reviewHistoryTable th,
+.reviewHistoryTable td {
+  padding: 12px 10px;
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+  color: var(--text-color);
+  font-size: 0.86rem;
+  line-height: 1.4;
+  letter-spacing: 0;
+  text-align: left;
+  vertical-align: middle;
+}
+
+.reviewHistoryTable th {
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  font-weight: 450;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.reviewHistoryTable td:first-child {
+  min-width: 160px;
+}
+
+.reviewHistoryTable td:first-child strong,
+.reviewHistoryTable td:first-child span {
+  display: block;
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.reviewHistoryTable td:first-child strong {
+  font-weight: 540;
+}
+
+.reviewHistoryTable td:first-child span {
+  margin-top: 3px;
+  color: var(--text-muted);
+  font-size: 0.78rem;
+}
+
+.reviewHistoryTable td:last-child {
+  width: 1%;
+  white-space: nowrap;
 }
 
 .uploadArea {
@@ -153,7 +225,7 @@
 }
 
 .onboardingStatus .statusLabel,
-.openReviewNotice .statusLabel,
+.reviewHistory .statusLabel,
 .uploadSummary .statusLabel,
 .generationPanel .statusLabel {
   color: var(--text-color);
@@ -197,9 +269,15 @@
     flex-direction: column;
     gap: 16px;
   }
-  .openReviewNotice {
-    align-items: stretch;
+  .reviewHistory {
+    padding: 16px;
+  }
+  .reviewHistoryHeader {
     flex-direction: column;
+    gap: 8px;
+  }
+  .reviewHistoryHeader p {
+    text-align: left;
   }
   .fileInfo {
     width: 100%;

--- a/frontend/src/pages/upload/ui/WorkspaceUploadPage.test.tsx
+++ b/frontend/src/pages/upload/ui/WorkspaceUploadPage.test.tsx
@@ -40,7 +40,8 @@ vi.mock("../../../features/log-upload/ui/LogUploadForm", () => ({
       {paidUploadCooldown?.nextAvailableAt ?? "none"} review:
       {openReviewRecord?.path ?? "none"} job:
       {openReviewRecord?.pipelineJobId ?? "none"} pending:
-      {openReviewRecord?.pendingReviewCount ?? "none"} dataset:
+      {openReviewRecord?.pendingReviewCount ?? "none"} datasetId:
+      {openReviewRecord?.datasetId ?? "none"} dataset:
       {openReviewRecord?.datasetName ?? "none"} status:
       {openReviewRecord?.status ?? "none"}
     </div>
@@ -117,7 +118,7 @@ describe("WorkspaceUploadPage", () => {
     renderRoute("/workspaces/1/upload");
 
     expect(screen.getByTestId("upload-form")).toHaveTextContent(
-      "workspace:1 onboarding:AVAILABLE active:false loading:false cooldown:false next:none review:none job:none pending:none dataset:none status:none",
+      "workspace:1 onboarding:AVAILABLE active:false loading:false cooldown:false next:none review:none job:none pending:none datasetId:none dataset:none status:none",
     );
   });
 
@@ -144,7 +145,34 @@ describe("WorkspaceUploadPage", () => {
     renderRoute("/workspaces/2/upload");
 
     expect(screen.getByTestId("upload-form")).toHaveTextContent(
-      "review:/workspaces/2/pipeline-jobs/43/review job:43 pending:3 dataset:refund-log.zip status:WAITING_DOMAIN_CONFIRMATION",
+      "review:/workspaces/2/pipeline-jobs/43/review job:43 pending:3 datasetId:77 dataset:refund-log.zip status:WAITING_DOMAIN_CONFIRMATION",
+    );
+  });
+
+  it("does not mix dataset names from a different log upload", () => {
+    mockUseWorkspaceDashboardHealth.mockReturnValue({
+      data: {
+        pendingReviewCount: 1,
+        latestOpenReviewPipelineJobId: 43,
+        lastLogUpload: {
+          datasetId: 88,
+          datasetKey: "dataset-other-log",
+          datasetName: "other-log.zip",
+          datasetStatus: "READY",
+        },
+        lastKnowledgePackGeneration: {
+          pipelineJobId: 43,
+          datasetId: 77,
+          status: "WAITING_DOMAIN_CONFIRMATION",
+        },
+      },
+      isLoading: false,
+    });
+
+    renderRoute("/workspaces/2/upload");
+
+    expect(screen.getByTestId("upload-form")).toHaveTextContent(
+      "review:/workspaces/2/pipeline-jobs/43/review job:43 pending:1 datasetId:77 dataset:none status:WAITING_DOMAIN_CONFIRMATION",
     );
   });
 
@@ -163,7 +191,7 @@ describe("WorkspaceUploadPage", () => {
     renderRoute("/workspaces/1/upload");
 
     expect(screen.getByTestId("upload-form")).toHaveTextContent(
-      "workspace:1 onboarding:CONSUMED active:true loading:false cooldown:false next:none review:none job:none pending:none dataset:none status:none",
+      "workspace:1 onboarding:CONSUMED active:true loading:false cooldown:false next:none review:none job:none pending:none datasetId:none dataset:none status:none",
     );
   });
 
@@ -187,7 +215,7 @@ describe("WorkspaceUploadPage", () => {
     renderRoute("/workspaces/1/upload");
 
     expect(screen.getByTestId("upload-form")).toHaveTextContent(
-      "workspace:1 onboarding:AVAILABLE active:true loading:false cooldown:true next:2026-06-04T10:30:00+09:00 review:none job:none pending:none dataset:none status:none",
+      "workspace:1 onboarding:AVAILABLE active:true loading:false cooldown:true next:2026-06-04T10:30:00+09:00 review:none job:none pending:none datasetId:none dataset:none status:none",
     );
   });
 
@@ -211,7 +239,7 @@ describe("WorkspaceUploadPage", () => {
     renderRoute("/workspaces/1/upload");
 
     expect(screen.getByTestId("upload-form")).toHaveTextContent(
-      "workspace:1 onboarding:CONSUMED active:false loading:false cooldown:false next:none review:none job:none pending:none dataset:none status:none",
+      "workspace:1 onboarding:CONSUMED active:false loading:false cooldown:false next:none review:none job:none pending:none datasetId:none dataset:none status:none",
     );
 
     act(() => {

--- a/frontend/src/pages/upload/ui/WorkspaceUploadPage.test.tsx
+++ b/frontend/src/pages/upload/ui/WorkspaceUploadPage.test.tsx
@@ -16,14 +16,21 @@ vi.mock("../../../features/log-upload/ui/LogUploadForm", () => ({
     hasActiveSubscription,
     isEntitlementLoading,
     paidUploadCooldown,
-    openReviewCta,
+    openReviewRecord,
   }: {
     workspaceId?: number;
     freeOnboardingStatus?: string;
     hasActiveSubscription?: boolean;
     isEntitlementLoading?: boolean;
     paidUploadCooldown?: { isBlocked?: boolean; nextAvailableAt?: string | null };
-    openReviewCta?: { path: string; pendingReviewCount: number } | null;
+    openReviewRecord?: {
+      path: string;
+      pipelineJobId: number;
+      pendingReviewCount: number;
+      datasetId?: number | null;
+      datasetName?: string | null;
+      status?: string | null;
+    } | null;
   }) => (
     <div data-testid="upload-form">
       workspace:{workspaceId} onboarding:{freeOnboardingStatus} active:
@@ -31,8 +38,11 @@ vi.mock("../../../features/log-upload/ui/LogUploadForm", () => ({
       cooldown:
       {String(paidUploadCooldown?.isBlocked)} next:
       {paidUploadCooldown?.nextAvailableAt ?? "none"} review:
-      {openReviewCta?.path ?? "none"} pending:
-      {openReviewCta?.pendingReviewCount ?? "none"}
+      {openReviewRecord?.path ?? "none"} job:
+      {openReviewRecord?.pipelineJobId ?? "none"} pending:
+      {openReviewRecord?.pendingReviewCount ?? "none"} dataset:
+      {openReviewRecord?.datasetName ?? "none"} status:
+      {openReviewRecord?.status ?? "none"}
     </div>
   ),
 }));
@@ -107,7 +117,7 @@ describe("WorkspaceUploadPage", () => {
     renderRoute("/workspaces/1/upload");
 
     expect(screen.getByTestId("upload-form")).toHaveTextContent(
-      "workspace:1 onboarding:AVAILABLE active:false loading:false cooldown:false next:none review:none pending:none",
+      "workspace:1 onboarding:AVAILABLE active:false loading:false cooldown:false next:none review:none job:none pending:none dataset:none status:none",
     );
   });
 
@@ -116,6 +126,17 @@ describe("WorkspaceUploadPage", () => {
       data: {
         pendingReviewCount: 3,
         latestOpenReviewPipelineJobId: 43,
+        lastLogUpload: {
+          datasetId: 77,
+          datasetKey: "dataset-refund-log",
+          datasetName: "refund-log.zip",
+          datasetStatus: "READY",
+        },
+        lastKnowledgePackGeneration: {
+          pipelineJobId: 43,
+          datasetId: 77,
+          status: "WAITING_DOMAIN_CONFIRMATION",
+        },
       },
       isLoading: false,
     });
@@ -123,7 +144,7 @@ describe("WorkspaceUploadPage", () => {
     renderRoute("/workspaces/2/upload");
 
     expect(screen.getByTestId("upload-form")).toHaveTextContent(
-      "review:/workspaces/2/pipeline-jobs/43/review pending:3",
+      "review:/workspaces/2/pipeline-jobs/43/review job:43 pending:3 dataset:refund-log.zip status:WAITING_DOMAIN_CONFIRMATION",
     );
   });
 
@@ -142,7 +163,7 @@ describe("WorkspaceUploadPage", () => {
     renderRoute("/workspaces/1/upload");
 
     expect(screen.getByTestId("upload-form")).toHaveTextContent(
-      "workspace:1 onboarding:CONSUMED active:true loading:false cooldown:false next:none review:none pending:none",
+      "workspace:1 onboarding:CONSUMED active:true loading:false cooldown:false next:none review:none job:none pending:none dataset:none status:none",
     );
   });
 
@@ -166,7 +187,7 @@ describe("WorkspaceUploadPage", () => {
     renderRoute("/workspaces/1/upload");
 
     expect(screen.getByTestId("upload-form")).toHaveTextContent(
-      "workspace:1 onboarding:AVAILABLE active:true loading:false cooldown:true next:2026-06-04T10:30:00+09:00 review:none pending:none",
+      "workspace:1 onboarding:AVAILABLE active:true loading:false cooldown:true next:2026-06-04T10:30:00+09:00 review:none job:none pending:none dataset:none status:none",
     );
   });
 
@@ -190,7 +211,7 @@ describe("WorkspaceUploadPage", () => {
     renderRoute("/workspaces/1/upload");
 
     expect(screen.getByTestId("upload-form")).toHaveTextContent(
-      "workspace:1 onboarding:CONSUMED active:false loading:false cooldown:false next:none review:none pending:none",
+      "workspace:1 onboarding:CONSUMED active:false loading:false cooldown:false next:none review:none job:none pending:none dataset:none status:none",
     );
 
     act(() => {

--- a/frontend/src/pages/upload/ui/WorkspaceUploadPage.tsx
+++ b/frontend/src/pages/upload/ui/WorkspaceUploadPage.tsx
@@ -74,17 +74,22 @@ export function WorkspaceUploadPage() {
   const dashboardHealth = dashboardHealthQuery.data ?? null;
   const latestOpenReviewPipelineJobId =
     dashboardHealth?.latestOpenReviewPipelineJobId ?? null;
+  const reviewDatasetId =
+    dashboardHealth?.lastKnowledgePackGeneration?.datasetId ??
+    dashboardHealth?.lastLogUpload?.datasetId ??
+    null;
+  const reviewDatasetName =
+    dashboardHealth?.lastLogUpload?.datasetId === reviewDatasetId
+      ? dashboardHealth.lastLogUpload.datasetName
+      : null;
   const openReviewRecord =
     parsedWorkspaceId !== null && latestOpenReviewPipelineJobId !== null
       ? {
           path: `/workspaces/${parsedWorkspaceId}/pipeline-jobs/${latestOpenReviewPipelineJobId}/review`,
           pipelineJobId: latestOpenReviewPipelineJobId,
           pendingReviewCount: dashboardHealth?.pendingReviewCount ?? 0,
-          datasetId:
-            dashboardHealth?.lastKnowledgePackGeneration?.datasetId ??
-            dashboardHealth?.lastLogUpload?.datasetId ??
-            null,
-          datasetName: dashboardHealth?.lastLogUpload?.datasetName ?? null,
+          datasetId: reviewDatasetId,
+          datasetName: reviewDatasetName,
           status: dashboardHealth?.lastKnowledgePackGeneration?.status ?? null,
           requestedAt:
             dashboardHealth?.lastKnowledgePackGeneration?.requestedAt ??

--- a/frontend/src/pages/upload/ui/WorkspaceUploadPage.tsx
+++ b/frontend/src/pages/upload/ui/WorkspaceUploadPage.tsx
@@ -71,13 +71,25 @@ export function WorkspaceUploadPage() {
     (subscriptionQuery.data as SubscriptionResponse | null) ?? null;
   const hasActiveSubscription = isSubscriptionEngaged(subscription?.status);
   const paidUploadCooldown = resolvePaidUploadCooldown(subscription);
+  const dashboardHealth = dashboardHealthQuery.data ?? null;
   const latestOpenReviewPipelineJobId =
-    dashboardHealthQuery.data?.latestOpenReviewPipelineJobId ?? null;
-  const openReviewCta =
+    dashboardHealth?.latestOpenReviewPipelineJobId ?? null;
+  const openReviewRecord =
     parsedWorkspaceId !== null && latestOpenReviewPipelineJobId !== null
       ? {
           path: `/workspaces/${parsedWorkspaceId}/pipeline-jobs/${latestOpenReviewPipelineJobId}/review`,
-          pendingReviewCount: dashboardHealthQuery.data?.pendingReviewCount ?? 0,
+          pipelineJobId: latestOpenReviewPipelineJobId,
+          pendingReviewCount: dashboardHealth?.pendingReviewCount ?? 0,
+          datasetId:
+            dashboardHealth?.lastKnowledgePackGeneration?.datasetId ??
+            dashboardHealth?.lastLogUpload?.datasetId ??
+            null,
+          datasetName: dashboardHealth?.lastLogUpload?.datasetName ?? null,
+          status: dashboardHealth?.lastKnowledgePackGeneration?.status ?? null,
+          requestedAt:
+            dashboardHealth?.lastKnowledgePackGeneration?.requestedAt ??
+            dashboardHealth?.lastLogUpload?.uploadedAt ??
+            null,
         }
       : null;
   const refetchWorkspace = workspaceQuery.refetch;
@@ -129,7 +141,7 @@ export function WorkspaceUploadPage() {
         hasActiveSubscription={hasActiveSubscription}
         isEntitlementLoading={isEntitlementLoading}
         paidUploadCooldown={paidUploadCooldown}
-        openReviewCta={openReviewCta}
+        openReviewRecord={openReviewRecord}
       />
     </div>
   );


### PR DESCRIPTION
## 변경 사항

- 상담 로그 수집 화면의 검토 대기 진입을 단일 안내 배너에서 `상담 로그 처리 기록` 테이블로 바꿉니다.
- 최신 열린 review job을 파일명, dataset ID, pipeline job, 상태, 요청 시각과 함께 한 행으로 표시하고 해당 행에서 검토 화면으로 이동할 수 있게 합니다.
- 현재 API가 전체 pending review 목록이 아니라 최신 열린 review job ID와 pending count만 제공하므로, 여러 대기 건은 `검토 대기 항목 N개 중 최신 1건`으로 명시합니다.

## 검증

- `pnpm --dir frontend test -- WorkspaceUploadPage.test.tsx LogUploadForm.test.tsx`
- `pnpm --dir frontend exec eslint e2e/auth-login.spec.ts e2e/support/app-mocks.ts e2e/upload-domain-pack-generation.spec.ts src/pages/upload/ui/WorkspaceUploadPage.tsx src/pages/upload/ui/WorkspaceUploadPage.test.tsx src/features/log-upload/ui/LogUploadForm.tsx src/features/log-upload/ui/LogUploadForm.test.tsx src/features/workspace-dashboard-health/api/workspaceDashboardHealthApi.ts src/features/workspace-dashboard-health/index.ts`
- `pnpm --dir frontend exec playwright test e2e/upload-domain-pack-generation.spec.ts --config=playwright.upload-review-entry.config.ts --grep "open pipeline review exists"` (임시 4174 포트 config 사용 후 제거)
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 업로드 완료 화면에서 간단 안내 대신 상세한 상담 로그 처리 기록(헤더·요약·테이블)을 표시하도록 변경
  * 테이블에 데이터셋 파일명, 파이프라인 잡 ID 표기(JOB-...), 처리 상태 및 요청 시각을 추가하여 검토 대기 항목을 명확히 표시
  * 업로드 화면의 요약/CTA가 처리 기록 형태로 대체되어 보류 중인 리뷰 가시성이 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->