### PR TITLE
chore(admin): 데모 로그인 계정을 prod 프로파일에서도 시드

### DIFF
--- a/backend/src/main/java/com/init/auth/infrastructure/SuperAdminBootstrapRunner.java
+++ b/backend/src/main/java/com/init/auth/infrastructure/SuperAdminBootstrapRunner.java
@@ -9,11 +9,16 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+// env/secret 기반 운영 SUPER_ADMIN 을 먼저 생성하도록 DemoAccountSeedRunner(-50)보다 앞선 순서로 고정한다.
+// 데모 SUPER_ADMIN 이 먼저 들어가면 existsByRole 가드에 걸려 운영 계정이 누락되므로, 둘의 공존을 위해 순서가 중요하다.
 @Component
+@Order(Ordered.LOWEST_PRECEDENCE - 60)
 public class SuperAdminBootstrapRunner implements ApplicationRunner {
 
   private static final Logger log = LoggerFactory.getLogger(SuperAdminBootstrapRunner.class);

--- a/backend/src/main/java/com/init/domainpack/infrastructure/ActiveVentureDomainPackSeedRunner.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/ActiveVentureDomainPackSeedRunner.java
@@ -46,7 +46,6 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.io.ClassPathResource;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -58,9 +57,6 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
   private static final Logger log =
       LoggerFactory.getLogger(ActiveVentureDomainPackSeedRunner.class);
   private static final String DESCRIPTION_FIELD = "description";
-  private static final String DEMO_SIGN_IN_VALUE = String.join("", "demo", "1234");
-  private static final String SUPER_ADMIN_DEMO_EMAIL = "superadmin.demo@ostone.local";
-  private static final String SUPER_ADMIN_DEMO_NAME = "슈퍼 어드민 데모 계정";
   private static final List<SeedConfig> SEED_CONFIGS =
       List.of(
           new SeedConfig(
@@ -87,10 +83,6 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
                   "card_loan_and_cash_advance_management_flow",
                   "card_limit_management_flow",
                   "digital_payment_service_registration_flow")));
-  private static final List<DemoAccountConfig> DEMO_ACCOUNT_CONFIGS =
-      List.of(
-          new DemoAccountConfig(1L, "activeventure.demo@ostone.local", "액티벤처 데모 사용자"),
-          new DemoAccountConfig(2L, "hanacard.demo@ostone.local", "하나카드 데모 사용자"));
 
   private final DomainPackCommandRepository domainPackRepository;
   private final DomainPackVersionRepository domainPackVersionRepository;
@@ -103,7 +95,6 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
   private final WorkflowMatchingProfileBuildRequestService profileBuildRequestService;
   private final EntityManager entityManager;
   private final ObjectMapper objectMapper;
-  private final PasswordEncoder passwordEncoder;
 
   public ActiveVentureDomainPackSeedRunner(
       DomainPackCommandRepository domainPackRepository,
@@ -116,8 +107,7 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
       IntentSlotBindingRepository intentSlotBindingRepository,
       WorkflowMatchingProfileBuildRequestService profileBuildRequestService,
       EntityManager entityManager,
-      ObjectMapper objectMapper,
-      PasswordEncoder passwordEncoder) {
+      ObjectMapper objectMapper) {
     this.domainPackRepository = domainPackRepository;
     this.domainPackVersionRepository = domainPackVersionRepository;
     this.intentDefinitionRepository = intentDefinitionRepository;
@@ -129,7 +119,6 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
     this.profileBuildRequestService = profileBuildRequestService;
     this.entityManager = entityManager;
     this.objectMapper = objectMapper;
-    this.passwordEncoder = passwordEncoder;
   }
 
   @Override
@@ -138,7 +127,6 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
     for (SeedConfig seedConfig : SEED_CONFIGS) {
       seed(seedConfig);
     }
-    seedDemoAccounts();
   }
 
   private void seed(SeedConfig seedConfig) {
@@ -232,124 +220,6 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
     entityManager
         .createNativeQuery(
             "SELECT setval('app.workspace_id_seq', (SELECT COALESCE(MAX(id), 1) FROM app.workspace), true)")
-        .getSingleResult();
-  }
-
-  private void seedDemoAccounts() {
-    for (DemoAccountConfig accountConfig : DEMO_ACCOUNT_CONFIGS) {
-      Long userId = upsertDemoUser(accountConfig);
-      upsertDemoMembership(accountConfig.workspaceId(), userId);
-      log.info(
-          "Seed demo account '{}' mapped to workspace {}",
-          accountConfig.email(),
-          accountConfig.workspaceId());
-    }
-    seedSuperAdminAccount();
-    resetAppUserSequence();
-    resetWorkspaceMemberSequence();
-  }
-
-  // 워크스페이스에 종속되지 않는 글로벌 SUPER_ADMIN 데모 계정을 멱등 upsert 한다.
-  // SUPER_ADMIN 전용 콘솔/관리 API 로컬 시연·검증용이며, 운영자 데모 계정과 동일한
-  // DEMO_SIGN_IN_VALUE 비밀번호를 사용한다(workspace_member 매핑은 만들지 않는다).
-  private void seedSuperAdminAccount() {
-    entityManager
-        .createNativeQuery(
-            """
-            INSERT INTO app.app_user (
-              email, name, password_hash, password_reset_required, role, status, profile_json
-            )
-            VALUES (
-              :email, :name, :credentialHash, false, 'SUPER_ADMIN', 'ACTIVE', '{}'::jsonb
-            )
-            ON CONFLICT (email) DO UPDATE
-              SET name = EXCLUDED.name,
-                  password_hash = EXCLUDED.password_hash,
-                  password_reset_required = false,
-                  role = 'SUPER_ADMIN',
-                  status = 'ACTIVE',
-                  profile_json = '{}'::jsonb,
-                  password_reset_token_hash = null,
-                  password_reset_token_expires_at = null,
-                  updated_at = now()
-            """)
-        .setParameter("email", SUPER_ADMIN_DEMO_EMAIL)
-        .setParameter("name", SUPER_ADMIN_DEMO_NAME)
-        .setParameter("credentialHash", passwordEncoder.encode(DEMO_SIGN_IN_VALUE))
-        .executeUpdate();
-    log.info("Seed super admin demo account '{}'", SUPER_ADMIN_DEMO_EMAIL);
-  }
-
-  private Long upsertDemoUser(DemoAccountConfig accountConfig) {
-    Object result =
-        entityManager
-            .createNativeQuery(
-                """
-                INSERT INTO app.app_user (
-                  email, name, password_hash, password_reset_required, role, status, profile_json
-                )
-                VALUES (
-                  :email, :name, :credentialHash, false, 'OPERATOR', 'ACTIVE', '{}'::jsonb
-                )
-                ON CONFLICT (email) DO UPDATE
-                  SET name = EXCLUDED.name,
-                      password_hash = EXCLUDED.password_hash,
-                      password_reset_required = false,
-                      role = 'OPERATOR',
-                      status = 'ACTIVE',
-                      profile_json = '{}'::jsonb,
-                      password_reset_token_hash = null,
-                      password_reset_token_expires_at = null,
-                      updated_at = now()
-                RETURNING id
-            """)
-            .setParameter("email", accountConfig.email())
-            .setParameter("name", accountConfig.name())
-            .setParameter("credentialHash", passwordEncoder.encode(DEMO_SIGN_IN_VALUE))
-            .getSingleResult();
-    if (result instanceof Number number) {
-      return number.longValue();
-    }
-    throw new IllegalStateException("Demo account upsert did not return a numeric user id");
-  }
-
-  private void upsertDemoMembership(Long workspaceId, Long userId) {
-    entityManager
-        .createNativeQuery(
-            """
-            INSERT INTO app.workspace_member (workspace_id, user_id, member_role)
-            VALUES (:workspaceId, :userId, 'OPERATOR')
-            ON CONFLICT (workspace_id, user_id) DO UPDATE
-              SET member_role = EXCLUDED.member_role
-            """)
-        .setParameter("workspaceId", workspaceId)
-        .setParameter("userId", userId)
-        .executeUpdate();
-  }
-
-  private void resetAppUserSequence() {
-    entityManager
-        .createNativeQuery(
-            """
-            SELECT setval(
-              'app.app_user_id_seq',
-              (SELECT COALESCE(MAX(id), 1) FROM app.app_user),
-              true
-            )
-            """)
-        .getSingleResult();
-  }
-
-  private void resetWorkspaceMemberSequence() {
-    entityManager
-        .createNativeQuery(
-            """
-            SELECT setval(
-              'app.workspace_member_id_seq',
-              (SELECT COALESCE(MAX(id), 1) FROM app.workspace_member),
-              true
-            )
-            """)
         .getSingleResult();
   }
 
@@ -1055,6 +925,4 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
       String description,
       String profileBuildSource,
       Set<String> policyHandoffWorkflowCodes) {}
-
-  private record DemoAccountConfig(Long workspaceId, String email, String name) {}
 }

--- a/backend/src/main/java/com/init/domainpack/infrastructure/DemoAccountSeedRunner.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/DemoAccountSeedRunner.java
@@ -1,0 +1,215 @@
+package com.init.domainpack.infrastructure;
+
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 데모 로그인 계정(OPERATOR 2개 + SUPER_ADMIN 1개)과 그 소속 워크스페이스(1·2)를 멱등 시드한다.
+ *
+ * <p>도메인팩 본문 시드는 {@link ActiveVentureDomainPackSeedRunner}(local/dev 전용)가 담당하고, 이 러너는 계정/멤버십만 다룬다.
+ * {@code app.workspace} · {@code app.app_user} · {@code app.workspace_member}만 건드리므로 {@code
+ * domain_pack_version} 의존이 없어 prod 프로파일에서도 안전하게 실행된다.
+ *
+ * <p>prod 에서는 {@code SuperAdminBootstrapRunner}(env/secret 기반)가 먼저 실행되어 운영용 SUPER_ADMIN 을 만든 뒤, 이
+ * 러너가 데모 SUPER_ADMIN 을 추가로 upsert 한다(둘은 공존). 두 러너의 선후는 @Order 로 고정한다.
+ */
+@Component
+@Profile({"local", "dev", "prod"})
+@Order(Ordered.LOWEST_PRECEDENCE - 50)
+public class DemoAccountSeedRunner implements ApplicationRunner {
+
+  private static final Logger log = LoggerFactory.getLogger(DemoAccountSeedRunner.class);
+  private static final String DESCRIPTION_FIELD = "description";
+  private static final String DEMO_SIGN_IN_VALUE = String.join("", "demo", "1234");
+  private static final String SUPER_ADMIN_DEMO_EMAIL = "superadmin.demo@ostone.local";
+  private static final String SUPER_ADMIN_DEMO_NAME = "슈퍼 어드민 데모 계정";
+
+  // 워크스페이스 정체성(id/key/name)은 ActiveVentureDomainPackSeedRunner 의 SEED_CONFIGS 와 동일해야 한다.
+  // 도메인팩 시더가 돌지 않는 prod 에서도 OPERATOR 멤버십 FK 가 유효하도록 여기서 워크스페이스 존재를 보장한다.
+  private static final List<DemoWorkspaceConfig> DEMO_WORKSPACE_CONFIGS =
+      List.of(
+          new DemoWorkspaceConfig(
+              1L, "WS-DEMO", "액티벤처 여행 상담 워크스페이스", "액티벤처 여행 상담 도메인팩 로컬 시연용 워크스페이스"),
+          new DemoWorkspaceConfig(
+              2L,
+              "WS-HANACARD-DEMO",
+              "하나카드 카드 상담 워크스페이스",
+              "하나카드 상담 로그에서 추출한 카드 상담 도메인팩 로컬 시연용 워크스페이스"));
+  private static final List<DemoAccountConfig> DEMO_ACCOUNT_CONFIGS =
+      List.of(
+          new DemoAccountConfig(1L, "activeventure.demo@ostone.local", "액티벤처 데모 사용자"),
+          new DemoAccountConfig(2L, "hanacard.demo@ostone.local", "하나카드 데모 사용자"));
+
+  private final EntityManager entityManager;
+  private final PasswordEncoder passwordEncoder;
+
+  public DemoAccountSeedRunner(EntityManager entityManager, PasswordEncoder passwordEncoder) {
+    this.entityManager = entityManager;
+    this.passwordEncoder = passwordEncoder;
+  }
+
+  @Override
+  @Transactional
+  public void run(ApplicationArguments args) {
+    for (DemoWorkspaceConfig workspaceConfig : DEMO_WORKSPACE_CONFIGS) {
+      ensureWorkspace(workspaceConfig);
+    }
+    resetWorkspaceSequence();
+    for (DemoAccountConfig accountConfig : DEMO_ACCOUNT_CONFIGS) {
+      Long userId = upsertDemoUser(accountConfig);
+      upsertDemoMembership(accountConfig.workspaceId(), userId);
+      log.info(
+          "Seed demo account '{}' mapped to workspace {}",
+          accountConfig.email(),
+          accountConfig.workspaceId());
+    }
+    seedSuperAdminAccount();
+    resetAppUserSequence();
+    resetWorkspaceMemberSequence();
+  }
+
+  private void ensureWorkspace(DemoWorkspaceConfig workspaceConfig) {
+    entityManager
+        .createNativeQuery(
+            """
+            INSERT INTO app.workspace (id, workspace_key, name, description)
+            VALUES (:id, :workspaceKey, :name, :description)
+            ON CONFLICT (id) DO UPDATE
+              SET name = EXCLUDED.name,
+                  description = EXCLUDED.description,
+                  status = 'ACTIVE',
+                  updated_at = now()
+            """)
+        .setParameter("id", workspaceConfig.id())
+        .setParameter("workspaceKey", workspaceConfig.workspaceKey())
+        .setParameter("name", workspaceConfig.name())
+        .setParameter(DESCRIPTION_FIELD, workspaceConfig.description())
+        .executeUpdate();
+  }
+
+  // 워크스페이스에 종속되지 않는 글로벌 SUPER_ADMIN 데모 계정을 멱등 upsert 한다.
+  // SUPER_ADMIN 전용 콘솔/관리 API 시연·검증용이며, 운영자 데모 계정과 동일한 DEMO_SIGN_IN_VALUE
+  // 비밀번호를 사용한다(workspace_member 매핑은 만들지 않는다).
+  private void seedSuperAdminAccount() {
+    entityManager
+        .createNativeQuery(
+            """
+            INSERT INTO app.app_user (
+              email, name, password_hash, password_reset_required, role, status, profile_json
+            )
+            VALUES (
+              :email, :name, :credentialHash, false, 'SUPER_ADMIN', 'ACTIVE', '{}'::jsonb
+            )
+            ON CONFLICT (email) DO UPDATE
+              SET name = EXCLUDED.name,
+                  password_hash = EXCLUDED.password_hash,
+                  password_reset_required = false,
+                  role = 'SUPER_ADMIN',
+                  status = 'ACTIVE',
+                  profile_json = '{}'::jsonb,
+                  password_reset_token_hash = null,
+                  password_reset_token_expires_at = null,
+                  updated_at = now()
+            """)
+        .setParameter("email", SUPER_ADMIN_DEMO_EMAIL)
+        .setParameter("name", SUPER_ADMIN_DEMO_NAME)
+        .setParameter("credentialHash", passwordEncoder.encode(DEMO_SIGN_IN_VALUE))
+        .executeUpdate();
+    log.info("Seed super admin demo account '{}'", SUPER_ADMIN_DEMO_EMAIL);
+  }
+
+  private Long upsertDemoUser(DemoAccountConfig accountConfig) {
+    Object result =
+        entityManager
+            .createNativeQuery(
+                """
+                INSERT INTO app.app_user (
+                  email, name, password_hash, password_reset_required, role, status, profile_json
+                )
+                VALUES (
+                  :email, :name, :credentialHash, false, 'OPERATOR', 'ACTIVE', '{}'::jsonb
+                )
+                ON CONFLICT (email) DO UPDATE
+                  SET name = EXCLUDED.name,
+                      password_hash = EXCLUDED.password_hash,
+                      password_reset_required = false,
+                      role = 'OPERATOR',
+                      status = 'ACTIVE',
+                      profile_json = '{}'::jsonb,
+                      password_reset_token_hash = null,
+                      password_reset_token_expires_at = null,
+                      updated_at = now()
+                RETURNING id
+            """)
+            .setParameter("email", accountConfig.email())
+            .setParameter("name", accountConfig.name())
+            .setParameter("credentialHash", passwordEncoder.encode(DEMO_SIGN_IN_VALUE))
+            .getSingleResult();
+    if (result instanceof Number number) {
+      return number.longValue();
+    }
+    throw new IllegalStateException("Demo account upsert did not return a numeric user id");
+  }
+
+  private void upsertDemoMembership(Long workspaceId, Long userId) {
+    entityManager
+        .createNativeQuery(
+            """
+            INSERT INTO app.workspace_member (workspace_id, user_id, member_role)
+            VALUES (:workspaceId, :userId, 'OPERATOR')
+            ON CONFLICT (workspace_id, user_id) DO UPDATE
+              SET member_role = EXCLUDED.member_role
+            """)
+        .setParameter("workspaceId", workspaceId)
+        .setParameter("userId", userId)
+        .executeUpdate();
+  }
+
+  private void resetWorkspaceSequence() {
+    entityManager
+        .createNativeQuery(
+            "SELECT setval('app.workspace_id_seq', (SELECT COALESCE(MAX(id), 1) FROM app.workspace), true)")
+        .getSingleResult();
+  }
+
+  private void resetAppUserSequence() {
+    entityManager
+        .createNativeQuery(
+            """
+            SELECT setval(
+              'app.app_user_id_seq',
+              (SELECT COALESCE(MAX(id), 1) FROM app.app_user),
+              true
+            )
+            """)
+        .getSingleResult();
+  }
+
+  private void resetWorkspaceMemberSequence() {
+    entityManager
+        .createNativeQuery(
+            """
+            SELECT setval(
+              'app.workspace_member_id_seq',
+              (SELECT COALESCE(MAX(id), 1) FROM app.workspace_member),
+              true
+            )
+            """)
+        .getSingleResult();
+  }
+
+  private record DemoWorkspaceConfig(
+      Long id, String workspaceKey, String name, String description) {}
+
+  private record DemoAccountConfig(Long workspaceId, String email, String name) {}
+}

--- a/backend/src/test/java/com/init/domainpack/infrastructure/ActiveVentureDomainPackSeedRunnerTest.java
+++ b/backend/src/test/java/com/init/domainpack/infrastructure/ActiveVentureDomainPackSeedRunnerTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -48,7 +47,6 @@ class ActiveVentureDomainPackSeedRunnerTest {
   @Mock private WorkflowMatchingProfileBuildRequestService profileBuildRequestService;
   @Mock private EntityManager entityManager;
   @Mock private Query query;
-  @Mock private PasswordEncoder passwordEncoder;
 
   private ActiveVentureDomainPackSeedRunner runner;
 
@@ -66,8 +64,7 @@ class ActiveVentureDomainPackSeedRunnerTest {
             intentSlotBindingRepository,
             profileBuildRequestService,
             entityManager,
-            objectMapper,
-            passwordEncoder);
+            objectMapper);
   }
 
   @Test

--- a/backend/src/test/java/com/init/domainpack/infrastructure/DemoAccountSeedRunnerIntegrationTest.java
+++ b/backend/src/test/java/com/init/domainpack/infrastructure/DemoAccountSeedRunnerIntegrationTest.java
@@ -1,0 +1,50 @@
+package com.init.domainpack.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@DisplayName("DemoAccountSeedRunner profile")
+class DemoAccountSeedRunnerIntegrationTest {
+
+  private final ApplicationContextRunner contextRunner =
+      new ApplicationContextRunner()
+          .withUserConfiguration(DemoAccountSeedRunner.class, RunnerDependencies.class);
+
+  @Test
+  @DisplayName("local/dev/prod profile이 활성화되면 bean이 로드된다")
+  void shouldLoadRunnerBeanForSeededProfiles() {
+    for (String profile : new String[] {"local", "dev", "prod"}) {
+      contextRunner
+          .withPropertyValues("spring.profiles.active=" + profile)
+          .run(context -> assertThat(context).hasSingleBean(DemoAccountSeedRunner.class));
+    }
+  }
+
+  @Test
+  @DisplayName("test(default) profile에서는 bean이 생성되지 않는다")
+  void shouldNotLoadRunnerBeanWhenNoSeedProfileActive() {
+    contextRunner.run(context -> assertThat(context).doesNotHaveBean(DemoAccountSeedRunner.class));
+  }
+
+  @TestConfiguration
+  static class RunnerDependencies {
+
+    @Bean
+    EntityManager entityManager() {
+      return mock(EntityManager.class);
+    }
+
+    @Bean
+    PasswordEncoder passwordEncoder() {
+      return mock(PasswordEncoder.class);
+    }
+  }
+}

--- a/scripts/demo-credentials-consistency.test.mjs
+++ b/scripts/demo-credentials-consistency.test.mjs
@@ -7,7 +7,7 @@ import { test } from "node:test";
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const SEED_RUNNER = join(
   ROOT,
-  "backend/src/main/java/com/init/domainpack/infrastructure/ActiveVentureDomainPackSeedRunner.java",
+  "backend/src/main/java/com/init/domainpack/infrastructure/DemoAccountSeedRunner.java",
 );
 const README = join(ROOT, "README.md");
 


### PR DESCRIPTION
## 문제

README의 데모 계정 표(`activeventure.demo`·`hanacard.demo`=OPERATOR, `superadmin.demo`=SUPER_ADMIN, 비번 `demo1234`)가 **prod에서 로그인되지 않았다.** 세 계정 모두 `ActiveVentureDomainPackSeedRunner`(`@Profile({"local","dev"})`)가 시드하므로 `SPRING_PROFILES_ACTIVE=prod`인 운영에서는 생성되지 않았다. (#840은 prod SUPER_ADMIN을 env/secret 기반 `superadmin@ajou-cstone.com`으로만 통합했고, OPERATOR 2계정은 prod 경로가 없었다.)

## 변경

- **`DemoAccountSeedRunner` 신규** (`@Profile({"local","dev","prod"})`): OPERATOR 2계정 + SUPER_ADMIN 데모 계정과 워크스페이스 1·2를 멱등 시드. `app.workspace`/`app_user`/`workspace_member`만 다뤄 `domain_pack_version` 의존이 없으므로 prod에서도 안전(=#833이 겪은 FK 깨짐 회피).
- **`ActiveVentureDomainPackSeedRunner`**: 계정 로직 제거(−126줄), 도메인팩 본문 시드만 유지(local/dev).
- **`SuperAdminBootstrapRunner`에 `@Order` 부여**: env/secret 기반 운영 SUPER_ADMIN이 먼저 생성된 뒤 데모 SUPER_ADMIN이 추가되도록 해 **둘이 공존**(#840 운영 계정 유지). 데모가 먼저 들어가면 `existsByRole` 가드에 운영 계정이 누락되므로 순서가 중요.
- 테스트: 프로파일 게이팅 검증 테스트 추가, `demo-credentials-consistency` 시드 러너 경로 갱신.

## 검증

- 전체 H2 테스트 통과 / `demo-credentials-consistency` 3/3 / spotless·컴파일 클린.

## prod 효과

머지 시 prod에 README 표의 3계정이 생성되어 그대로 로그인 가능. `superadmin@ajou-cstone.com`(#840)도 유지.

> ⚠️ OPERATOR는 로그인되나 **ws2(하나카드) 도메인팩 콘텐츠는 prod에 없을 수 있음**(별도 사안 — 도메인팩 prod 시드는 미포함). `demo1234` SUPER_ADMIN을 prod에 노출하는 점은 데모 목적상 의도된 결정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

**Chores**
* 데모 계정 초기화 프로세스를 재구성하여 시스템 안정성을 개선했습니다.
* 애플리케이션 시작 시 부트스트랩 단계의 실행 순서를 최적화하고 테스트 커버리지를 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->