### PR TITLE
fix(ml): publish internal LLM runtime image

### DIFF
--- a/.agent/docs/deployment.md
+++ b/.agent/docs/deployment.md
@@ -90,7 +90,7 @@ GitHub repository 또는 `prod` environment에 다음 secrets를 설정한다.
 | `PROD_EMBEDDING_MODEL_NAME` | `BAAI/bge-m3` |
 | `PROD_ML_RUNTIME_PROFILE` | `balanced` |
 | `PROD_LLM_MODEL_NAME` | `Qwen/Qwen3-14B` |
-| `PROD_LLM_MODEL_PATH` | `/models/model.gguf` |
+| `PROD_LLM_MODEL_PATH` | `/models/model.gguf`; 내부 LLM service의 `/models`는 GPU task와 공유하는 EFS model cache에 mount되므로, 이 경로에 GGUF 모델 파일을 미리 배치해야 한다. |
 | `PROD_LLM_SERVICE_DESIRED_COUNT` | `0` |
 | `PROD_TOSS_CLIENT_KEY` | Toss Payments client key; frontend build에 `VITE_TOSS_CLIENT_KEY`로 주입 |
 
@@ -134,7 +134,7 @@ terraform output ecs_airflow_security_group_id
 
 - Backend 변경: Gradle `bootJar` 후 `ostone/backend` 이미지를 ECR에 push하고 ECS service를 새 task definition으로 갱신한다.
 - Frontend 변경: `pnpm build` 후 S3에 `frontend/dist/`를 sync하고 CloudFront invalidation을 생성한다.
-- ML 변경: CPU/GPU ML stage 이미지를 ECR에 push하고 Airflow 이미지를 갱신한다.
+- ML 변경: CPU/GPU ML stage 이미지와 내부 LLM runtime 이미지를 ECR에 push하고 Airflow 이미지를 갱신한다.
 - Terraform 변경: apply 후 필요한 배포 job이 Terraform output을 사용한다.
 
 인프라만 수동으로 검토/적용하려면 [`.github/workflows/terraform-cd.yml`](../../.github/workflows/terraform-cd.yml)을 수동 실행한다.

--- a/.agent/specs/824.md
+++ b/.agent/specs/824.md
@@ -1,0 +1,47 @@
+# Issue 824: Publish the internal LLM runtime image
+
+## Problem
+
+Production Airflow starts the internal `ostone-prod-ml-llm` ECS service before LLM-backed
+pipeline stages. The ECS task definition points at `ostone/ml-llm:latest`, but the production
+deploy workflow currently builds only the ML stage CPU/GPU images and the Airflow image.
+
+In production this leaves the ECR repository empty and the service fails with:
+
+```text
+CannotPullImageManifestError: manifest unknown: Requested image not found
+```
+
+## Goal
+
+The production deploy workflow must publish the image consumed by the internal LLM ECS service.
+The image must expose the runtime contract already used by Terraform and Airflow:
+
+- HTTP health check at `/health`
+- OpenAI-compatible chat completions under `/v1/chat/completions`
+- host/port controlled by `LLM_SERVER_HOST` and `LLM_SERVER_PORT`
+- model path controlled by `LLM_MODEL_PATH`
+
+## Scope
+
+- Add a production `ml-llm` container image definition.
+- Add an entrypoint that starts an OpenAI-compatible llama.cpp server using the configured model path.
+- Build and push `ostone/ml-llm` in the production deploy ML job.
+- Mount the shared EFS model cache at `/models` so the 0-to-1 GPU service lifecycle does not depend on
+  ephemeral host-local model files.
+- Keep the service desired count lifecycle unchanged; Airflow remains responsible for scaling the
+  service from 0 to 1 only when LLM stages need it.
+
+## Non-goals
+
+- Do not change prompt behavior or LLM response schemas.
+- Do not add a CPU LLM fallback path.
+- Do not bake a large model file into the repository or image.
+
+## Verification
+
+- `docker manifest inspect ghcr.io/ggml-org/llama.cpp:server-cuda`
+- `docker build -f ml/Dockerfile.llm .`
+- `terraform -chdir=infra/terraform init -backend=false`
+- `terraform -chdir=infra/terraform validate`
+- `pnpm run ci:ml`

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -474,6 +474,22 @@ jobs:
             "$ECR_REGISTRY/$ECR_REPOSITORY:latest" || true
           docker system prune -af || true
 
+      - name: Build, tag, and push ML LLM image to ECR
+        env:
+          ECR_REPOSITORY: ostone/ml-llm
+          IMAGE_TAG: ${{ github.sha }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          docker build -t "$ECR_REPOSITORY:$IMAGE_TAG" -f ml/Dockerfile.llm .
+          docker tag "$ECR_REPOSITORY:$IMAGE_TAG" "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+          docker tag "$ECR_REPOSITORY:$IMAGE_TAG" "$ECR_REGISTRY/$ECR_REPOSITORY:latest"
+          docker push --all-tags "$ECR_REGISTRY/$ECR_REPOSITORY"
+          docker image rm \
+            "$ECR_REPOSITORY:$IMAGE_TAG" \
+            "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" \
+            "$ECR_REGISTRY/$ECR_REPOSITORY:latest" || true
+          docker system prune -af || true
+
   airflow:
     needs: [paths-filter, terraform, ml]
     if: ${{ always() && (github.event_name == 'workflow_dispatch' || needs.paths-filter.outputs.airflow == 'true' || needs.paths-filter.outputs.ml == 'true') && needs.terraform.result == 'success' && (needs.ml.result == 'success' || needs.ml.result == 'skipped') }}

--- a/infra/terraform/ecs-llm.tf
+++ b/infra/terraform/ecs-llm.tf
@@ -53,8 +53,17 @@ resource "aws_ecs_task_definition" "ml_llm" {
   task_role_arn            = aws_iam_role.gpu_task.arn
 
   volume {
-    name      = "model-cache"
-    host_path = "/opt/ostone/model-cache"
+    name = "model-cache"
+
+    efs_volume_configuration {
+      file_system_id     = aws_efs_file_system.embedding_model_cache.id
+      transit_encryption = "ENABLED"
+
+      authorization_config {
+        access_point_id = aws_efs_access_point.embedding_model_cache.id
+        iam             = "ENABLED"
+      }
+    }
   }
 
   container_definitions = jsonencode([

--- a/infra/terraform/security-groups.tf
+++ b/infra/terraform/security-groups.tf
@@ -408,6 +408,16 @@ resource "aws_security_group_rule" "efs_model_cache_ingress_gpu_task" {
   protocol                 = "tcp"
 }
 
+resource "aws_security_group_rule" "efs_model_cache_ingress_ml_llm_service" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.efs_model_cache.id
+  source_security_group_id = aws_security_group.ml_llm_service.id
+  description              = "NFS traffic from the internal LLM service."
+  from_port                = 2049
+  to_port                  = 2049
+  protocol                 = "tcp"
+}
+
 resource "aws_security_group" "ml_llm_alb" {
   name        = "${local.name_prefix}-ml-llm-alb-sg"
   description = "Internal ALB for the OpenAI-compatible ML LLM service."
@@ -476,4 +486,14 @@ resource "aws_security_group_rule" "ml_llm_service_egress_https" {
   to_port           = 443
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "ml_llm_service_egress_efs_model_cache" {
+  type                     = "egress"
+  security_group_id        = aws_security_group.ml_llm_service.id
+  description              = "Allow the internal LLM service to mount the model cache EFS."
+  from_port                = 2049
+  to_port                  = 2049
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.efs_model_cache.id
 }

--- a/ml/Dockerfile.llm
+++ b/ml/Dockerfile.llm
@@ -1,0 +1,8 @@
+# OpenAI-compatible local LLM service for ECS.
+FROM ghcr.io/ggml-org/llama.cpp:server-cuda
+
+COPY ml/docker/llm-entrypoint.sh /usr/local/bin/ostone-llm-entrypoint
+
+EXPOSE 8000
+
+ENTRYPOINT ["/usr/local/bin/ostone-llm-entrypoint"]

--- a/ml/docker/llm-entrypoint.sh
+++ b/ml/docker/llm-entrypoint.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env sh
+set -eu
+
+host="${LLM_SERVER_HOST:-0.0.0.0}"
+port="${LLM_SERVER_PORT:-8000}"
+model_path="${LLM_MODEL_PATH:-/models/model.gguf}"
+
+if [ ! -f "$model_path" ]; then
+  echo "LLM model file not found: $model_path" >&2
+  echo "Mount or pre-seed a GGUF model at LLM_MODEL_PATH before starting the LLM service." >&2
+  exit 78
+fi
+
+if command -v llama-server >/dev/null 2>&1; then
+  server_bin="$(command -v llama-server)"
+elif [ -x /app/llama-server ]; then
+  server_bin="/app/llama-server"
+elif [ -x /usr/local/bin/llama-server ]; then
+  server_bin="/usr/local/bin/llama-server"
+else
+  echo "llama-server binary not found in the base image." >&2
+  exit 127
+fi
+
+ctx_size="${LLM_CONTEXT_SIZE:-8192}"
+parallel="${LLM_PARALLEL:-1}"
+n_gpu_layers="${LLM_N_GPU_LAYERS:-999}"
+model_name="${LLM_MODEL_NAME:-}"
+api_key="${LLM_RUNTIME_API_KEY:-}"
+
+set -- "$server_bin" \
+  --host "$host" \
+  --port "$port" \
+  --model "$model_path" \
+  --ctx-size "$ctx_size" \
+  --parallel "$parallel" \
+  --n-gpu-layers "$n_gpu_layers"
+
+if [ -n "$model_name" ]; then
+  set -- "$@" --alias "$model_name"
+fi
+
+if [ -n "$api_key" ]; then
+  set -- "$@" --api-key "$api_key"
+fi
+
+exec "$@"


### PR DESCRIPTION
Fixes #824

## Summary
- Add the `ml-llm` production image that starts a llama.cpp OpenAI-compatible server for the existing internal LLM ECS service contract.
- Publish `ostone/ml-llm` from the production deploy ML job so `ostone-prod-ml-llm` can pull `:latest` when Airflow scales it up.
- Mount the shared EFS model cache at `/models` for the LLM service and allow the service security group to use NFS, so the 0-to-1 GPU lifecycle does not depend on ephemeral host-local model files.
- Document the required GGUF model path behavior in the deployment guide and issue spec.

## Context
Production `pipeline_job_44` reached `start_initial_llm_service`, but ECS could not start `ostone-prod-ml-llm` because `ostone/ml-llm:latest` did not exist in ECR. The Terraform service already expected an OpenAI-compatible runtime at `/health` and `/v1/chat/completions`; this change completes the missing image and deploy path.

## Validation
- `docker manifest inspect ghcr.io/ggml-org/llama.cpp:server-cuda`
- `sh -n ml/docker/llm-entrypoint.sh`
- `docker build -f ml/Dockerfile.llm -t ostone-ml-llm:test .`
- `docker run --rm ostone-ml-llm:test` exits 78 with a clear missing-model message when `/models/model.gguf` is absent
- `terraform fmt -check infra/terraform/ecs-llm.tf infra/terraform/security-groups.tf`
- `terraform -chdir=infra/terraform init -backend=false`
- `terraform -chdir=infra/terraform validate`
- `pnpm run ci:ml`
- `git diff --check`
- `git diff --cached --check`