### PR TITLE
fix(auth): #846 슈퍼어드민의 일반 워크스페이스 화면 진입 차단

### DIFF
--- a/.agent/specs/846.md
+++ b/.agent/specs/846.md
@@ -1,0 +1,40 @@
+# [FE-846] 슈퍼어드민 계정이 일반 워크스페이스 화면에 진입 가능 — 라우트 가드 부재
+
+> **Backlog**: 슈퍼어드민 계정은 슈퍼어드민 화면(`/admin/*`)에만 접근 가능해야 한다.
+> **Layer**: Frontend
+> **Branch**: `fix/846-super-admin-route-guard`
+> **Verified existing paths**: `frontend/src/shared/ui/PrivateRoute.tsx`, `frontend/src/shared/ui/PrivateRoute.test.tsx`, `frontend/src/shared/lib/auth.ts`
+
+---
+
+## Goal
+
+인증된 슈퍼어드민(`SUPER_ADMIN`)이 일반 보호 라우트(`/workspaces`, `/billing`, `/chat` 등)에 진입하면 `/admin`으로 리다이렉트되어, 슈퍼어드민 화면에만 접근하도록 한다.
+
+---
+
+## Current State
+
+배포 환경에서 슈퍼어드민 계정으로 로그인 후 루트 URL(`/`)로 접근하면 `/workspaces`로 리다이렉트되어 일반 role 사용자처럼 워크스페이스에 진입된다.
+
+- `PrivateRoute`(`frontend/src/shared/ui/PrivateRoute.tsx`)에는 비-슈퍼어드민이 `/admin`에 접근하는 것을 막는 `RequireSuperAdmin` 가드만 존재한다.
+- 반대로 슈퍼어드민이 일반 보호 라우트에 진입하는 것을 막는 가드가 없어, `/` → `/workspaces` 리다이렉트 시 인증만 확인되고 그대로 통과된다.
+
+---
+
+## Target Flow
+
+`PrivateRoute`에 슈퍼어드민 차단 가드를 추가한다.
+
+- `PrivateRoute`에 `allowSuperAdmin?: boolean` prop 추가(기본값 `false`)
+  - 인증된 사용자가 슈퍼어드민이고 `allowSuperAdmin`이 `false`면 `/admin`으로 `Navigate`
+- `AdminRoute`는 `allowSuperAdmin`을 지정해 예외 처리(무한 리다이렉트 방지)
+
+---
+
+## Acceptance
+
+- [ ] SUPER_ADMIN으로 `/admin/*` 접근 → 정상 진입
+- [ ] SUPER_ADMIN으로 `/workspaces` 등 일반 보호 라우트 접근 → `/admin`으로 리다이렉트
+- [ ] OPERATOR/ADMIN/OWNER 등 비-슈퍼어드민 → 기존대로 일반 보호 라우트 접근, `/admin`은 `/workspaces`로 리다이렉트
+- [ ] `vp test run src/shared/ui/PrivateRoute.test.tsx` 통과

--- a/frontend/src/shared/ui/PrivateRoute.test.tsx
+++ b/frontend/src/shared/ui/PrivateRoute.test.tsx
@@ -71,6 +71,33 @@ describe("PrivateRoute", () => {
     );
   });
 
+  it("SUPER_ADMIN이면 보호 화면 대신 관리자 화면으로 이동한다", () => {
+    localStorage.setItem("accessToken", createAccessToken(3600, "SUPER_ADMIN"));
+    localStorage.setItem(
+      "user",
+      JSON.stringify({ id: 1, email: "superadmin@ostone.com", name: "슈퍼관리자", role: "SUPER_ADMIN" }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/private"]}>
+        <Routes>
+          <Route
+            path="/private"
+            element={
+              <PrivateRoute>
+                <div>보호 화면</div>
+              </PrivateRoute>
+            }
+          />
+          <Route path="/admin" element={<div>관리자 화면</div>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("관리자 화면")).toBeInTheDocument();
+    expect(screen.queryByText("보호 화면")).not.toBeInTheDocument();
+  });
+
   it("refresh cookie 갱신에 실패하면 session을 정리하고 login으로 이동한다", async () => {
     localStorage.setItem("accessToken", createAccessToken(-60));
     localStorage.setItem("refreshToken", "legacy-expired-refresh-token");

--- a/frontend/src/shared/ui/PrivateRoute.tsx
+++ b/frontend/src/shared/ui/PrivateRoute.tsx
@@ -5,13 +5,20 @@ import { clearAuthSession, isAuthenticated, isSuperAdmin } from "../lib/auth";
 
 interface PrivateRouteProps {
   children: React.ReactNode;
+  /**
+   * 슈퍼어드민의 접근 허용 여부입니다. 기본값은 `false`로, 슈퍼어드민은
+   * 일반 보호 라우트 접근 시 `/admin`으로 리다이렉트됩니다. 관리자 전용
+   * 라우트(`AdminRoute`)에서만 `true`로 설정합니다.
+   */
+  allowSuperAdmin?: boolean;
 }
 
 /**
  * 인증된 사용자만 접근할 수 있도록 보호하는 라우트 컴포넌트입니다.
  * 인증되지 않은 사용자는 로그인 페이지로 리다이렉트됩니다.
+ * 슈퍼어드민은 별도로 허용하지 않는 한 관리자 화면(`/admin`)으로 리다이렉트됩니다.
  */
-export const PrivateRoute: React.FC<PrivateRouteProps> = ({ children }) => {
+export const PrivateRoute: React.FC<PrivateRouteProps> = ({ children, allowSuperAdmin = false }) => {
   const location = useLocation();
   const [isAuthorized, setIsAuthorized] = useState<boolean | null>(() =>
     isAuthenticated() ? true : null,
@@ -49,12 +56,16 @@ export const PrivateRoute: React.FC<PrivateRouteProps> = ({ children }) => {
     return <Navigate to="/login" state={{ from: location }} replace />;
   }
 
+  if (!allowSuperAdmin && isSuperAdmin()) {
+    return <Navigate to="/admin" replace />;
+  }
+
   return <>{children}</>;
 };
 
 export const AdminRoute: React.FC<PrivateRouteProps> = ({ children }) => {
   return (
-    <PrivateRoute>
+    <PrivateRoute allowSuperAdmin>
       <RequireSuperAdmin>{children}</RequireSuperAdmin>
     </PrivateRoute>
   );


### PR DESCRIPTION
## 개요

Closes #846

배포 환경에서 슈퍼어드민 계정으로 로그인 후 루트 URL(`/`)로 접근하면 일반 role 사용자처럼 워크스페이스에 진입되던 문제를 수정합니다. 슈퍼어드민은 슈퍼어드민 화면(`/admin/*`)에만 접근 가능해야 합니다.

## 원인

`PrivateRoute`에는 비-슈퍼어드민이 `/admin`에 접근하는 것을 막는 `RequireSuperAdmin` 가드만 있었고, **반대 방향(슈퍼어드민이 일반 보호 라우트에 진입하는 것)을 막는 가드가 없었습니다.** `/` → `/workspaces` 리다이렉트 시 `PrivateRoute`가 인증 여부만 확인하므로 슈퍼어드민도 그대로 통과되었습니다.

## 변경 사항

- `PrivateRoute`에 `allowSuperAdmin` prop 추가 (기본값 `false`)
  - 인증된 슈퍼어드민이 일반 보호 라우트(`/workspaces`, `/billing`, `/chat` 등)에 진입하면 `/admin`으로 리다이렉트
- `AdminRoute`는 `allowSuperAdmin`을 지정해 예외 처리 (무한 리다이렉트 방지)
- `PrivateRoute.test.tsx`: 슈퍼어드민이 보호 화면 대신 `/admin`으로 이동하는 테스트 추가

## 테스트

- `vp test run src/shared/ui/PrivateRoute.test.tsx` → 6/6 통과
- 변경 파일 eslint clean

## 기대 동작

| role | `/admin/*` | `/workspaces` 등 일반 보호 라우트 |
|------|-----------|------------------------------|
| SUPER_ADMIN | ✅ 접근 | ➡️ `/admin`으로 리다이렉트 |
| OPERATOR/ADMIN/OWNER | ➡️ `/workspaces`로 리다이렉트 | ✅ 접근 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * 슈퍼 관리자 역할에 따른 보호 라우트 동작을 검증하는 테스트 케이스 추가

* **Bug Fixes**
  * 슈퍼 관리자 사용자가 일반 보호 라우트 접근 시 관리자 페이지로 리다이렉트되도록 동작 개선
  * 관리자 전용 라우트에서 슈퍼 관리자 예외 처리가 올바르게 적용되도록 수정

* **Documentation**
  * 라우트 접근 흐름과 기대 동작을 정리한 설명 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->