### PR TITLE
fix(ml): #842 도메인 후보 LLM thinking 비활성화와 timeout 확장

### DIFF
--- a/infra/terraform/ecs-airflow.tf
+++ b/infra/terraform/ecs-airflow.tf
@@ -255,7 +255,7 @@ locals {
     },
     {
       name  = "PIPELINE_DOMAIN_CANDIDATE_LLM_TIMEOUT_SECONDS"
-      value = "90"
+      value = "240"
     },
     {
       name  = "S3_EXPECTED_BUCKET_OWNER"

--- a/ml/src/pipeline/stages/domain_candidate_generation/main.py
+++ b/ml/src/pipeline/stages/domain_candidate_generation/main.py
@@ -25,7 +25,7 @@ MAX_SAMPLE_SIZE = 24
 MAX_CANDIDATES = 5
 MIN_CANDIDATES = 3
 MAX_SNIPPET_CHARS = 360
-DEFAULT_LLM_TIMEOUT_SECONDS = 90.0
+DEFAULT_LLM_TIMEOUT_SECONDS = 240.0
 MAX_LLM_TIMEOUT_SECONDS = 300.0
 LLM_MAX_TOKENS = 520
 STOPWORDS = frozenset(
@@ -140,6 +140,7 @@ def _generate_llm_candidates(
             {"role": "user", "content": prompt},
         ],
         "response_format": {"type": "json_object"},
+        "options": {"think": False},
     }
     with httpx.Client(timeout=_llm_timeout()) as client:
         response = client.post(endpoint, headers=headers, json=request_payload)

--- a/ml/tests/stages/test_domain_candidate_generation_main.py
+++ b/ml/tests/stages/test_domain_candidate_generation_main.py
@@ -254,6 +254,7 @@ def test_generate_llm_candidates_posts_prompt_and_parses_response(monkeypatch: p
     assert request["headers"]["Authorization"] == "Bearer secret-token"
     assert request["json"]["model"] == "model-a"
     assert request["json"]["max_tokens"] == main.LLM_MAX_TOKENS
+    assert request["json"]["options"] == {"think": False}
 
 
 def test_generate_llm_candidates_requires_candidates_list() -> None:


### PR DESCRIPTION
## 개요

#842 후속 보정입니다. Qwen 기반 domain candidate 생성이 thinking mode로 장황하게 생성되다가 stage client timeout에 걸리는 문제를 줄입니다.

## 변경

- domain candidate LLM 요청 payload에 `options: {"think": false}`를 추가해 실제 런타임 옵션으로 thinking을 비활성화합니다.
- domain candidate LLM timeout 기본값과 prod Airflow 전달값을 240초로 확장합니다. 최대 cap은 300초를 유지합니다.
- LLM 요청 payload 테스트에 thinking 비활성화 옵션 검증을 추가합니다.

## 검증

- `cd ml && uv run pytest tests/stages/test_domain_candidate_generation_main.py`
- `cd ml && uv run ruff check src/pipeline/stages/domain_candidate_generation/main.py tests/stages/test_domain_candidate_generation_main.py`
- `terraform -chdir=infra/terraform fmt -check ecs-airflow.tf`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 및 안정성 개선**
  * LLM 요청 타임아웃을 90초에서 240초로 증가하여 처리 안정성 향상
  * LLM 요청 설정 옵션을 업데이트하여 동작 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->