### PR TITLE
chore(admin): 데모 도메인팩 콘텐츠를 prod 프로파일에서도 시드

### DIFF
--- a/backend/src/main/java/com/init/domainpack/infrastructure/ActiveVentureDomainPackSeedRunner.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/ActiveVentureDomainPackSeedRunner.java
@@ -45,12 +45,17 @@ import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+// prod 에서도 데모 도메인팩 콘텐츠(액티벤처/하나카드)를 멱등 시드한다. publish 는 version.activate()
+// 로 이뤄지고 findCurrentPublishedByDomainPackId 가 재실행을 backfill 로 흡수하므로 version 중복이 없다.
+// 단 prod 에서는 임베딩 matching profile build enqueue 를 건너뛴다(prod ML 런타임 트리거 회피).
 @Component
-@Profile({"local", "dev"})
+@Profile({"local", "dev", "prod"})
 @Order(Ordered.LOWEST_PRECEDENCE - 90)
 public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
 
@@ -95,6 +100,8 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
   private final WorkflowMatchingProfileBuildRequestService profileBuildRequestService;
   private final EntityManager entityManager;
   private final ObjectMapper objectMapper;
+  // prod 가 아닐 때만 임베딩 matching profile build 를 enqueue 한다(prod ML 런타임 트리거 회피).
+  private final boolean profileBuildEnqueueEnabled;
 
   public ActiveVentureDomainPackSeedRunner(
       DomainPackCommandRepository domainPackRepository,
@@ -107,7 +114,8 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
       IntentSlotBindingRepository intentSlotBindingRepository,
       WorkflowMatchingProfileBuildRequestService profileBuildRequestService,
       EntityManager entityManager,
-      ObjectMapper objectMapper) {
+      ObjectMapper objectMapper,
+      Environment environment) {
     this.domainPackRepository = domainPackRepository;
     this.domainPackVersionRepository = domainPackVersionRepository;
     this.intentDefinitionRepository = intentDefinitionRepository;
@@ -119,6 +127,7 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
     this.profileBuildRequestService = profileBuildRequestService;
     this.entityManager = entityManager;
     this.objectMapper = objectMapper;
+    this.profileBuildEnqueueEnabled = !environment.acceptsProfiles(Profiles.of("prod"));
   }
 
   @Override
@@ -170,8 +179,14 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
 
     version.activate(OffsetDateTime.now());
     domainPackVersionRepository.saveAndFlush(version);
-    profileBuildRequestService.enqueue(version.getId(), seedConfig.profileBuildSource());
-    log.info("Seed domain pack '{}' seeded as version {}", packKey, version.getId());
+    if (profileBuildEnqueueEnabled) {
+      profileBuildRequestService.enqueue(version.getId(), seedConfig.profileBuildSource());
+    }
+    log.info(
+        "Seed domain pack '{}' seeded as version {} (profileBuildEnqueue={})",
+        packKey,
+        version.getId(),
+        profileBuildEnqueueEnabled);
   }
 
   private JsonNode loadSeed(SeedConfig seedConfig) {

--- a/backend/src/test/java/com/init/domainpack/infrastructure/ActiveVentureDomainPackSeedRunnerTest.java
+++ b/backend/src/test/java/com/init/domainpack/infrastructure/ActiveVentureDomainPackSeedRunnerTest.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -47,6 +49,7 @@ class ActiveVentureDomainPackSeedRunnerTest {
   @Mock private WorkflowMatchingProfileBuildRequestService profileBuildRequestService;
   @Mock private EntityManager entityManager;
   @Mock private Query query;
+  @Mock private Environment environment;
 
   private ActiveVentureDomainPackSeedRunner runner;
 
@@ -64,7 +67,8 @@ class ActiveVentureDomainPackSeedRunnerTest {
             intentSlotBindingRepository,
             profileBuildRequestService,
             entityManager,
-            objectMapper);
+            objectMapper,
+            environment);
   }
 
   @Test
@@ -153,6 +157,37 @@ class ActiveVentureDomainPackSeedRunnerTest {
     verify(query).setParameter(eq("intentCode"), eq("reservation_progress_and_documents"));
     verify(query).setParameter(eq("slotCode"), eq("reservation_number"));
     verify(query).setParameter(eq("promptHint"), eq("예약번호를 확인해 주세요."));
+  }
+
+  @Test
+  @DisplayName("prod 프로파일이면 profile build enqueue를 비활성화한다")
+  void shouldDisableProfileBuildEnqueueInProd() {
+    given(environment.acceptsProfiles(any(Profiles.class))).willReturn(true);
+
+    ActiveVentureDomainPackSeedRunner prodRunner =
+        new ActiveVentureDomainPackSeedRunner(
+            domainPackRepository,
+            domainPackVersionRepository,
+            intentDefinitionRepository,
+            slotDefinitionRepository,
+            policyDefinitionRepository,
+            riskDefinitionRepository,
+            workflowDefinitionRepository,
+            intentSlotBindingRepository,
+            profileBuildRequestService,
+            entityManager,
+            objectMapper,
+            environment);
+
+    assertThat((Boolean) ReflectionTestUtils.getField(prodRunner, "profileBuildEnqueueEnabled"))
+        .isFalse();
+  }
+
+  @Test
+  @DisplayName("prod 가 아니면 profile build enqueue를 활성화한다")
+  void shouldEnableProfileBuildEnqueueWhenNotProd() {
+    assertThat((Boolean) ReflectionTestUtils.getField(runner, "profileBuildEnqueueEnabled"))
+        .isTrue();
   }
 
   private JsonNode sampleIntentDraft() throws Exception {


### PR DESCRIPTION
## 배경

#848(머지됨)로 데모 계정·워크스페이스 1·2는 prod에 시드되지만, **prod RDS 실측 결과 도메인팩 콘텐츠는 거의 없음**:
- pack 2개 모두 ws1 소속 — `PACK-DEMO`(ver1, **콘텐츠 0**) + `demo_refund_pack`(ver101: intent 1·slot 4·workflow 1 `refund_request_flow`)
- **ws2(하나카드)에는 도메인팩 0**, 전체 policy 0·risk 0
- 즉 OPERATOR가 로그인해도 액티벤처/하나카드 상담 팩 콘텐츠가 비어 있음

## 변경

- `ActiveVentureDomainPackSeedRunner`의 `@Profile`에 **`prod`** 추가 → 액티벤처(ws1, 12 workflow)·하나카드(ws2, 14 workflow) 도메인팩을 prod에서도 멱등 시드.
- prod에서는 **임베딩 matching profile build `enqueue`를 스킵**(prod ML 런타임 트리거 회피). 판정은 `Environment.acceptsProfiles("prod")`.

## 안전성

- **version 중복 없음**: publish는 `version.activate()`(→`PUBLISHED`)로 이뤄지고, 재실행 시 `findCurrentPublishedByDomainPackId`가 backfill 분기로 흡수.
- **팩 충돌 없음**: seed packKey(`activeventure-travel`/`hanacard-card-service`)가 기존 prod 팩(`PACK-DEMO`/`demo_refund_pack`)과 달라 신규 팩으로 생성. 기존 데이터 비훼손.
- **워크스페이스 비훼손**: ws1·2는 이미 데모 이름으로 존재 → `ensureWorkspace`가 동일 값으로 재확인만.
- **enqueue 스킵은 publish/멱등성과 독립** → 안전.

## 검증

전체 H2 테스트 통과 + enqueue 게이팅 단위 테스트 추가(prod=비활성 / 그 외=활성).

## 머지 시 효과 / 한계

머지 후 prod 배포되면 ws1·ws2에 데모 팩 콘텐츠가 채워져 데모 화면이 실제로 보인다.
> 한계: prod에서 `enqueue`를 스킵하므로 chat-demo의 임베딩 기반 **auto-matching profile은 prod에서 빌드되지 않는다**(도메인팩 열람·구조는 정상). 필요 시 별도로 트리거.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 프로덕션 환경에서의 프로필 빌드 프로세스 동작을 최적화했습니다.
  * 환경별 프로필 빌드 실행 조건을 개선하여 애플리케이션 성능을 향상시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->