### PR TITLE
test(backend): #836 백엔드 테스트 시간 의존성 제거

### DIFF
--- a/.agent/specs/836.md
+++ b/.agent/specs/836.md
@@ -1,0 +1,47 @@
+# Issue 836: 백엔드 테스트 시간 의존성 제거
+
+## Problem
+
+백엔드 테스트가 wall-clock 시간과 고정 대기 시간에 직접 의존한다. `Thread.sleep`,
+`System.currentTimeMillis()`, no-arg `OffsetDateTime.now()`가 fixture와 경계 검증에 섞이면 실행
+환경에 따라 테스트가 느려지거나 드물게 흔들릴 수 있다.
+
+## Goal
+
+백엔드 테스트의 시간 fixture와 비동기 대기를 결정적으로 만들어 반복 실행 시 안정적으로 통과하게 한다.
+
+## Scope
+
+- `backend/src/test/java`의 `Thread.sleep` 사용을 이벤트 기반 대기로 교체한다.
+- JWT 인증 controller 테스트의 만료 시각 fixture를 고정된 helper로 통일한다.
+- 테스트 데이터 fixture의 no-arg `OffsetDateTime.now()`를 고정 상수 또는 고정 clock 기반 값으로 교체한다.
+- 현재 시각 경계 비교가 있는 테스트는 명시적인 기준 시각 또는 안정적인 상태 검증으로 바꾼다.
+
+## Non-goals
+
+- 운영 코드의 시간 정책이나 JWT 만료 정책을 변경하지 않는다.
+- 테스트 전반의 구조를 리팩터링하거나 새로운 테스트 프레임워크를 도입하지 않는다.
+- 이미 `Clock.fixed` 또는 고정 clock 인자로 결정적으로 작성된 테스트까지 변경하지 않는다.
+
+## Affected Modules
+
+- Backend test fixtures: `backend/src/test/java/com/init/fixtures`
+- Auth tests: `backend/src/test/java/com/init/auth`
+- Corpus tests: `backend/src/test/java/com/init/corpus`
+- Pipeline job tests: `backend/src/test/java/com/init/pipelinejob`
+- Payment tests: `backend/src/test/java/com/init/payment`
+- Workflow runtime tests: `backend/src/test/java/com/init/workflowruntime`
+
+## Requirements
+
+- `backend/src/test/java`에 `Thread.sleep`이 남지 않아야 한다.
+- JWT controller 테스트는 `System.currentTimeMillis()` 대신 고정된 만료 시각을 사용하는 shared helper를 사용한다.
+- fixture 목적의 no-arg `OffsetDateTime.now()`는 고정 상수, `OffsetDateTime.parse(...)`, 또는 이미 고정된 `Clock` 값으로 대체한다.
+- WebSocket 구독 테스트는 임의 sleep 대신 구독 receipt 또는 동등한 이벤트 기반 완료 신호를 기다린다.
+- 운영 코드 동작 변경 없이 테스트 안정성만 개선한다.
+
+## Validation
+
+- `rg -n "Thread\\.sleep|System\\.currentTimeMillis\\(|OffsetDateTime\\.now\\(\\)" backend/src/test/java`
+- `./gradlew test --tests '*Admin*ControllerTest' --tests '*PipelineJobStatusControllerTest' --tests '*ChatWebSocketIntegrationTest' --tests '*AuthServiceTest' --tests '*AppUserTest' --tests '*RefreshTokenTest' --tests '*CompleteRawFileUploadServiceTest' --tests '*PipelineArtifactTest'`
+- 필요 시 `./gradlew test`

--- a/backend/src/test/java/com/init/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/init/auth/application/AuthServiceTest.java
@@ -35,6 +35,11 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @DisplayName("AuthService")
 class AuthServiceTest {
 
+  private static final OffsetDateTime FUTURE_EXPIRES_AT =
+      OffsetDateTime.parse("2099-01-01T00:00:00Z");
+  private static final OffsetDateTime PAST_EXPIRES_AT =
+      OffsetDateTime.parse("2000-01-01T00:00:00Z");
+
   @Mock private AppUserRepository userRepository;
   @Mock private RefreshTokenRepository refreshTokenRepository;
   @Mock private JwtService jwtService;
@@ -109,8 +114,7 @@ class AuthServiceTest {
     given(jwtService.getAccessTokenExpiration()).willReturn(3600000L);
     given(tokenHasher.hash("refresh-token-value")).willReturn("sha256-refresh-hash");
 
-    RefreshToken savedToken =
-        RefreshToken.create(1L, "sha256-refresh-hash", OffsetDateTime.now().plusDays(7));
+    RefreshToken savedToken = RefreshToken.create(1L, "sha256-refresh-hash", FUTURE_EXPIRES_AT);
     given(refreshTokenRepository.save(any(RefreshToken.class))).willReturn(savedToken);
 
     // when
@@ -204,8 +208,7 @@ class AuthServiceTest {
     TokenRefreshCommand command = new TokenRefreshCommand("valid-refresh-token");
     given(tokenHasher.hash("valid-refresh-token")).willReturn("sha256-hash-of-token");
 
-    RefreshToken refreshToken =
-        RefreshToken.create(1L, "sha256-hash-of-token", OffsetDateTime.now().plusDays(7));
+    RefreshToken refreshToken = RefreshToken.create(1L, "sha256-hash-of-token", FUTURE_EXPIRES_AT);
     given(refreshTokenRepository.findByTokenHashForUpdate("sha256-hash-of-token"))
         .willReturn(Optional.of(refreshToken));
 
@@ -225,7 +228,7 @@ class AuthServiceTest {
     given(tokenHasher.hash("new-refresh-token")).willReturn("sha256-new-refresh-hash");
 
     RefreshToken newSavedToken =
-        RefreshToken.create(1L, "sha256-new-refresh-hash", OffsetDateTime.now().plusDays(7));
+        RefreshToken.create(1L, "sha256-new-refresh-hash", FUTURE_EXPIRES_AT);
     given(refreshTokenRepository.save(any(RefreshToken.class))).willReturn(newSavedToken);
 
     // when
@@ -247,8 +250,7 @@ class AuthServiceTest {
     given(tokenHasher.hash("expired-refresh-token")).willReturn("sha256-hash-expired");
 
     // 만료된 토큰 (expiresAt이 과거)
-    RefreshToken expiredToken =
-        RefreshToken.create(1L, "sha256-hash-expired", OffsetDateTime.now().minusSeconds(1));
+    RefreshToken expiredToken = RefreshToken.create(1L, "sha256-hash-expired", PAST_EXPIRES_AT);
     given(refreshTokenRepository.findByTokenHashForUpdate("sha256-hash-expired"))
         .willReturn(Optional.of(expiredToken));
 
@@ -280,8 +282,7 @@ class AuthServiceTest {
     TokenRefreshCommand command = new TokenRefreshCommand("revoked-token");
     given(tokenHasher.hash("revoked-token")).willReturn("sha256-hash-revoked");
 
-    RefreshToken revokedToken =
-        RefreshToken.create(1L, "sha256-hash-revoked", OffsetDateTime.now().plusDays(7));
+    RefreshToken revokedToken = RefreshToken.create(1L, "sha256-hash-revoked", FUTURE_EXPIRES_AT);
     revokedToken.revoke();
     given(refreshTokenRepository.findByTokenHashForUpdate("sha256-hash-revoked"))
         .willReturn(Optional.of(revokedToken));
@@ -301,8 +302,7 @@ class AuthServiceTest {
     LogoutCommand command = new LogoutCommand("valid-token");
     given(tokenHasher.hash("valid-token")).willReturn("sha256-hash");
 
-    RefreshToken refreshToken =
-        RefreshToken.create(1L, "sha256-hash", OffsetDateTime.now().plusDays(7));
+    RefreshToken refreshToken = RefreshToken.create(1L, "sha256-hash", FUTURE_EXPIRES_AT);
     given(refreshTokenRepository.findByTokenHash("sha256-hash"))
         .willReturn(Optional.of(refreshToken));
 

--- a/backend/src/test/java/com/init/auth/domain/model/AppUserTest.java
+++ b/backend/src/test/java/com/init/auth/domain/model/AppUserTest.java
@@ -10,6 +10,11 @@ import org.junit.jupiter.api.Test;
 @DisplayName("AppUser 도메인 모델")
 class AppUserTest {
 
+  private static final OffsetDateTime FUTURE_EXPIRES_AT =
+      OffsetDateTime.parse("2099-01-01T00:00:00Z");
+  private static final OffsetDateTime PAST_EXPIRES_AT =
+      OffsetDateTime.parse("2000-01-01T00:00:00Z");
+
   // ── 팩토리 ──────────────────────────────────────────────────────────────────
 
   @Test
@@ -124,7 +129,7 @@ class AppUserTest {
     // given
     AppUser user = AppUser.create("홍길동", "hong@example.com", "$2a$10$dummyhash");
     String tokenHash = "sha256hashvalue";
-    OffsetDateTime expiresAt = OffsetDateTime.now().plusMinutes(30);
+    OffsetDateTime expiresAt = FUTURE_EXPIRES_AT;
 
     // when
     user.initiatePasswordReset(tokenHash, expiresAt);
@@ -140,7 +145,7 @@ class AppUserTest {
     AppUser user = AppUser.create("홍길동", "hong@example.com", "$2a$10$dummyhash");
 
     // when & then
-    assertThatThrownBy(() -> user.initiatePasswordReset(null, OffsetDateTime.now().plusMinutes(30)))
+    assertThatThrownBy(() -> user.initiatePasswordReset(null, FUTURE_EXPIRES_AT))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("tokenHash must not be null or blank");
   }
@@ -152,7 +157,7 @@ class AppUserTest {
     AppUser user = AppUser.create("홍길동", "hong@example.com", "$2a$10$dummyhash");
 
     // when & then
-    assertThatThrownBy(() -> user.initiatePasswordReset("", OffsetDateTime.now().plusMinutes(30)))
+    assertThatThrownBy(() -> user.initiatePasswordReset("", FUTURE_EXPIRES_AT))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("tokenHash must not be null or blank");
   }
@@ -164,8 +169,7 @@ class AppUserTest {
     AppUser user = AppUser.create("홍길동", "hong@example.com", "$2a$10$dummyhash");
 
     // when & then
-    assertThatThrownBy(
-            () -> user.initiatePasswordReset("   ", OffsetDateTime.now().plusMinutes(30)))
+    assertThatThrownBy(() -> user.initiatePasswordReset("   ", FUTURE_EXPIRES_AT))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("tokenHash must not be null or blank");
   }
@@ -199,7 +203,7 @@ class AppUserTest {
   void should_false반환_when_만료된토큰() {
     // given
     AppUser user = AppUser.create("홍길동", "hong@example.com", "$2a$10$dummyhash");
-    user.initiatePasswordReset("sha256hash", OffsetDateTime.now().minusMinutes(1));
+    user.initiatePasswordReset("sha256hash", PAST_EXPIRES_AT);
 
     // when & then
     assertThat(user.isPasswordResetTokenValid()).isFalse();
@@ -210,7 +214,7 @@ class AppUserTest {
   void should_true반환_when_유효한토큰() {
     // given
     AppUser user = AppUser.create("홍길동", "hong@example.com", "$2a$10$dummyhash");
-    user.initiatePasswordReset("sha256hash", OffsetDateTime.now().plusMinutes(30));
+    user.initiatePasswordReset("sha256hash", FUTURE_EXPIRES_AT);
 
     // when & then
     assertThat(user.isPasswordResetTokenValid()).isTrue();
@@ -223,7 +227,7 @@ class AppUserTest {
   void should_비밀번호재설정완료_when_새해시제공() {
     // given
     AppUser user = AppUser.create("홍길동", "hong@example.com", "$2a$10$oldhash");
-    user.initiatePasswordReset("sha256hash", OffsetDateTime.now().plusMinutes(30));
+    user.initiatePasswordReset("sha256hash", FUTURE_EXPIRES_AT);
 
     // when
     user.completePasswordReset("$2a$10$newhash");

--- a/backend/src/test/java/com/init/auth/domain/model/RefreshTokenTest.java
+++ b/backend/src/test/java/com/init/auth/domain/model/RefreshTokenTest.java
@@ -19,6 +19,7 @@ class RefreshTokenTest {
 
   private static final Clock FIXED_NOW =
       Clock.fixed(Instant.parse("2026-04-10T00:00:00Z"), ZoneOffset.UTC);
+  private static final OffsetDateTime FUTURE_EXPIRES_AT = OffsetDateTime.now(FIXED_NOW).plusDays(7);
 
   @AfterEach
   void resetClock() {
@@ -48,8 +49,7 @@ class RefreshTokenTest {
   @Test
   @DisplayName("create: userId가 null → NullPointerException 발생")
   void should_예외발생_when_userId가null() {
-    assertThatThrownBy(
-            () -> RefreshToken.create(null, "sha256hash", OffsetDateTime.now().plusDays(7)))
+    assertThatThrownBy(() -> RefreshToken.create(null, "sha256hash", FUTURE_EXPIRES_AT))
         .isInstanceOf(NullPointerException.class)
         .hasMessageContaining("userId must not be null");
   }
@@ -57,7 +57,7 @@ class RefreshTokenTest {
   @Test
   @DisplayName("create: tokenHash가 null → IllegalArgumentException 발생")
   void should_예외발생_when_tokenHash가null() {
-    assertThatThrownBy(() -> RefreshToken.create(1L, null, OffsetDateTime.now().plusDays(7)))
+    assertThatThrownBy(() -> RefreshToken.create(1L, null, FUTURE_EXPIRES_AT))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("tokenHash must not be null or blank");
   }
@@ -65,7 +65,7 @@ class RefreshTokenTest {
   @Test
   @DisplayName("create: tokenHash가 공백 → IllegalArgumentException 발생")
   void should_예외발생_when_tokenHash가공백() {
-    assertThatThrownBy(() -> RefreshToken.create(1L, "  ", OffsetDateTime.now().plusDays(7)))
+    assertThatThrownBy(() -> RefreshToken.create(1L, "  ", FUTURE_EXPIRES_AT))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("tokenHash must not be null or blank");
   }

--- a/backend/src/test/java/com/init/auth/presentation/AdminAccountControllerTest.java
+++ b/backend/src/test/java/com/init/auth/presentation/AdminAccountControllerTest.java
@@ -1,5 +1,6 @@
 package com.init.auth.presentation;
 
+import static com.init.fixtures.JwtClaimsFixtures.accessClaims;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -15,8 +16,6 @@ import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
 import com.init.shared.infrastructure.security.SecurityConfig;
 import com.init.shared.presentation.GlobalExceptionHandler;
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
-import java.util.Date;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -196,13 +195,7 @@ class AdminAccountControllerTest {
   }
 
   private void givenBearerToken(String token, String role) {
-    Claims claims =
-        Jwts.claims()
-            .subject("1")
-            .add("type", "access")
-            .add("role", role)
-            .expiration(new Date(System.currentTimeMillis() + 60_000))
-            .build();
+    Claims claims = accessClaims("1", role);
     given(jwtService.parseClaims(token)).willReturn(claims);
     given(jwtService.isTokenValid(claims)).willReturn(true);
     given(jwtService.isAccessToken(claims)).willReturn(true);

--- a/backend/src/test/java/com/init/corpus/application/CompleteRawFileUploadServiceTest.java
+++ b/backend/src/test/java/com/init/corpus/application/CompleteRawFileUploadServiceTest.java
@@ -54,6 +54,10 @@ class CompleteRawFileUploadServiceTest {
   private static final String COMPLETED_KEY =
       "completed/workspaces/1/datasets/test-key/uuid_data.zip";
   private static final long EXPECTED_SIZE = 1024L;
+  private static final OffsetDateTime FUTURE_EXPIRES_AT =
+      OffsetDateTime.parse("2099-01-01T00:00:00Z");
+  private static final OffsetDateTime PAST_EXPIRES_AT =
+      OffsetDateTime.parse("2000-01-01T00:00:00Z");
 
   @BeforeEach
   void setUp() {
@@ -115,7 +119,7 @@ class CompleteRawFileUploadServiceTest {
   }
 
   private String buildMeta(long size) {
-    return buildMeta(size, OffsetDateTime.now().plusMinutes(15), 1L);
+    return buildMeta(size, FUTURE_EXPIRES_AT, 1L);
   }
 
   private String buildMeta(long size, OffsetDateTime expiresAt, long createdBy) {
@@ -344,7 +348,7 @@ class CompleteRawFileUploadServiceTest {
   void complete_expiredUploadSession_throws() {
     givenMember();
     Dataset dataset = uploadingDataset();
-    dataset.updateMetaJson(buildMeta(EXPECTED_SIZE, OffsetDateTime.now().minusMinutes(1), 1L));
+    dataset.updateMetaJson(buildMeta(EXPECTED_SIZE, PAST_EXPIRES_AT, 1L));
     givenDatasetForCompletion(dataset);
 
     assertThatThrownBy(() -> service.complete(command()))
@@ -413,7 +417,7 @@ class CompleteRawFileUploadServiceTest {
             + "\",\"expectedSizeBytes\":"
             + EXPECTED_SIZE
             + ",\"filename\":\"data.zip\",\"contentType\":\"application/zip\",\"expiresAt\":\""
-            + OffsetDateTime.now().plusMinutes(15)
+            + FUTURE_EXPIRES_AT
             + "\"}}");
     givenDatasetForCompletion(dataset);
 
@@ -487,7 +491,7 @@ class CompleteRawFileUploadServiceTest {
         "{\"upload\":{\"objectKey\":\"direct/key.zip\",\"expectedSizeBytes\":"
             + EXPECTED_SIZE
             + ",\"filename\":\"data.zip\",\"contentType\":\"application/zip\",\"expiresAt\":\""
-            + OffsetDateTime.now().plusMinutes(15)
+            + FUTURE_EXPIRES_AT
             + "\",\"createdBy\":1}}");
     givenDatasetForCompletion(dataset);
     given(storagePort.headObject("direct/key.zip"))
@@ -565,7 +569,7 @@ class CompleteRawFileUploadServiceTest {
             + "\",\"expectedSizeBytes\":"
             + EXPECTED_SIZE
             + ",\"expiresAt\":\""
-            + OffsetDateTime.now().plusMinutes(15)
+            + FUTURE_EXPIRES_AT
             + "\",\"createdBy\":1}}");
     givenDatasetForCompletion(dataset);
     givenUploadedObject(EXPECTED_SIZE, "\"etag\"");
@@ -596,7 +600,7 @@ class CompleteRawFileUploadServiceTest {
         "{\"upload\":{\"objectKey\":\"direct/key.zip\",\"expectedSizeBytes\":"
             + EXPECTED_SIZE
             + ",\"filename\":\"data.zip\",\"contentType\":\"application/zip\",\"expiresAt\":\""
-            + OffsetDateTime.now().plusMinutes(15)
+            + FUTURE_EXPIRES_AT
             + "\",\"createdBy\":1}}";
     dataset.updateMetaJson(nonPendingMeta);
     givenDatasetForCompletion(dataset);

--- a/backend/src/test/java/com/init/corpus/domain/model/ConversationTest.java
+++ b/backend/src/test/java/com/init/corpus/domain/model/ConversationTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Test;
 @DisplayName("Conversation")
 class ConversationTest {
 
+  private static final OffsetDateTime STARTED_AT = OffsetDateTime.parse("2026-06-01T09:00:00Z");
+
   @Test
   @DisplayName("유효한 입력으로 Conversation을 생성한다")
   void should_생성성공_when_유효한입력() {
@@ -61,7 +63,7 @@ class ConversationTest {
   @DisplayName("endedAt이 startedAt보다 이전이면 IllegalArgumentException을 던진다")
   void should_IAE_when_endedAtBeforeStartedAt() {
     // given
-    OffsetDateTime start = OffsetDateTime.now();
+    OffsetDateTime start = STARTED_AT;
     OffsetDateTime end = start.minusMinutes(1);
 
     // when & then

--- a/backend/src/test/java/com/init/fixtures/JwtClaimsFixtures.java
+++ b/backend/src/test/java/com/init/fixtures/JwtClaimsFixtures.java
@@ -1,0 +1,23 @@
+package com.init.fixtures;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import java.time.Instant;
+import java.util.Date;
+
+public final class JwtClaimsFixtures {
+
+  private static final Instant FIXED_ACCESS_TOKEN_EXPIRATION =
+      Instant.parse("2099-01-01T00:00:00Z");
+
+  private JwtClaimsFixtures() {}
+
+  public static Claims accessClaims(String subject, String role) {
+    return Jwts.claims()
+        .subject(subject)
+        .add("type", "access")
+        .add("role", role)
+        .expiration(Date.from(FIXED_ACCESS_TOKEN_EXPIRATION))
+        .build();
+  }
+}

--- a/backend/src/test/java/com/init/payment/application/AdminBillingUseCaseTest.java
+++ b/backend/src/test/java/com/init/payment/application/AdminBillingUseCaseTest.java
@@ -40,6 +40,9 @@ import org.springframework.transaction.support.SimpleTransactionStatus;
 @DisplayName("AdminBillingUseCase")
 class AdminBillingUseCaseTest {
 
+  private static final OffsetDateTime APPROVED_AT = OffsetDateTime.parse("2026-06-01T09:00:00Z");
+  private static final OffsetDateTime CANCELED_AT = OffsetDateTime.parse("2026-06-03T12:00:00Z");
+
   @Mock private AdminBillingQueryRepository queryRepository;
   @Mock private PaymentRepository paymentRepository;
   @Mock private PaymentCancelRepository paymentCancelRepository;
@@ -59,11 +62,10 @@ class AdminBillingUseCaseTest {
   void should_결제취소와환불기록저장_when_TossCancel성공() {
     // given
     Payment payment = completedPayment("ord_1", "pay_1");
-    OffsetDateTime canceledAt = OffsetDateTime.parse("2026-06-03T12:00:00Z");
     given(paymentRepository.findByIdForUpdate(100L)).willReturn(Optional.of(payment));
     given(paymentCancelRepository.existsByPaymentId(100L)).willReturn(false);
     given(tossPaymentGateway.cancelPayment(eq("pay_1"), eq("고객 요청"), eq("admin-full-refund-100")))
-        .willReturn(new TossCancelResult("tx_cancel_1", canceledAt));
+        .willReturn(new TossCancelResult("tx_cancel_1", CANCELED_AT));
 
     // when
     AdminBillingRefundResult result =
@@ -225,7 +227,7 @@ class AdminBillingUseCaseTest {
   void should_Toss호출없이실패_when_완료상태아님() {
     // given
     Payment payment = completedPayment("ord_1", "pay_1");
-    payment.refundFull("고객 요청", "tx_cancel_1", OffsetDateTime.now());
+    payment.refundFull("고객 요청", "tx_cancel_1", CANCELED_AT);
     given(paymentRepository.findByIdForUpdate(100L)).willReturn(Optional.of(payment));
     given(paymentCancelRepository.existsByPaymentId(100L)).willReturn(false);
     AdminBillingRefundCommand command = new AdminBillingRefundCommand(100L, "고객 요청");
@@ -252,7 +254,7 @@ class AdminBillingUseCaseTest {
   private Payment completedPayment(String orderId, String paymentKey) {
     Payment payment = Payment.createOrder(1L, 10L, orderId, 29_000L, "KRW", "Pro");
     PersistenceTestFixtures.assignGeneratedId(payment, 100L);
-    payment.complete(paymentKey, "CARD", OffsetDateTime.now(), "https://receipt", "{}");
+    payment.complete(paymentKey, "CARD", APPROVED_AT, "https://receipt", "{}");
     return payment;
   }
 }

--- a/backend/src/test/java/com/init/payment/presentation/AdminBillingControllerTest.java
+++ b/backend/src/test/java/com/init/payment/presentation/AdminBillingControllerTest.java
@@ -1,5 +1,6 @@
 package com.init.payment.presentation;
 
+import static com.init.fixtures.JwtClaimsFixtures.accessClaims;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -17,9 +18,7 @@ import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
 import com.init.shared.infrastructure.security.SecurityConfig;
 import com.init.shared.presentation.GlobalExceptionHandler;
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
 import java.time.OffsetDateTime;
-import java.util.Date;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -167,13 +166,7 @@ class AdminBillingControllerTest {
   }
 
   private void givenBearerToken(String token, String role) {
-    Claims claims =
-        Jwts.claims()
-            .subject("1")
-            .add("type", "access")
-            .add("role", role)
-            .expiration(new Date(System.currentTimeMillis() + 60_000))
-            .build();
+    Claims claims = accessClaims("1", role);
     given(jwtService.parseClaims(token)).willReturn(claims);
     given(jwtService.isTokenValid(claims)).willReturn(true);
     given(jwtService.isAccessToken(claims)).willReturn(true);

--- a/backend/src/test/java/com/init/pipelinejob/domain/model/PipelineArtifactTest.java
+++ b/backend/src/test/java/com/init/pipelinejob/domain/model/PipelineArtifactTest.java
@@ -36,13 +36,11 @@ class PipelineArtifactTest {
   @Test
   @DisplayName("payload와 생성 시간이 없으면 기본값을 사용한다")
   void create_withNullPayloadAndCreatedAt_usesDefaults() {
-    OffsetDateTime before = OffsetDateTime.now().minusSeconds(1);
-
     PipelineArtifact artifact =
         PipelineArtifact.create(7L, "stage", "TYPE", null, null, null, null);
 
     assertThat(artifact.getArtifactUri()).isNull();
     assertThat(artifact.getPayloadJson()).isEqualTo("{}");
-    assertThat(artifact.getCreatedAt()).isAfter(before);
+    assertThat(artifact.getCreatedAt()).isNotNull();
   }
 }

--- a/backend/src/test/java/com/init/pipelinejob/presentation/AdminPipelineJobControllerTest.java
+++ b/backend/src/test/java/com/init/pipelinejob/presentation/AdminPipelineJobControllerTest.java
@@ -1,5 +1,6 @@
 package com.init.pipelinejob.presentation;
 
+import static com.init.fixtures.JwtClaimsFixtures.accessClaims;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -19,9 +20,7 @@ import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
 import com.init.shared.infrastructure.security.SecurityConfig;
 import com.init.shared.presentation.GlobalExceptionHandler;
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
 import java.time.OffsetDateTime;
-import java.util.Date;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -154,13 +153,7 @@ class AdminPipelineJobControllerTest {
   }
 
   private void givenBearerToken(String token, String role) {
-    Claims claims =
-        Jwts.claims()
-            .subject("1")
-            .add("type", "access")
-            .add("role", role)
-            .expiration(new Date(System.currentTimeMillis() + 60_000))
-            .build();
+    Claims claims = accessClaims("1", role);
     given(jwtService.parseClaims(token)).willReturn(claims);
     given(jwtService.isTokenValid(claims)).willReturn(true);
     given(jwtService.isAccessToken(claims)).willReturn(true);

--- a/backend/src/test/java/com/init/pipelinejob/presentation/PipelineJobStatusControllerTest.java
+++ b/backend/src/test/java/com/init/pipelinejob/presentation/PipelineJobStatusControllerTest.java
@@ -1,5 +1,6 @@
 package com.init.pipelinejob.presentation;
 
+import static com.init.fixtures.JwtClaimsFixtures.accessClaims;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -18,9 +19,7 @@ import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
 import com.init.shared.infrastructure.security.SecurityConfig;
 import com.init.shared.presentation.GlobalExceptionHandler;
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
 import java.time.OffsetDateTime;
-import java.util.Date;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -114,13 +113,7 @@ class PipelineJobStatusControllerTest {
   }
 
   private void givenBearerToken(String token, String role) {
-    Claims claims =
-        Jwts.claims()
-            .subject("9")
-            .add("type", "access")
-            .add("role", role)
-            .expiration(new Date(System.currentTimeMillis() + 60_000))
-            .build();
+    Claims claims = accessClaims("9", role);
     given(jwtService.parseClaims(token)).willReturn(claims);
     given(jwtService.isTokenValid(claims)).willReturn(true);
     given(jwtService.isAccessToken(claims)).willReturn(true);

--- a/backend/src/test/java/com/init/workflowruntime/application/SimulationImprovementCandidateServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/SimulationImprovementCandidateServiceTest.java
@@ -95,6 +95,7 @@ class SimulationImprovementCandidateServiceTest {
   private static final Long VERSION_ID = 101L;
   private static final Long SESSION_ID = 55L;
   private static final Long FEEDBACK_ID = 900L;
+  private static final OffsetDateTime REVIEWED_AT = OffsetDateTime.parse("2026-06-01T09:00:00Z");
 
   @Mock private SimulationFeedbackRepository feedbackRepository;
   @Mock private SimulationImprovementCandidateRepository candidateRepository;
@@ -1036,7 +1037,7 @@ class SimulationImprovementCandidateServiceTest {
     feedback.markCandidateCreated();
     SimulationImprovementCandidate candidate = withCandidateId(candidate(feedback), 1000L);
     candidate.submitForReview(2000L, 3000L);
-    candidate.markApplied(VERSION_ID, USER_ID, "이미 반영됨", OffsetDateTime.now());
+    candidate.markApplied(VERSION_ID, USER_ID, "이미 반영됨", REVIEWED_AT);
     given(candidateRepository.findById(1000L)).willReturn(Optional.of(candidate));
     given(feedbackRepository.findByIdForUpdate(FEEDBACK_ID)).willReturn(Optional.of(feedback));
 
@@ -1082,7 +1083,7 @@ class SimulationImprovementCandidateServiceTest {
     SimulationImprovementCandidate candidate = withCandidateId(candidate(feedback), 1000L);
     candidate.submitForReview(2000L, 3000L);
     ReviewTask task = reviewTask(2000L, candidate.getId(), 3000L);
-    task.resolve(USER_ID, OffsetDateTime.now());
+    task.resolve(USER_ID, REVIEWED_AT);
     given(candidateRepository.findById(1000L)).willReturn(Optional.of(candidate));
     given(feedbackRepository.findByIdForUpdate(FEEDBACK_ID)).willReturn(Optional.of(feedback));
     given(reviewTaskRepository.findById(3000L)).willReturn(Optional.of(task));
@@ -1320,7 +1321,7 @@ class SimulationImprovementCandidateServiceTest {
             null,
             USER_ID,
             "{}",
-            OffsetDateTime.now());
+            REVIEWED_AT);
     return reviewSessionWithId(session, id);
   }
 
@@ -1334,7 +1335,7 @@ class SimulationImprovementCandidateServiceTest {
             "task",
             "NORMAL",
             "{}",
-            OffsetDateTime.now());
+            REVIEWED_AT);
     return reviewTaskWithId(task, id);
   }
 }

--- a/backend/src/test/java/com/init/workflowruntime/presentation/ChatWebSocketControllerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/ChatWebSocketControllerTest.java
@@ -25,6 +25,8 @@ import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 @DisplayName("ChatWebSocketController")
 class ChatWebSocketControllerTest {
 
+  private static final OffsetDateTime SENT_AT = OffsetDateTime.parse("2026-06-01T09:00:00Z");
+
   @Mock private ChatWebSocketService chatWebSocketService;
 
   private ChatWebSocketController controller;
@@ -44,7 +46,7 @@ class ChatWebSocketControllerTest {
     Principal principal = () -> "42";
 
     ChatMessageResponse expected =
-        new ChatMessageResponse(10L, 1, "USER", "TEXT", "Hello", OffsetDateTime.now());
+        new ChatMessageResponse(10L, 1, "USER", "TEXT", "Hello", SENT_AT);
 
     given(chatWebSocketService.saveAndBroadcast(any(SendChatMessageCommand.class)))
         .willReturn(expected);

--- a/backend/src/test/java/com/init/workflowruntime/presentation/ChatWebSocketIntegrationTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/ChatWebSocketIntegrationTest.java
@@ -5,13 +5,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.init.auth.application.JwtService;
 import java.lang.reflect.Type;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Bean;
 import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.stomp.StompFrameHandler;
 import org.springframework.messaging.simp.stomp.StompHeaders;
 import org.springframework.messaging.simp.stomp.StompSession;
@@ -19,6 +24,7 @@ import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.socket.WebSocketHttpHeaders;
 import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
 import org.springframework.web.socket.messaging.WebSocketStompClient;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -29,6 +35,7 @@ class ChatWebSocketIntegrationTest {
   @LocalServerPort private int port;
 
   @Autowired private JwtService jwtService;
+  @Autowired private SubscriptionTracker subscriptionTracker;
 
   @Test
   @DisplayName("valid access token으로 STOMP 연결이 수립된다")
@@ -86,8 +93,10 @@ class ChatWebSocketIntegrationTest {
             .get(5, TimeUnit.SECONDS);
 
     try {
+      String destination = "/user/queue/errors";
+      CompletableFuture<Void> subscribed = subscriptionTracker.expect(destination);
       session.subscribe(
-          "/user/queue/errors",
+          destination,
           new StompFrameHandler() {
             @Override
             public Type getPayloadType(StompHeaders headers) {
@@ -97,14 +106,50 @@ class ChatWebSocketIntegrationTest {
             @Override
             public void handleFrame(StompHeaders headers, Object payload) {}
           });
-
-      Thread.sleep(250);
+      subscribed.get(5, TimeUnit.SECONDS);
       assertThat(session.isConnected()).isTrue();
     } finally {
       if (session.isConnected()) {
         session.disconnect();
       }
       stompClient.stop();
+    }
+  }
+
+  @TestConfiguration
+  static class SubscriptionTrackerConfig {
+
+    @Bean
+    SubscriptionTracker subscriptionTracker() {
+      return new SubscriptionTracker();
+    }
+
+    @Bean
+    ApplicationListener<SessionSubscribeEvent> subscriptionTrackerListener(
+        SubscriptionTracker tracker) {
+      return event -> {
+        String destination = SimpMessageHeaderAccessor.wrap(event.getMessage()).getDestination();
+        tracker.markSubscribed(destination);
+      };
+    }
+  }
+
+  static class SubscriptionTracker {
+
+    private final ConcurrentHashMap<String, CompletableFuture<Void>> subscriptions =
+        new ConcurrentHashMap<>();
+
+    CompletableFuture<Void> expect(String destination) {
+      CompletableFuture<Void> subscription = new CompletableFuture<>();
+      subscriptions.put(destination, subscription);
+      return subscription;
+    }
+
+    void markSubscribed(String destination) {
+      CompletableFuture<Void> subscription = subscriptions.get(destination);
+      if (subscription != null) {
+        subscription.complete(null);
+      }
     }
   }
 }

--- a/backend/src/test/java/com/init/workflowruntime/presentation/ConsultationControllerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/ConsultationControllerTest.java
@@ -61,6 +61,7 @@ import org.springframework.test.web.servlet.MockMvc;
 class ConsultationControllerTest {
 
   private static final String DRAFT_RESPONSE = "주문번호를 확인해주시면 환불 가능 여부를 안내드리겠습니다.";
+  private static final OffsetDateTime SENT_AT = OffsetDateTime.parse("2026-06-01T09:00:00Z");
 
   @Autowired private MockMvc mockMvc;
 
@@ -86,8 +87,7 @@ class ConsultationControllerTest {
   @DisplayName("GET /api/v1/consultation/sessions/{id}/messages - 메시지 조회 성공")
   void should_메시지목록반환_when_정상조회() throws Exception {
     // given
-    ChatMessageResponse msg =
-        new ChatMessageResponse(1L, 1, "CUSTOMER", "TEXT", "Hello", OffsetDateTime.now());
+    ChatMessageResponse msg = new ChatMessageResponse(1L, 1, "CUSTOMER", "TEXT", "Hello", SENT_AT);
 
     given(consultationService.getMessages(1L, 7L, 0, 50))
         .willReturn(new ChatMessagePageResponse(List.of(msg), 0, 50, 1, 1));
@@ -107,8 +107,7 @@ class ConsultationControllerTest {
   @Test
   @DisplayName("GET /api/v1/consultation/sessions/{id}/messages - page/size 파라미터 전달")
   void should_페이지파라미터전달_when_메시지조회() throws Exception {
-    ChatMessageResponse msg =
-        new ChatMessageResponse(2L, 45, "CUSTOMER", "TEXT", "Old", OffsetDateTime.now());
+    ChatMessageResponse msg = new ChatMessageResponse(2L, 45, "CUSTOMER", "TEXT", "Old", SENT_AT);
     given(consultationService.getMessages(1L, 7L, 1, 25))
         .willReturn(new ChatMessagePageResponse(List.of(msg), 1, 25, 80, 4));
 
@@ -136,7 +135,7 @@ class ConsultationControllerTest {
     request.setNote(false);
 
     ChatMessageResponse response =
-        new ChatMessageResponse(10L, 1, "AGENT", "TEXT", "Hello Operator", OffsetDateTime.now());
+        new ChatMessageResponse(10L, 1, "AGENT", "TEXT", "Hello Operator", SENT_AT);
 
     given(consultationService.sendMessage(eq(1L), any(SendMessageRequest.class), eq(7L)))
         .willReturn(response);

--- a/backend/src/test/java/com/init/workflowruntime/presentation/CounselorSessionControllerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/CounselorSessionControllerTest.java
@@ -41,6 +41,8 @@ import org.springframework.test.web.servlet.MockMvc;
 @AutoConfigureMockMvc(addFilters = false)
 class CounselorSessionControllerTest {
 
+  private static final OffsetDateTime STARTED_AT = OffsetDateTime.parse("2026-06-01T09:00:00Z");
+
   @Autowired private MockMvc mockMvc;
 
   @SuppressWarnings("removal")
@@ -55,7 +57,7 @@ class CounselorSessionControllerTest {
     response.setStatus("ACTIVE");
     response.setAssignedCounselorId(42L);
     response.setChannel("WEB");
-    response.setStartedAt(OffsetDateTime.now());
+    response.setStartedAt(STARTED_AT);
 
     given(counselorService.assignSession(eq(1L), eq(42L))).willReturn(response);
 
@@ -75,7 +77,7 @@ class CounselorSessionControllerTest {
     response.setStatus("ACTIVE");
     response.setAssignedCounselorId(42L);
     response.setChannel("WEB");
-    response.setStartedAt(OffsetDateTime.now());
+    response.setStartedAt(STARTED_AT);
 
     given(counselorService.assignSession(eq(1L), eq(42L))).willReturn(response);
 

--- a/backend/src/test/java/com/init/workflowruntime/presentation/CounselorWebSocketControllerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/CounselorWebSocketControllerTest.java
@@ -23,6 +23,8 @@ import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 @DisplayName("CounselorWebSocketController")
 class CounselorWebSocketControllerTest {
 
+  private static final OffsetDateTime SENT_AT = OffsetDateTime.parse("2026-06-01T09:00:00Z");
+
   @Mock private CounselorService counselorService;
 
   private CounselorWebSocketController controller;
@@ -42,8 +44,7 @@ class CounselorWebSocketControllerTest {
     Principal principal = () -> "42";
 
     ChatMessageResponse expected =
-        new ChatMessageResponse(
-            10L, 1, "COUNSELOR", "TEXT", "Counselor message", OffsetDateTime.now());
+        new ChatMessageResponse(10L, 1, "COUNSELOR", "TEXT", "Counselor message", SENT_AT);
 
     given(counselorService.sendCounselorMessage(1L, "Counselor message", 42L, false))
         .willReturn(expected);

--- a/backend/src/test/java/com/init/workflowruntime/presentation/WorkspaceConsultationQueueControllerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/WorkspaceConsultationQueueControllerTest.java
@@ -31,6 +31,8 @@ import org.springframework.test.web.servlet.MockMvc;
 @AutoConfigureMockMvc(addFilters = false)
 class WorkspaceConsultationQueueControllerTest {
 
+  private static final OffsetDateTime STARTED_AT = OffsetDateTime.parse("2026-06-01T09:00:00Z");
+
   @Autowired private MockMvc mockMvc;
 
   @SuppressWarnings("removal")
@@ -44,7 +46,7 @@ class WorkspaceConsultationQueueControllerTest {
     response.setId(1L);
     response.setStatus("OPEN");
     response.setChannel("카카오톡");
-    response.setStartedAt(OffsetDateTime.now());
+    response.setStartedAt(STARTED_AT);
 
     given(consultationService.getActiveQueue(2L, 7L)).willReturn(List.of(response));
 

--- a/backend/src/test/java/com/init/workspace/presentation/AdminCustomerControllerTest.java
+++ b/backend/src/test/java/com/init/workspace/presentation/AdminCustomerControllerTest.java
@@ -1,5 +1,6 @@
 package com.init.workspace.presentation;
 
+import static com.init.fixtures.JwtClaimsFixtures.accessClaims;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -26,9 +27,7 @@ import com.init.workspace.application.GetAdminCustomerListUseCase;
 import com.init.workspace.application.WorkspaceFreeOnboardingResult;
 import com.init.workspace.application.WorkspaceFreeOnboardingService;
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
 import java.time.OffsetDateTime;
-import java.util.Date;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -175,13 +174,7 @@ class AdminCustomerControllerTest {
   }
 
   private void givenBearerToken(String token, String role) {
-    Claims claims =
-        Jwts.claims()
-            .subject("1")
-            .add("type", "access")
-            .add("role", role)
-            .expiration(new Date(System.currentTimeMillis() + 60_000))
-            .build();
+    Claims claims = accessClaims("1", role);
     given(jwtService.parseClaims(token)).willReturn(claims);
     given(jwtService.isTokenValid(claims)).willReturn(true);
     given(jwtService.isAccessToken(claims)).willReturn(true);


### PR DESCRIPTION
## 개요

Closes #836

백엔드 테스트에서 wall-clock fixture와 고정 sleep에 직접 의존하던 패턴을 제거합니다. 운영 코드, API, DB schema 동작은 변경하지 않고 backend test/spec diff로 제한했습니다.

## 변경

- `.agent/specs/836.md`에 문제, 범위, 비목표, 검증 기준을 정리했습니다.
- JWT controller 테스트의 claims fixture를 `JwtClaimsFixtures`로 모아 고정 만료 시각을 사용하도록 했습니다.
- auth, corpus, payment, pipeline-job, workflow-runtime 테스트의 no-arg `OffsetDateTime.now()` fixture를 명시적인 고정 시각으로 바꿨습니다.
- `ChatWebSocketIntegrationTest`의 `Thread.sleep(250)`을 서버 측 `SessionSubscribeEvent` 기반 대기로 교체했습니다.

## 품질 근거

- 변경 전 `backend/src/test/java`에서 `Thread.sleep`, `System.currentTimeMillis()`, no-arg `OffsetDateTime.now()` 사용 지점을 스캔하고, 이미 `Clock.fixed`/고정 clock 인자를 쓰는 테스트는 유지했습니다.
- 구현은 test fixture/helper와 기존 JUnit/Spring WebSocket test 패턴 안에서만 이뤄졌고 production DDD/API/schema 영향은 없습니다.
- 3회 self-review 결과:
  - Round 1(issue fidelity/behavior): 이슈의 sleep 제거, JWT fixed clock helper, fixture time 고정, WebSocket 이벤트 대기 조건을 diff와 스캔 결과에 매핑했습니다.
  - Round 2(architecture/integration): shared JWT helper의 test-only 경계와 WebSocket test configuration 범위를 확인했고, mutable `Date` fixture 공유 가능성을 수정했습니다.
  - Round 3(reviewer/CI): unintended files, stale paths, whitespace, remaining time-pattern scan, staged diff를 점검했습니다.

## 검증

- `cd backend && JAVA_HOME=/Users/owen/.local/share/mise/installs/java/temurin-21.0.11+10.0.LTS ./gradlew spotlessApply` → BUILD SUCCESSFUL
- `cd backend && JAVA_HOME=/Users/owen/.local/share/mise/installs/java/temurin-21.0.11+10.0.LTS ./gradlew test --tests '*Admin*ControllerTest' --tests '*PipelineJobStatusControllerTest' --tests '*ChatWebSocketIntegrationTest' --tests '*AuthServiceTest' --tests '*AppUserTest' --tests '*RefreshTokenTest' --tests '*CompleteRawFileUploadServiceTest' --tests '*PipelineArtifactTest' --tests '*SimulationImprovementCandidateServiceTest' --tests '*ChatWebSocketControllerTest' --tests '*CounselorWebSocketControllerTest' --tests '*ConsultationControllerTest' --tests '*CounselorSessionControllerTest' --tests '*WorkspaceConsultationQueueControllerTest' --tests '*ChatSessionTest' --tests '*ConversationTest'` → BUILD SUCCESSFUL
- `cd backend && JAVA_HOME=/Users/owen/.local/share/mise/installs/java/temurin-21.0.11+10.0.LTS ./gradlew test` → BUILD SUCCESSFUL
- `rg -n "Thread\.sleep|System\.currentTimeMillis\(|OffsetDateTime\.now\(\)|Instant\.now\(\)|LocalDateTime\.now\(\)|LocalDate\.now\(\)|ZonedDateTime\.now\(" backend/src/test/java` → no output
- `git diff --check` → no output

## 참고

- 로컬 기본 `java`는 17로 잡혀 Gradle Java 21 toolchain 요구사항을 만족하지 않아, mise의 Temurin 21 경로를 명시해 검증했습니다.