### PR TITLE
test(corpus): #837 업로드 테스트 fixture로 mock setup 정리

### DIFF
--- a/.agent/specs/837.md
+++ b/.agent/specs/837.md
@@ -1,0 +1,54 @@
+# 백엔드 application 테스트 mock fixture 정리
+
+## Goal
+
+백엔드 application/service 테스트의 반복 mock setup을 의도가 드러나는 fixture helper로 정리해 테스트가 내부 호출 준비보다 관찰 가능한 결과와 핵심 side effect를 중심으로 읽히게 한다.
+
+## Scope
+
+- 대상 영역: backend application/service 테스트
+- 우선 정리 대상:
+  - `backend/src/test/java/com/init/corpus/application/CompleteRawFileUploadServiceTest.java`
+  - `backend/src/test/java/com/init/corpus/application/RawDatasetUploadServiceTest.java`
+- 변경 유형: 테스트 fixture/helper 정리와 검증 표현 개선
+- 프로덕션 코드, REST API, DB schema, OpenAPI/generated client 변경은 포함하지 않는다.
+
+## Problem
+
+일부 application/service 테스트는 워크스페이스 접근, 데이터셋 조회, 스토리지 메타데이터, 저장 엔티티 mock 같은 공통 given 구문을 테스트마다 직접 나열한다. 이 때문에 테스트 이름보다 mock 호출 준비가 먼저 눈에 들어오고, 실제 검증 의도가 결과 상태인지 단순 호출 만족 조건인지 구분하기 어렵다.
+
+## Requirements
+
+- 반복되는 workspace membership, dataset lookup, storage metadata, saved dataset/conversation setup은 테스트 의도를 담은 helper로 묶는다.
+- helper 이름만으로 성공 경로, 접근 불가, 업로드 세션 오류, 저장 실패 같은 상황을 이해할 수 있어야 한다.
+- 관찰 가능한 결과 DTO, 도메인 객체 상태, 저장된 엔티티 값 검증은 유지하거나 더 명확하게 만든다.
+- `verify`는 스토리지 promotion/delete, ingestion trigger, 보상 삭제, 접근 차단처럼 호출 자체가 의미 있는 side effect에 집중한다.
+- 기존 테스트 시나리오와 예외 기대값은 유지한다.
+
+## Non-goals
+
+- Mockito를 완전히 제거하거나 in-memory fake를 광범위하게 도입하지 않는다.
+- 테스트 대상 service의 동작, transaction 처리, storage/ingestion contract를 변경하지 않는다.
+- 이 이슈에서 나열된 모든 테스트 파일을 한 번에 대규모로 재작성하지 않는다. 우선 반복도가 높고 위험이 낮은 corpus application 테스트부터 정리한다.
+
+## Design Notes
+
+- `CompleteRawFileUploadServiceTest`는 `givenMember()`, `givenUploadingDataset()`, `givenUploadedObject(...)`, transaction synchronization helper처럼 반복 precondition을 scenario helper로 추출한다.
+- `RawDatasetUploadServiceTest`는 workspace access/dataset key 허용, saved dataset mock, saved conversation mock, successful persistence path helper를 분리한다.
+- 실패 경로에서 의미 있는 `verify(..., never())`는 유지하되, 단순 setup 만족을 위한 중복 stubbing은 helper로 숨긴다.
+
+## Acceptance Criteria
+
+- `.agent/specs/837.md`가 존재하고 이슈 번호만 파일명에 포함한다.
+- 정리 대상 테스트에서 반복 mock setup 라인이 줄고, 테스트 본문이 시나리오의 given/when/then을 더 직접적으로 드러낸다.
+- 스토리지 promotion, after-commit trigger, rollback cleanup, compensation delete 같은 외부 side effect 검증은 유지된다.
+- 관련 backend 테스트가 통과한다.
+
+## Validation
+
+- 최소 검증: `./gradlew test --tests com.init.corpus.application.CompleteRawFileUploadServiceTest --tests com.init.corpus.application.RawDatasetUploadServiceTest`
+- 필요 시 확장 검증: `./gradlew test --tests com.init.corpus.application.*`
+
+## Open Questions
+
+- 없음. 이 이슈는 테스트 가독성 및 유지보수성 개선이며 프로덕션 동작 변경을 요구하지 않는다.

--- a/backend/src/test/java/com/init/corpus/application/CompleteRawFileUploadServiceTest.java
+++ b/backend/src/test/java/com/init/corpus/application/CompleteRawFileUploadServiceTest.java
@@ -78,6 +78,42 @@ class CompleteRawFileUploadServiceTest {
     return dataset;
   }
 
+  private Dataset givenUploadingDataset() {
+    Dataset dataset = uploadingDataset();
+    givenDatasetForCompletion(dataset);
+    return dataset;
+  }
+
+  private void givenDatasetForCompletion(Dataset dataset) {
+    given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L))
+        .willReturn(Optional.of(dataset));
+  }
+
+  private void givenMember() {
+    givenMember(1L);
+  }
+
+  private void givenMember(long userId) {
+    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, userId)).willReturn(true);
+  }
+
+  private void givenUploadedObject() {
+    givenUploadedObject(EXPECTED_SIZE, "\"etag-123\"");
+  }
+
+  private void givenUploadedObject(long size, String etag) {
+    given(storagePort.headObject(OBJECT_KEY))
+        .willReturn(Optional.of(new ObjectMetadata(size, etag)));
+  }
+
+  private void givenDatasetSaveReturnsArgument() {
+    given(datasetRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+  }
+
+  private List<TransactionSynchronization> registeredSynchronizations() {
+    return List.copyOf(TransactionSynchronizationManager.getSynchronizations());
+  }
+
   private String buildMeta(long size) {
     return buildMeta(size, OffsetDateTime.now().plusMinutes(15), 1L);
   }
@@ -97,13 +133,10 @@ class CompleteRawFileUploadServiceTest {
   @Test
   @DisplayName("should_promote_pending_to_completed_persist_rawfile_and_trigger_with_completed_key")
   void complete_success_promotesTransitionsAndTriggers() {
-    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
-    Dataset dataset = uploadingDataset();
-    given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L))
-        .willReturn(Optional.of(dataset));
-    given(storagePort.headObject(OBJECT_KEY))
-        .willReturn(Optional.of(new ObjectMetadata(EXPECTED_SIZE, "\"etag-123\"")));
-    given(datasetRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+    givenMember();
+    Dataset dataset = givenUploadingDataset();
+    givenUploadedObject();
+    givenDatasetSaveReturnsArgument();
 
     TransactionSynchronizationManager.initSynchronization();
     CompleteRawFileUploadResult result;
@@ -114,8 +147,7 @@ class CompleteRawFileUploadServiceTest {
       verify(storagePort, never()).delete(anyString());
       verify(triggerPort, never()).trigger(anyLong(), anyLong(), anyString());
 
-      List<TransactionSynchronization> synchronizations =
-          List.copyOf(TransactionSynchronizationManager.getSynchronizations());
+      List<TransactionSynchronization> synchronizations = registeredSynchronizations();
       assertThat(synchronizations).hasSize(2);
       synchronizations.forEach(TransactionSynchronization::afterCommit);
       synchronizations.forEach(
@@ -148,12 +180,9 @@ class CompleteRawFileUploadServiceTest {
   @Test
   @DisplayName("should_not_persist_or_trigger_when_storage_promotion_fails")
   void complete_copyFails_doesNotPersistOrTrigger() {
-    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
-    Dataset dataset = uploadingDataset();
-    given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L))
-        .willReturn(Optional.of(dataset));
-    given(storagePort.headObject(OBJECT_KEY))
-        .willReturn(Optional.of(new ObjectMetadata(EXPECTED_SIZE, "\"etag-123\"")));
+    givenMember();
+    Dataset dataset = givenUploadingDataset();
+    givenUploadedObject();
     org.mockito.BDDMockito.willThrow(new IllegalStateException("copy failed"))
         .given(storagePort)
         .copyObject(OBJECT_KEY, COMPLETED_KEY);
@@ -170,12 +199,9 @@ class CompleteRawFileUploadServiceTest {
   @Test
   @DisplayName("should_delete_completed_object_when_db_save_rolls_back_after_promotion")
   void complete_dbSaveFails_deletesCompletedObjectOnRollback() {
-    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
-    Dataset dataset = uploadingDataset();
-    given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L))
-        .willReturn(Optional.of(dataset));
-    given(storagePort.headObject(OBJECT_KEY))
-        .willReturn(Optional.of(new ObjectMetadata(EXPECTED_SIZE, "\"etag-123\"")));
+    givenMember();
+    givenUploadingDataset();
+    givenUploadedObject();
     org.mockito.BDDMockito.willThrow(new IllegalStateException("db down"))
         .given(rawFileRepository)
         .save(any());
@@ -186,8 +212,7 @@ class CompleteRawFileUploadServiceTest {
           .isInstanceOf(IllegalStateException.class)
           .hasMessageContaining("db down");
 
-      List<TransactionSynchronization> synchronizations =
-          List.copyOf(TransactionSynchronizationManager.getSynchronizations());
+      List<TransactionSynchronization> synchronizations = registeredSynchronizations();
       assertThat(synchronizations).hasSize(1);
       synchronizations.forEach(
           synchronization ->
@@ -206,20 +231,16 @@ class CompleteRawFileUploadServiceTest {
   @Test
   @DisplayName("should_delete_completed_object_when_transaction_completion_is_unknown")
   void complete_transactionUnknown_deletesCompletedObject() {
-    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
-    Dataset dataset = uploadingDataset();
-    given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L))
-        .willReturn(Optional.of(dataset));
-    given(storagePort.headObject(OBJECT_KEY))
-        .willReturn(Optional.of(new ObjectMetadata(EXPECTED_SIZE, "\"etag-123\"")));
-    given(datasetRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+    givenMember();
+    givenUploadingDataset();
+    givenUploadedObject();
+    givenDatasetSaveReturnsArgument();
 
     TransactionSynchronizationManager.initSynchronization();
     try {
       service.complete(command());
 
-      List<TransactionSynchronization> synchronizations =
-          List.copyOf(TransactionSynchronizationManager.getSynchronizations());
+      List<TransactionSynchronization> synchronizations = registeredSynchronizations();
       assertThat(synchronizations).hasSize(2);
       synchronizations.forEach(
           synchronization ->
@@ -236,13 +257,10 @@ class CompleteRawFileUploadServiceTest {
   @Test
   @DisplayName("should_propagate_afterCommit_trigger_failure_after_processing_transition")
   void complete_triggerFails_propagatesAfterCommitFailure() {
-    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
-    Dataset dataset = uploadingDataset();
-    given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L))
-        .willReturn(Optional.of(dataset));
-    given(storagePort.headObject(OBJECT_KEY))
-        .willReturn(Optional.of(new ObjectMetadata(EXPECTED_SIZE, "\"etag-123\"")));
-    given(datasetRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+    givenMember();
+    Dataset dataset = givenUploadingDataset();
+    givenUploadedObject();
+    givenDatasetSaveReturnsArgument();
     org.mockito.BDDMockito.willThrow(new IllegalStateException("airflow down"))
         .given(triggerPort)
         .trigger(1L, 42L, COMPLETED_KEY);
@@ -252,8 +270,7 @@ class CompleteRawFileUploadServiceTest {
       service.complete(command());
 
       verify(triggerPort, never()).trigger(anyLong(), anyLong(), anyString());
-      List<TransactionSynchronization> synchronizations =
-          List.copyOf(TransactionSynchronizationManager.getSynchronizations());
+      List<TransactionSynchronization> synchronizations = registeredSynchronizations();
 
       // 트리거 실패는 afterCommit 단계에서 전파되며, DB 상태 전이는 이미 완료된 상태다.
       assertThatThrownBy(() -> synchronizations.forEach(TransactionSynchronization::afterCommit))
@@ -269,11 +286,10 @@ class CompleteRawFileUploadServiceTest {
   @Test
   @DisplayName("should_be_idempotent_when_already_processing")
   void complete_alreadyProcessing_doesNotRetrigger() {
-    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
+    givenMember();
     Dataset dataset = uploadingDataset();
     dataset.markProcessing();
-    given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L))
-        .willReturn(Optional.of(dataset));
+    givenDatasetForCompletion(dataset);
 
     CompleteRawFileUploadResult result = service.complete(command());
 
@@ -299,7 +315,7 @@ class CompleteRawFileUploadServiceTest {
   @Test
   @DisplayName("should_throw_DatasetNotFoundException_when_데이터셋_없음")
   void complete_datasetNotFound_throws() {
-    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
+    givenMember();
     given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L)).willReturn(Optional.empty());
 
     assertThatThrownBy(() -> service.complete(command()))
@@ -311,9 +327,8 @@ class CompleteRawFileUploadServiceTest {
   @Test
   @DisplayName("should_throw_when_object_missing_in_storage")
   void complete_objectMissing_throws() {
-    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
-    given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L))
-        .willReturn(Optional.of(uploadingDataset()));
+    givenMember();
+    givenUploadingDataset();
     given(storagePort.headObject(OBJECT_KEY)).willReturn(Optional.empty());
 
     assertThatThrownBy(() -> service.complete(command()))
@@ -327,11 +342,10 @@ class CompleteRawFileUploadServiceTest {
   @Test
   @DisplayName("should_throw_when_upload_session_expired")
   void complete_expiredUploadSession_throws() {
-    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
+    givenMember();
     Dataset dataset = uploadingDataset();
     dataset.updateMetaJson(buildMeta(EXPECTED_SIZE, OffsetDateTime.now().minusMinutes(1), 1L));
-    given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L))
-        .willReturn(Optional.of(dataset));
+    givenDatasetForCompletion(dataset);
 
     assertThatThrownBy(() -> service.complete(command()))
         .isInstanceOf(InvalidUploadStateException.class)
@@ -347,7 +361,7 @@ class CompleteRawFileUploadServiceTest {
   @Test
   @DisplayName("should_throw_when_upload_session_expiresAt_missing")
   void complete_missingExpiresAt_throws() {
-    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
+    givenMember();
     Dataset dataset = uploadingDataset();
     dataset.updateMetaJson(
         "{\"upload\":{\"objectKey\":\""
@@ -355,8 +369,7 @@ class CompleteRawFileUploadServiceTest {
             + "\",\"expectedSizeBytes\":"
             + EXPECTED_SIZE
             + ",\"filename\":\"data.zip\",\"contentType\":\"application/zip\",\"createdBy\":1}}");
-    given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L))
-        .willReturn(Optional.of(dataset));
+    givenDatasetForCompletion(dataset);
 
     assertThatThrownBy(() -> service.complete(command()))
         .isInstanceOf(InvalidUploadStateException.class)
@@ -370,7 +383,7 @@ class CompleteRawFileUploadServiceTest {
   @Test
   @DisplayName("should_throw_when_upload_session_expiresAt_malformed")
   void complete_malformedExpiresAt_throws() {
-    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
+    givenMember();
     Dataset dataset = uploadingDataset();
     dataset.updateMetaJson(
         "{\"upload\":{\"objectKey\":\""
@@ -378,8 +391,7 @@ class CompleteRawFileUploadServiceTest {
             + "\",\"expectedSizeBytes\":"
             + EXPECTED_SIZE
             + ",\"filename\":\"data.zip\",\"contentType\":\"application/zip\",\"expiresAt\":\"not-a-date\",\"createdBy\":1}}");
-    given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L))
-        .willReturn(Optional.of(dataset));
+    givenDatasetForCompletion(dataset);
 
     assertThatThrownBy(() -> service.complete(command()))
         .isInstanceOf(InvalidUploadStateException.class)
@@ -393,7 +405,7 @@ class CompleteRawFileUploadServiceTest {
   @Test
   @DisplayName("should_throw_when_upload_session_createdBy_missing")
   void complete_missingCreatedBy_throws() {
-    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
+    givenMember();
     Dataset dataset = uploadingDataset();
     dataset.updateMetaJson(
         "{\"upload\":{\"objectKey\":\""
@@ -403,8 +415,7 @@ class CompleteRawFileUploadServiceTest {
             + ",\"filename\":\"data.zip\",\"contentType\":\"application/zip\",\"expiresAt\":\""
             + OffsetDateTime.now().plusMinutes(15)
             + "\"}}");
-    given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L))
-        .willReturn(Optional.of(dataset));
+    givenDatasetForCompletion(dataset);
 
     assertThatThrownBy(() -> service.complete(command()))
         .isInstanceOf(InvalidUploadStateException.class)
@@ -418,10 +429,9 @@ class CompleteRawFileUploadServiceTest {
   @Test
   @DisplayName("should_throw_when_upload_session_createdBy_mismatches_request_user")
   void complete_createdByMismatch_throws() {
-    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 2L)).willReturn(true);
+    givenMember(2L);
     Dataset dataset = uploadingDataset();
-    given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L))
-        .willReturn(Optional.of(dataset));
+    givenDatasetForCompletion(dataset);
 
     assertThatThrownBy(() -> service.complete(new CompleteRawFileUploadCommand(1L, 42L, 2L)))
         .isInstanceOf(InvalidUploadStateException.class)
@@ -437,11 +447,9 @@ class CompleteRawFileUploadServiceTest {
   @Test
   @DisplayName("should_throw_when_object_size_mismatches_expected")
   void complete_sizeMismatch_throws() {
-    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
-    given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L))
-        .willReturn(Optional.of(uploadingDataset()));
-    given(storagePort.headObject(OBJECT_KEY))
-        .willReturn(Optional.of(new ObjectMetadata(EXPECTED_SIZE + 1, "\"etag\"")));
+    givenMember();
+    givenUploadingDataset();
+    givenUploadedObject(EXPECTED_SIZE + 1, "\"etag\"");
 
     assertThatThrownBy(() -> service.complete(command()))
         .isInstanceOf(InvalidUploadStateException.class)
@@ -454,17 +462,13 @@ class CompleteRawFileUploadServiceTest {
   @Test
   @DisplayName("should_throw_when_object_size_over_4GB")
   void complete_sizeOverLimit_throws() {
-    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
+    givenMember();
     Dataset dataset = Dataset.createUploading(1L, "test-key", "테스트", "CRM", 1L);
     ReflectionTestUtils.setField(dataset, "id", 42L);
     long huge = InitRawFileUploadService.MAX_UPLOAD_BYTES + 10;
     dataset.updateMetaJson(buildMeta(huge));
-    given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L))
-        .willReturn(Optional.of(dataset));
-    given(storagePort.headObject(OBJECT_KEY))
-        .willReturn(
-            Optional.of(
-                new ObjectMetadata(InitRawFileUploadService.MAX_UPLOAD_BYTES + 1, "\"etag\"")));
+    givenDatasetForCompletion(dataset);
+    givenUploadedObject(InitRawFileUploadService.MAX_UPLOAD_BYTES + 1, "\"etag\"");
 
     assertThatThrownBy(() -> service.complete(command()))
         .isInstanceOf(InvalidUploadStateException.class)
@@ -476,7 +480,7 @@ class CompleteRawFileUploadServiceTest {
   @Test
   @DisplayName("should_throw_when_uploading_object_key_has_no_pending_prefix")
   void complete_uploadingObjectKeyWithoutPendingPrefix_throws() {
-    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
+    givenMember();
     Dataset dataset = Dataset.createUploading(1L, "test-key", "테스트", "CRM", 1L);
     ReflectionTestUtils.setField(dataset, "id", 42L);
     dataset.updateMetaJson(
@@ -485,8 +489,7 @@ class CompleteRawFileUploadServiceTest {
             + ",\"filename\":\"data.zip\",\"contentType\":\"application/zip\",\"expiresAt\":\""
             + OffsetDateTime.now().plusMinutes(15)
             + "\",\"createdBy\":1}}");
-    given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L))
-        .willReturn(Optional.of(dataset));
+    givenDatasetForCompletion(dataset);
     given(storagePort.headObject("direct/key.zip"))
         .willReturn(Optional.of(new ObjectMetadata(EXPECTED_SIZE, "\"etag\"")));
 
@@ -503,12 +506,11 @@ class CompleteRawFileUploadServiceTest {
   @Test
   @DisplayName("should_throw_when_upload_field_missing_in_meta")
   void complete_noUploadFieldInMeta_throws() {
-    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
+    givenMember();
     Dataset dataset = Dataset.createUploading(1L, "test-key", "테스트", "CRM", 1L);
     ReflectionTestUtils.setField(dataset, "id", 42L);
     dataset.updateMetaJson("{\"other\":\"value\"}");
-    given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L))
-        .willReturn(Optional.of(dataset));
+    givenDatasetForCompletion(dataset);
 
     assertThatThrownBy(() -> service.complete(command()))
         .isInstanceOf(InvalidUploadStateException.class)
@@ -520,12 +522,11 @@ class CompleteRawFileUploadServiceTest {
   @Test
   @DisplayName("should_throw_when_objectKey_missing_in_upload_session")
   void complete_objectKeyMissingInSession_throws() {
-    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
+    givenMember();
     Dataset dataset = Dataset.createUploading(1L, "test-key", "테스트", "CRM", 1L);
     ReflectionTestUtils.setField(dataset, "id", 42L);
     dataset.updateMetaJson("{\"upload\":{\"expectedSizeBytes\":1024,\"filename\":\"d.zip\"}}");
-    given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L))
-        .willReturn(Optional.of(dataset));
+    givenDatasetForCompletion(dataset);
 
     assertThatThrownBy(() -> service.complete(command()))
         .isInstanceOf(InvalidUploadStateException.class)
@@ -537,13 +538,12 @@ class CompleteRawFileUploadServiceTest {
   @Test
   @DisplayName("should_throw_when_expectedSizeBytes_missing_in_upload_session")
   void complete_expectedSizeBytesMissing_throws() {
-    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
+    givenMember();
     Dataset dataset = Dataset.createUploading(1L, "test-key", "테스트", "CRM", 1L);
     ReflectionTestUtils.setField(dataset, "id", 42L);
     dataset.updateMetaJson(
         "{\"upload\":{\"objectKey\":\"" + OBJECT_KEY + "\",\"filename\":\"d.zip\"}}");
-    given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L))
-        .willReturn(Optional.of(dataset));
+    givenDatasetForCompletion(dataset);
 
     assertThatThrownBy(() -> service.complete(command()))
         .isInstanceOf(InvalidUploadStateException.class)
@@ -555,7 +555,7 @@ class CompleteRawFileUploadServiceTest {
   @Test
   @DisplayName("should_use_default_filename_and_contentType_when_missing_in_session")
   void complete_missingFilenameAndContentType_usesDefaults() {
-    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
+    givenMember();
     Dataset dataset = Dataset.createUploading(1L, "test-key", "테스트", "CRM", 1L);
     ReflectionTestUtils.setField(dataset, "id", 42L);
     // filename, contentType 필드 없음
@@ -567,11 +567,9 @@ class CompleteRawFileUploadServiceTest {
             + ",\"expiresAt\":\""
             + OffsetDateTime.now().plusMinutes(15)
             + "\",\"createdBy\":1}}");
-    given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L))
-        .willReturn(Optional.of(dataset));
-    given(storagePort.headObject(OBJECT_KEY))
-        .willReturn(Optional.of(new ObjectMetadata(EXPECTED_SIZE, "\"etag\"")));
-    given(datasetRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+    givenDatasetForCompletion(dataset);
+    givenUploadedObject(EXPECTED_SIZE, "\"etag\"");
+    givenDatasetSaveReturnsArgument();
 
     CompleteRawFileUploadResult result = service.complete(command());
 
@@ -588,7 +586,7 @@ class CompleteRawFileUploadServiceTest {
   @Test
   @DisplayName("should_promote_key_without_pending_prefix_unchanged")
   void complete_objectKeyWithoutPendingPrefix_returnsKeyUnchanged() {
-    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
+    givenMember();
     Dataset dataset = Dataset.createUploading(1L, "test-key", "테스트", "CRM", 1L);
     ReflectionTestUtils.setField(dataset, "id", 42L);
 
@@ -601,8 +599,7 @@ class CompleteRawFileUploadServiceTest {
             + OffsetDateTime.now().plusMinutes(15)
             + "\",\"createdBy\":1}}";
     dataset.updateMetaJson(nonPendingMeta);
-    given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L))
-        .willReturn(Optional.of(dataset));
+    givenDatasetForCompletion(dataset);
 
     CompleteRawFileUploadResult result = service.complete(command());
 

--- a/backend/src/test/java/com/init/corpus/application/RawDatasetUploadServiceTest.java
+++ b/backend/src/test/java/com/init/corpus/application/RawDatasetUploadServiceTest.java
@@ -76,6 +76,51 @@ class RawDatasetUploadServiceTest {
             transactionManager);
   }
 
+  private void givenWorkspaceAccessAllowed() {
+    given(workspaceExistenceRepository.existsById(1L)).willReturn(true);
+    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
+  }
+
+  private void givenDatasetKeyAvailable() {
+    given(datasetRepository.existsByWorkspaceIdAndDatasetKey(any(), any())).willReturn(false);
+  }
+
+  private void givenDatasetKeyAvailable(String datasetKey) {
+    given(datasetRepository.existsByWorkspaceIdAndDatasetKey(1L, datasetKey)).willReturn(false);
+  }
+
+  private void givenUploadAllowed() {
+    givenWorkspaceAccessAllowed();
+    givenDatasetKeyAvailable();
+  }
+
+  private Dataset givenSavedDataset(String datasetKey) {
+    Dataset savedDataset = givenSavedDatasetIdOnly();
+    given(savedDataset.getDatasetKey()).willReturn(datasetKey);
+    given(savedDataset.getStatus()).willReturn(DatasetStatus.READY);
+    given(savedDataset.getPiiRedactionStatus()).willReturn(PiiRedactionStatus.PENDING);
+    return savedDataset;
+  }
+
+  private Dataset givenSavedDatasetIdOnly() {
+    Dataset savedDataset = mock(Dataset.class);
+    given(savedDataset.getId()).willReturn(1L);
+    given(datasetRepository.save(any())).willReturn(savedDataset);
+    return savedDataset;
+  }
+
+  private Conversation givenSavedConversation() {
+    Conversation savedConversation = mock(Conversation.class);
+    given(savedConversation.getId()).willReturn(100L);
+    given(conversationRepository.save(any())).willReturn(savedConversation);
+    return savedConversation;
+  }
+
+  private void givenSuccessfulUploadPersistence(String datasetKey) {
+    givenSavedDataset(datasetKey);
+    givenSavedConversation();
+  }
+
   @Test
   @DisplayName("워크스페이스 없음 → WorkspaceNotFoundException, DB write 없음")
   void should_WorkspaceNotFoundException발생_when_워크스페이스없음() {
@@ -107,8 +152,7 @@ class RawDatasetUploadServiceTest {
   @DisplayName("데이터셋 키 중복 (사전 검증) → DatasetKeyConflictException, DB write 없음")
   void should_DatasetKeyConflictException발생_when_데이터셋키중복사전검증() {
     // given
-    given(workspaceExistenceRepository.existsById(1L)).willReturn(true);
-    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
+    givenWorkspaceAccessAllowed();
     given(datasetRepository.existsByWorkspaceIdAndDatasetKey(1L, "test-dataset-key"))
         .willReturn(true);
 
@@ -123,10 +167,8 @@ class RawDatasetUploadServiceTest {
   @DisplayName("quota 초과 → QuotaExceededException, DB write 없음")
   void should_QuotaExceededException발생_when_quota초과() {
     // given
-    given(workspaceExistenceRepository.existsById(1L)).willReturn(true);
-    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
-    given(datasetRepository.existsByWorkspaceIdAndDatasetKey(1L, "test-dataset-key"))
-        .willReturn(false);
+    givenWorkspaceAccessAllowed();
+    givenDatasetKeyAvailable("test-dataset-key");
     willThrow(new QuotaExceededException("DATASET_UPLOAD", 3, 3))
         .given(workspaceQuotaValidator)
         .assertDatasetUploadAllowed(1L);
@@ -142,19 +184,8 @@ class RawDatasetUploadServiceTest {
   @DisplayName("화자 prefix 없는 멀티라인 turn 을 포함한 content 도 거부 없이 업로드된다 (#505)")
   void should_업로드성공_when_멀티라인turn포함() {
     // given: 한 화자가 번호 목록으로 여러 줄에 걸쳐 말하는 실제 상담 로그 형태 (과거에는 400으로 거부됨)
-    given(workspaceExistenceRepository.existsById(1L)).willReturn(true);
-    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
-    given(datasetRepository.existsByWorkspaceIdAndDatasetKey(any(), any())).willReturn(false);
-
-    Dataset savedDataset = mock(Dataset.class);
-    given(savedDataset.getId()).willReturn(1L);
-    given(savedDataset.getDatasetKey()).willReturn("test-key");
-    given(savedDataset.getStatus()).willReturn(DatasetStatus.READY);
-    given(savedDataset.getPiiRedactionStatus()).willReturn(PiiRedactionStatus.PENDING);
-    given(datasetRepository.save(any())).willReturn(savedDataset);
-    Conversation savedConversation = mock(Conversation.class);
-    given(savedConversation.getId()).willReturn(100L);
-    given(conversationRepository.save(any())).willReturn(savedConversation);
+    givenUploadAllowed();
+    givenSuccessfulUploadPersistence("test-key");
 
     RawDatasetUploadCommand command =
         new RawDatasetUploadCommand(
@@ -185,21 +216,9 @@ class RawDatasetUploadServiceTest {
   @DisplayName("정상 업로드 → DatasetUploadResult 반환, conversation/turn 저장 확인")
   void should_DatasetUploadResult반환_when_정상업로드() {
     // given
-    given(workspaceExistenceRepository.existsById(1L)).willReturn(true);
-    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
-    given(datasetRepository.existsByWorkspaceIdAndDatasetKey(1L, "test-dataset-key"))
-        .willReturn(false);
-
-    Dataset savedDataset = mock(Dataset.class);
-    given(savedDataset.getId()).willReturn(1L);
-    given(savedDataset.getDatasetKey()).willReturn("test-dataset-key");
-    given(savedDataset.getStatus()).willReturn(DatasetStatus.READY);
-    given(savedDataset.getPiiRedactionStatus()).willReturn(PiiRedactionStatus.PENDING);
-    given(datasetRepository.save(any())).willReturn(savedDataset);
-
-    Conversation savedConversation = mock(Conversation.class);
-    given(savedConversation.getId()).willReturn(100L);
-    given(conversationRepository.save(any())).willReturn(savedConversation);
+    givenWorkspaceAccessAllowed();
+    givenDatasetKeyAvailable("test-dataset-key");
+    givenSuccessfulUploadPersistence("test-dataset-key");
 
     // when
     DatasetUploadResult result = service.upload(Fixtures.rawDatasetUploadCommand(1L, 1L));
@@ -217,9 +236,7 @@ class RawDatasetUploadServiceTest {
   @DisplayName("Dataset 저장 시 DataIntegrityViolationException → DatasetKeyConflictException")
   void should_DatasetKeyConflictException발생_when_Dataset저장DataIntegrityViolation() {
     // given
-    given(workspaceExistenceRepository.existsById(1L)).willReturn(true);
-    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
-    given(datasetRepository.existsByWorkspaceIdAndDatasetKey(any(), any())).willReturn(false);
+    givenUploadAllowed();
     given(datasetRepository.save(any()))
         .willThrow(new DataIntegrityViolationException("duplicate key"));
 
@@ -232,13 +249,8 @@ class RawDatasetUploadServiceTest {
   @DisplayName("conversationRepository.save() 실패 시 dataset/conversation 보상 삭제 실행")
   void should_보상삭제실행_when_conversationSave실패() {
     // given
-    given(workspaceExistenceRepository.existsById(1L)).willReturn(true);
-    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
-    given(datasetRepository.existsByWorkspaceIdAndDatasetKey(any(), any())).willReturn(false);
-
-    Dataset savedDataset = mock(Dataset.class);
-    given(savedDataset.getId()).willReturn(1L);
-    given(datasetRepository.save(any())).willReturn(savedDataset);
+    givenUploadAllowed();
+    givenSavedDatasetIdOnly();
 
     given(conversationRepository.save(any())).willThrow(new RuntimeException("flush failed"));
 
@@ -256,17 +268,9 @@ class RawDatasetUploadServiceTest {
       "conversationTurnRepository.flush() DataIntegrityViolationException(uq_turn_index) → DuplicateTurnIndexException, 보상 삭제 실행")
   void should_DuplicateTurnIndexException발생_when_flushDataIntegrityViolation() {
     // given
-    given(workspaceExistenceRepository.existsById(1L)).willReturn(true);
-    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
-    given(datasetRepository.existsByWorkspaceIdAndDatasetKey(any(), any())).willReturn(false);
-
-    Dataset savedDataset = mock(Dataset.class);
-    given(savedDataset.getId()).willReturn(1L);
-    given(datasetRepository.save(any())).willReturn(savedDataset);
-
-    Conversation savedConversation = mock(Conversation.class);
-    given(savedConversation.getId()).willReturn(100L);
-    given(conversationRepository.save(any())).willReturn(savedConversation);
+    givenUploadAllowed();
+    givenSavedDatasetIdOnly();
+    givenSavedConversation();
 
     given(conversationTurnRepository.saveAll(anyList()))
         .willReturn(List.of(mock(ConversationTurn.class)));
@@ -289,17 +293,9 @@ class RawDatasetUploadServiceTest {
       "conversationTurnRepository.flush() 비turn_index 제약 위반 → DataIntegrityViolationException 전파, 보상 삭제 실행")
   void should_DataIntegrityViolationException전파_when_flush비turnIndex제약위반() {
     // given
-    given(workspaceExistenceRepository.existsById(1L)).willReturn(true);
-    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
-    given(datasetRepository.existsByWorkspaceIdAndDatasetKey(any(), any())).willReturn(false);
-
-    Dataset savedDataset = mock(Dataset.class);
-    given(savedDataset.getId()).willReturn(1L);
-    given(datasetRepository.save(any())).willReturn(savedDataset);
-
-    Conversation savedConversation = mock(Conversation.class);
-    given(savedConversation.getId()).willReturn(100L);
-    given(conversationRepository.save(any())).willReturn(savedConversation);
+    givenUploadAllowed();
+    givenSavedDatasetIdOnly();
+    givenSavedConversation();
 
     given(conversationTurnRepository.saveAll(anyList()))
         .willReturn(List.of(mock(ConversationTurn.class)));
@@ -325,20 +321,8 @@ class RawDatasetUploadServiceTest {
   @DisplayName("1000건 업로드 시 conversationRepository.save() 1000회 호출 [Assumption: NI-3 Default A]")
   void should_1000회저장호출_when_1000건업로드() {
     // given
-    given(workspaceExistenceRepository.existsById(1L)).willReturn(true);
-    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
-    given(datasetRepository.existsByWorkspaceIdAndDatasetKey(any(), any())).willReturn(false);
-
-    Dataset savedDataset = mock(Dataset.class);
-    given(savedDataset.getId()).willReturn(1L);
-    given(savedDataset.getDatasetKey()).willReturn("batch-key");
-    given(savedDataset.getStatus()).willReturn(DatasetStatus.READY);
-    given(savedDataset.getPiiRedactionStatus()).willReturn(PiiRedactionStatus.PENDING);
-    given(datasetRepository.save(any())).willReturn(savedDataset);
-
-    Conversation savedConversation = mock(Conversation.class);
-    given(savedConversation.getId()).willReturn(100L);
-    given(conversationRepository.save(any())).willReturn(savedConversation);
+    givenUploadAllowed();
+    givenSuccessfulUploadPersistence("batch-key");
 
     List<RawConversationInput> conversations = new ArrayList<>(1000);
     for (int i = 0; i < 1000; i++) {


### PR DESCRIPTION
## 개요

#837 백엔드 application 테스트 mock fixture 정리입니다.

Corpus 업로드 application 테스트에서 반복되던 workspace 접근, dataset 조회, storage metadata, saved dataset/conversation mock setup을 private fixture helper로 묶어 각 테스트 본문이 검증 상황과 결과를 더 직접적으로 드러내도록 정리했습니다.

## 변경

- `.agent/specs/837.md`에 문제, 범위, 비목표, 검증 기준을 정리했습니다.
- `CompleteRawFileUploadServiceTest`의 member/dataset/object metadata/transaction synchronization setup을 scenario helper로 추출했습니다.
- `RawDatasetUploadServiceTest`의 workspace access, dataset key 허용, saved dataset/conversation setup을 성공 경로와 실패 경로에 맞는 fixture helper로 분리했습니다.
- storage promotion/delete, ingestion trigger, rollback cleanup, compensation delete처럼 호출 자체가 의미 있는 side effect 검증은 유지했습니다.

## 품질 근거

- 기존 테스트와 주변 helper 패턴을 먼저 확인하고, 프로덕션 코드/API/DB schema 변경 없이 backend test diff로 제한했습니다.
- 실패 경로 helper가 과하게 stubbing하던 부분은 Mockito strictness 실패로 확인 후 `givenSavedDatasetIdOnly()`로 분리했습니다.
- 3회 self-review 결과:
  - Round 1(issue fidelity/behavior): spec의 helper 이름 불일치 발견 후 수정.
  - Round 2(architecture/integration): 변경 범위가 spec + corpus application tests에 한정되고 DDD/API/schema 영향 없음 확인.
  - Round 3(reviewer/CI): `git diff --check`, 경로 검증, residual mock setup 확인, Spotless 검증 완료.

## 검증

- `cd backend && mise exec -- ./gradlew test --tests com.init.corpus.application.CompleteRawFileUploadServiceTest --tests com.init.corpus.application.RawDatasetUploadServiceTest`
- `cd backend && mise exec -- ./gradlew spotlessApply`
- `cd backend && mise exec -- ./gradlew test --tests com.init.corpus.application.CompleteRawFileUploadServiceTest --tests com.init.corpus.application.RawDatasetUploadServiceTest`
- `cd backend && mise exec -- ./gradlew spotlessCheck`
- `git diff --check`

## 참고

- 루트 `./gradlew ...`는 이 worktree에 wrapper가 없어 실패했고, 실제 wrapper 위치인 `backend/gradlew`를 `mise exec`로 실행했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 백엔드 파일 업로드 및 데이터셋 업로드 테스트의 반복되는 mock 설정 로직을 helper 메서드로 정리하여 테스트 코드의 가독성과 유지보수성을 개선했습니다.
  * 테스트 시나리오의 arrange 단계를 명확히 하고 검증 로직을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->