### PR TITLE
chore(admin): #828 슈퍼 어드민 계정 시드 및 prod 부트스트랩 자격증명 주입

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -109,6 +109,8 @@ jobs:
       TF_VAR_toss_secret_key: ${{ secrets.PROD_TOSS_SECRET_KEY }}
       TF_VAR_toss_webhook_secret: ${{ secrets.PROD_TOSS_WEBHOOK_SECRET }}
       TF_VAR_toss_billing_key_encryption_key: ${{ secrets.PROD_TOSS_BILLING_KEY_ENCRYPTION_KEY }}
+      TF_VAR_super_admin_email: ${{ vars.PROD_SUPER_ADMIN_EMAIL || 'superadmin@ajou-cstone.com' }}
+      TF_VAR_super_admin_password: ${{ secrets.PROD_SUPER_ADMIN_PASSWORD }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
@@ -161,6 +163,7 @@ jobs:
             TF_VAR_toss_secret_key
             TF_VAR_toss_webhook_secret
             TF_VAR_toss_billing_key_encryption_key
+            TF_VAR_super_admin_password
           )
           for name in "${required[@]}"; do
             test -n "${!name:-}" || { echo "$name is required"; exit 1; }

--- a/.github/workflows/terraform-cd.yml
+++ b/.github/workflows/terraform-cd.yml
@@ -48,6 +48,8 @@ jobs:
       TF_VAR_toss_secret_key: ${{ secrets.PROD_TOSS_SECRET_KEY }}
       TF_VAR_toss_webhook_secret: ${{ secrets.PROD_TOSS_WEBHOOK_SECRET }}
       TF_VAR_toss_billing_key_encryption_key: ${{ secrets.PROD_TOSS_BILLING_KEY_ENCRYPTION_KEY }}
+      TF_VAR_super_admin_email: ${{ vars.PROD_SUPER_ADMIN_EMAIL || 'superadmin@ajou-cstone.com' }}
+      TF_VAR_super_admin_password: ${{ secrets.PROD_SUPER_ADMIN_PASSWORD }}
     outputs:
       has_changes: ${{ steps.plan.outputs.has_changes }}
     steps:
@@ -103,6 +105,7 @@ jobs:
             TF_VAR_toss_secret_key
             TF_VAR_toss_webhook_secret
             TF_VAR_toss_billing_key_encryption_key
+            TF_VAR_super_admin_password
           )
           for name in "${required[@]}"; do
             test -n "${!name:-}" || { echo "$name is required"; exit 1; }
@@ -169,6 +172,8 @@ jobs:
       TF_VAR_toss_secret_key: ${{ secrets.PROD_TOSS_SECRET_KEY }}
       TF_VAR_toss_webhook_secret: ${{ secrets.PROD_TOSS_WEBHOOK_SECRET }}
       TF_VAR_toss_billing_key_encryption_key: ${{ secrets.PROD_TOSS_BILLING_KEY_ENCRYPTION_KEY }}
+      TF_VAR_super_admin_email: ${{ vars.PROD_SUPER_ADMIN_EMAIL || 'superadmin@ajou-cstone.com' }}
+      TF_VAR_super_admin_password: ${{ secrets.PROD_SUPER_ADMIN_PASSWORD }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
@@ -221,6 +226,7 @@ jobs:
             TF_VAR_toss_secret_key
             TF_VAR_toss_webhook_secret
             TF_VAR_toss_billing_key_encryption_key
+            TF_VAR_super_admin_password
           )
           for name in "${required[@]}"; do
             test -n "${!name:-}" || { echo "$name is required"; exit 1; }

--- a/README.md
+++ b/README.md
@@ -456,7 +456,9 @@ Backend는 `local` 프로필에서 springdoc 기반 OpenAPI 문서/Swagger UI를
 | --- | --- | --- | --- |
 | 액티벤처 여행 상담 (ws 1) | `activeventure.demo@ostone.local` | `demo1234` | OPERATOR |
 | 하나카드 카드 상담 (ws 2) | `hanacard.demo@ostone.local` | `demo1234` | OPERATOR |
+| 전체(글로벌 관리자) | `superadmin.demo@ostone.local` | `demo1234` | SUPER_ADMIN |
 
+- `SUPER_ADMIN` 데모 계정은 특정 워크스페이스에 종속되지 않으며, SUPER_ADMIN 전용 콘솔/관리 API(`/api/v1/admin/**`) 접근 검증용이다.
 - **로컬 데모 전용** 계정이다. 환경별 secret(`JWT_SECRET` 등)과 혼동하지 않는다.
 - 로그인이 안 되면: ① 활성 프로필이 `local` 또는 `dev`인지 확인 → ② backend 로그에서 `ActiveVentureDomainPackSeedRunner`의 `Seed demo account ...` 라인 확인 → ③ DB `app.app_user` / `app.workspace_member` 행 확인.
 - 비밀번호는 seed runner의 `DEMO_SIGN_IN_VALUE` 상수에서 정의된다. 코드와 본 표의 일치는 `scripts/demo-credentials-consistency.test.mjs`가 CI에서 검증한다.

--- a/backend/src/main/java/com/init/domainpack/infrastructure/ActiveVentureDomainPackSeedRunner.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/ActiveVentureDomainPackSeedRunner.java
@@ -59,6 +59,8 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
       LoggerFactory.getLogger(ActiveVentureDomainPackSeedRunner.class);
   private static final String DESCRIPTION_FIELD = "description";
   private static final String DEMO_SIGN_IN_VALUE = String.join("", "demo", "1234");
+  private static final String SUPER_ADMIN_DEMO_EMAIL = "superadmin.demo@ostone.local";
+  private static final String SUPER_ADMIN_DEMO_NAME = "슈퍼 어드민 데모 계정";
   private static final List<SeedConfig> SEED_CONFIGS =
       List.of(
           new SeedConfig(
@@ -242,8 +244,40 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
           accountConfig.email(),
           accountConfig.workspaceId());
     }
+    seedSuperAdminAccount();
     resetAppUserSequence();
     resetWorkspaceMemberSequence();
+  }
+
+  // 워크스페이스에 종속되지 않는 글로벌 SUPER_ADMIN 데모 계정을 멱등 upsert 한다.
+  // SUPER_ADMIN 전용 콘솔/관리 API 로컬 시연·검증용이며, 운영자 데모 계정과 동일한
+  // DEMO_SIGN_IN_VALUE 비밀번호를 사용한다(workspace_member 매핑은 만들지 않는다).
+  private void seedSuperAdminAccount() {
+    entityManager
+        .createNativeQuery(
+            """
+            INSERT INTO app.app_user (
+              email, name, password_hash, password_reset_required, role, status, profile_json
+            )
+            VALUES (
+              :email, :name, :credentialHash, false, 'SUPER_ADMIN', 'ACTIVE', '{}'::jsonb
+            )
+            ON CONFLICT (email) DO UPDATE
+              SET name = EXCLUDED.name,
+                  password_hash = EXCLUDED.password_hash,
+                  password_reset_required = false,
+                  role = 'SUPER_ADMIN',
+                  status = 'ACTIVE',
+                  profile_json = '{}'::jsonb,
+                  password_reset_token_hash = null,
+                  password_reset_token_expires_at = null,
+                  updated_at = now()
+            """)
+        .setParameter("email", SUPER_ADMIN_DEMO_EMAIL)
+        .setParameter("name", SUPER_ADMIN_DEMO_NAME)
+        .setParameter("credentialHash", passwordEncoder.encode(DEMO_SIGN_IN_VALUE))
+        .executeUpdate();
+    log.info("Seed super admin demo account '{}'", SUPER_ADMIN_DEMO_EMAIL);
   }
 
   private Long upsertDemoUser(DemoAccountConfig accountConfig) {

--- a/infra/terraform/ecs-cluster.tf
+++ b/infra/terraform/ecs-cluster.tf
@@ -61,6 +61,16 @@ resource "aws_ecs_task_definition" "backend" {
           value = "8080"
         },
         {
+          # 최초 기동 시 SUPER_ADMIN 계정이 없으면 SuperAdminBootstrapRunner가
+          # 이 이메일 + SUPER_ADMIN_PASSWORD(시크릿)로 1회 생성한다(이미 있으면 건너뜀).
+          name  = "SUPER_ADMIN_EMAIL"
+          value = var.super_admin_email
+        },
+        {
+          name  = "SUPER_ADMIN_NAME"
+          value = var.super_admin_name
+        },
+        {
           name  = "DB_HOST"
           value = aws_db_instance.postgres.address
         },
@@ -202,6 +212,10 @@ resource "aws_ecs_task_definition" "backend" {
         {
           name      = "TOSS_BILLING_KEY_ENCRYPTION_KEY"
           valueFrom = "${aws_secretsmanager_secret.app.arn}:toss_billing_key_encryption_key::"
+        },
+        {
+          name      = "SUPER_ADMIN_PASSWORD"
+          valueFrom = "${aws_secretsmanager_secret.app.arn}:super_admin_password::"
         }
       ]
 

--- a/infra/terraform/secrets.tf
+++ b/infra/terraform/secrets.tf
@@ -42,6 +42,7 @@ resource "aws_secretsmanager_secret_version" "app" {
     toss_secret_key                = var.toss_secret_key
     toss_webhook_secret            = var.toss_webhook_secret
     toss_billing_key_encryption_key = var.toss_billing_key_encryption_key
+    super_admin_password           = var.super_admin_password
   })
 }
 

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -20,6 +20,12 @@ toss_secret_key                 = "replace-with-toss-api-secret-key"
 toss_webhook_secret             = "replace-with-toss-webhook-secret"
 toss_billing_key_encryption_key = "replace-with-billing-key-encryption-key"
 
+# 최초 기동 시 SUPER_ADMIN 계정이 없으면 SuperAdminBootstrapRunner가 생성한다(멱등).
+# super_admin_email/name 은 기본값이 있어 선택, super_admin_password 는 필수(8-72 UTF-8 bytes).
+# super_admin_email    = "superadmin@ajou-cstone.com"
+# super_admin_name     = "Super Admin"
+super_admin_password = "replace-with-secure-super-admin-password"
+
 backend_desired_count = 0
 backend_autoscaling_min_capacity = 0
 backend_autoscaling_max_capacity = 3

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -333,6 +333,24 @@ variable "toss_billing_key_encryption_key" {
   sensitive   = true
 }
 
+variable "super_admin_email" {
+  description = "Email for the bootstrap SUPER_ADMIN account created on first backend startup."
+  type        = string
+  default     = "superadmin@ajou-cstone.com"
+}
+
+variable "super_admin_name" {
+  description = "Display name for the bootstrap SUPER_ADMIN account."
+  type        = string
+  default     = "Super Admin"
+}
+
+variable "super_admin_password" {
+  description = "Password for the bootstrap SUPER_ADMIN account (8-72 UTF-8 bytes). Empty disables bootstrap creation."
+  type        = string
+  sensitive   = true
+}
+
 variable "airflow_api_desired_count" {
   description = "Desired ECS task count for Airflow API server."
   type        = number

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -349,6 +349,16 @@ variable "super_admin_password" {
   description = "Password for the bootstrap SUPER_ADMIN account (8-72 UTF-8 bytes). Empty disables bootstrap creation."
   type        = string
   sensitive   = true
+
+  validation {
+    # 빈 값이면 부트스트랩을 비활성화하고, 그 외에는 8-72자를 강제한다.
+    # (Terraform length()는 UTF-8 바이트가 아닌 문자 수 기준이므로 대부분의 입력 실수만 사전 차단)
+    condition = (
+      var.super_admin_password == "" ||
+      (length(var.super_admin_password) >= 8 && length(var.super_admin_password) <= 72)
+    )
+    error_message = "super_admin_password must be empty (to disable bootstrap) or 8-72 characters."
+  }
 }
 
 variable "airflow_api_desired_count" {


### PR DESCRIPTION
## 개요
이슈 #828 — 슈퍼 어드민 계정 생성 seed.

`SUPER_ADMIN` 역할은 enum/DB에 이미 존재하지만, 실제 계정을 만들어주는 시드가 없었다. 환경별로 두 경로를 추가한다.

## 변경 내용

### local/dev — 데모 시드 (검증 완료)
- `ActiveVentureDomainPackSeedRunner`에 워크스페이스 비종속 `SUPER_ADMIN` 데모 계정(`superadmin.demo@ostone.local` / `demo1234`)을 멱등 upsert로 추가.
- README 데모 계정 표에 행 추가 (`scripts/demo-credentials-consistency.test.mjs`가 일치 검증).

### prod — 시크릿 기반 부트스트랩
기존 env 기반 `SuperAdminBootstrapRunner`(프로필 무관)가 최초 기동 시 `SUPER_ADMIN`이 없으면 계정을 생성하도록 자격증명을 주입한다. **비밀번호는 코드에 두지 않고 Secrets Manager로만 공급.**
- `infra/terraform/variables.tf`: `super_admin_email`(기본값), `super_admin_name`(기본값), `super_admin_password`(필수, sensitive)
- `infra/terraform/secrets.tf`: app 시크릿에 `super_admin_password` 추가
- `infra/terraform/ecs-cluster.tf`: backend 태스크에 `SUPER_ADMIN_EMAIL`/`SUPER_ADMIN_NAME`(env) + `SUPER_ADMIN_PASSWORD`(secret)
- `prod-deploy.yml`, `terraform-cd.yml`: `TF_VAR_super_admin_email/password` 주입 + 필수값 검증 등록
- `terraform.tfvars.example`: 예시 문서화

## 배포 전 필요한 설정 (저장소 Actions)
- **Secret** `PROD_SUPER_ADMIN_PASSWORD` (필수, 8~72 bytes) — 없으면 배포 필수값 검증 실패
- **Variable** `PROD_SUPER_ADMIN_EMAIL` (선택, 미설정 시 `superadmin@ajou-cstone.com`)

## 검증
- local 기동 → `superadmin.demo@ostone.local` / `demo1234` 로그인 → 응답 `role: SUPER_ADMIN`, accessToken 발급 확인
- 해당 토큰으로 `POST /api/v1/admin/super-admins` (SUPER_ADMIN 전용) → HTTP 201
- prod: DB에 SUPER_ADMIN이 하나도 없을 때만 생성됨(멱등).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 글로벌 SUPER_ADMIN(슈퍼 관리자) 계정 부트스트랩 및 전역 관리자 역할 도입
  * 런타임에 슈퍼 관리자 자격을 컨테이너 환경 및 시크릿으로 주입하도록 구성

* **Chores**
  * 배포 워크플로우에서 슈퍼 관리자 이메일/비밀번호를 필수 환경 변수로 검증하도록 강화
  * 인프라 변수에 슈퍼 관리자 이메일/이름/비밀번호 옵션 추가

* **Documentation**
  * 로컬 데모에 슈퍼 관리자 계정 정보 및 접근 설명 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->