### PR TITLE
fix(admin): #844 관리자 목록 API NULL 검색 파라미터 타입 캐스팅

### DIFF
--- a/.agent/specs/844.md
+++ b/.agent/specs/844.md
@@ -1,0 +1,45 @@
+# [BE-844] 슈퍼어드민 관리자 목록 API 500 — NULL 검색 파라미터 타입 미결정
+
+> **Backlog**: 슈퍼어드민 콘솔의 고객사 현황·파이프라인 목록 페이지가 서버 오류 없이 정상적으로 열려야 한다.
+> **Layer**: Backend
+> **Branch**: `fix/844-admin-list-null-param`
+> **Verified existing paths**: `backend/src/main/java/com/init/workspace/infrastructure/persistence/JdbcAdminCustomerQueryAdapter.java`, `backend/src/main/java/com/init/pipelinejob/infrastructure/persistence/JpaPipelineJobRepository.java`
+
+---
+
+## Goal
+
+`GET /api/v1/admin/customers`, `GET /api/v1/admin/pipeline-jobs`를 검색/필터 없이 호출해도(파라미터 NULL) 500 없이 목록을 반환한다.
+
+---
+
+## Current State
+
+두 목록 쿼리는 검색 파라미터가 비면 타입이 지정되지 않은 SQL NULL로 바인딩되고, PostgreSQL이 파라미터 타입을 추론하지 못해 실패한다.
+
+- `JdbcAdminCustomerQueryAdapter`: `WHERE (:search IS NULL OR LOWER(w.name) LIKE :search ...)`
+  → `42P18: could not determine data type of parameter $1`
+- `JpaPipelineJobRepository#findAdminPipelineJobs`: `lower(j.airflowDagId) like lower(concat('%', :dagId, '%'))`
+  → 타입 미지정 null이 `bytea`로 해석 → `42883: function lower(bytea) does not exist`
+
+그동안 prod에 SUPER_ADMIN 계정이 없어 호출된 적이 없어 잠복해 있던 버그이며, #828로 슈퍼어드민 계정이 생기면서 노출되었다.
+
+---
+
+## Target Flow
+
+검색/필터 문자열 파라미터에 명시적 text 캐스팅을 추가해 PostgreSQL이 타입을 결정할 수 있게 한다.
+
+- customer 네이티브 SQL: `:search` → `CAST(:search AS text)`, `:status` → `CAST(:status AS text)`
+- pipeline JPQL: `:dagId`/`:runId`/`:status` → `cast(:param as string)`
+
+동작은 동일(NULL이면 전체 조회, 값이 있으면 부분일치/일치)하며, 캐스팅만 추가한다.
+
+---
+
+## Acceptance
+
+- [ ] SUPER_ADMIN 토큰으로 `GET /api/v1/admin/customers` → 200, 목록 반환
+- [ ] SUPER_ADMIN 토큰으로 `GET /api/v1/admin/pipeline-jobs` → 200, 목록 반환
+- [ ] 검색 파라미터(`q`/`search`, `status`, `dagId`, `runId`)를 준 경우에도 정상 필터링
+- [ ] `./gradlew spotlessCheck` 통과

--- a/backend/src/main/java/com/init/pipelinejob/infrastructure/persistence/JpaPipelineJobRepository.java
+++ b/backend/src/main/java/com/init/pipelinejob/infrastructure/persistence/JpaPipelineJobRepository.java
@@ -51,10 +51,10 @@ public interface JpaPipelineJobRepository
       """
       select j
       from PipelineJob j
-      where (:status is null or j.status = :status)
+      where (cast(:status as string) is null or j.status = cast(:status as string))
         and (:workspaceId is null or j.workspaceId = :workspaceId)
-        and (:dagId is null or lower(j.airflowDagId) like lower(concat('%', :dagId, '%')))
-        and (:runId is null or lower(j.airflowRunId) like lower(concat('%', :runId, '%')))
+        and (cast(:dagId as string) is null or lower(j.airflowDagId) like lower(concat('%', cast(:dagId as string), '%')))
+        and (cast(:runId as string) is null or lower(j.airflowRunId) like lower(concat('%', cast(:runId as string), '%')))
       order by j.requestedAt desc
       """)
   Page<PipelineJob> findAdminPipelineJobs(

--- a/backend/src/main/java/com/init/workspace/infrastructure/persistence/JdbcAdminCustomerQueryAdapter.java
+++ b/backend/src/main/java/com/init/workspace/infrastructure/persistence/JdbcAdminCustomerQueryAdapter.java
@@ -82,8 +82,10 @@ public class JdbcAdminCustomerQueryAdapter implements AdminCustomerQueryPort {
               ORDER BY requested_at DESC, id DESC
               LIMIT 1
             ) pj ON TRUE
-            WHERE (:search IS NULL OR LOWER(w.name) LIKE :search OR LOWER(w.workspace_key) LIKE :search)
-              AND (:status IS NULL OR w.status = :status)
+            WHERE (CAST(:search AS text) IS NULL
+                   OR LOWER(w.name) LIKE CAST(:search AS text)
+                   OR LOWER(w.workspace_key) LIKE CAST(:search AS text))
+              AND (CAST(:status AS text) IS NULL OR w.status = CAST(:status AS text))
             ORDER BY w.id DESC
             LIMIT :limit OFFSET :offset
             """,


### PR DESCRIPTION
## 개요
이슈 #844 — 슈퍼어드민 콘솔의 고객사 현황·파이프라인 목록 페이지가 500(서버 오류)을 내던 문제 수정.

## 근본 원인
검색/필터 없이 목록을 조회하면 문자열 파라미터가 **타입이 지정되지 않은 SQL NULL**로 바인딩되고, PostgreSQL이 파라미터 타입을 추론하지 못해 쿼리가 실패했다.
- `GET /api/v1/admin/customers` → `42P18: could not determine data type of parameter $1`
- `GET /api/v1/admin/pipeline-jobs` → 타입 미지정 null이 `bytea`로 해석 → `42883: function lower(bytea) does not exist`

그동안 prod에 SUPER_ADMIN 계정이 없어 이 페이지가 호출된 적이 없어 잠복해 있던 버그이며, #828로 슈퍼어드민 계정이 생기면서 노출됐다.

## 변경
- `JdbcAdminCustomerQueryAdapter`: `:search`/`:status`를 `CAST(... AS text)`로 캐스팅
- `JpaPipelineJobRepository#findAdminPipelineJobs`(JPQL): `:status`/`:dagId`/`:runId`를 `cast(... as string)`으로 캐스팅
- 동작은 동일(NULL이면 전체, 값 있으면 필터링), 캐스팅만 추가

## 검증 (로컬 재현)
| 호출 | 수정 전 | 수정 후 |
|---|---|---|
| `GET /admin/customers` (필터 없음) | 500 | **200** |
| `GET /admin/customers?q=demo&status=ACTIVE` | 500 | **200** |
| `GET /admin/pipeline-jobs` (필터 없음) | 500 | **200** |
| `GET /admin/pipeline-jobs?dagId=domain&status=QUEUED` | 500 | **200** |

`./gradlew spotlessCheck` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 고객사 및 파이프라인 관리자 목록 조회 시 검색/필터 파라미터 처리 안정화
  * 검색 파라미터 없이 API 호출 시 발생하던 오류 해결
  * 필터링 및 검색 기능의 안정성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->