### PR TITLE
fix(workflow-runtime): #862 같은 intent workflow 선택 루프 방지

### DIFF
--- a/backend/src/main/java/com/init/workflowruntime/application/matching/WorkflowMatchingCore.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/matching/WorkflowMatchingCore.java
@@ -46,6 +46,11 @@ public class WorkflowMatchingCore {
       return WorkflowMatchResult.blocked(MATCH_FAILURE_MESSAGE, ranked.stream().limit(3).toList());
     }
     WorkflowMatchCandidate second = ranked.size() > 1 ? ranked.get(1) : null;
+    if (isSameIntentWorkflowOverlap(top, second)
+        && top.confidence() >= properties.confidentThresholdOrDefault()
+        && top.autoRunEligible()) {
+      return WorkflowMatchResult.confident(top);
+    }
     double margin = second == null ? 1.0 : top.confidence() - second.confidence();
     if (top.confidence() >= properties.confidentThresholdOrDefault()
         && margin >= properties.confidentMarginOrDefault()
@@ -57,6 +62,11 @@ public class WorkflowMatchingCore {
           buildConfirmationQuestion(ranked), ranked.stream().limit(3).toList());
     }
     return WorkflowMatchResult.unknown(MATCH_FAILURE_MESSAGE);
+  }
+
+  private boolean isSameIntentWorkflowOverlap(
+      WorkflowMatchCandidate top, WorkflowMatchCandidate second) {
+    return second != null && top.intentDefinitionId().equals(second.intentDefinitionId());
   }
 
   private WorkflowMatchCandidate rerank(

--- a/backend/src/test/java/com/init/workflowruntime/application/matching/WorkflowMatchingServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/matching/WorkflowMatchingServiceTest.java
@@ -449,8 +449,8 @@ class WorkflowMatchingServiceTest {
   }
 
   @Test
-  @DisplayName("top 후보 간 margin이 좁으면 혼동 유형을 남기고 확인 질문으로 내린다")
-  void should_markConfusionType_when_candidatesAreTooClose() {
+  @DisplayName("같은 intent의 workflow 후보만 겹치면 top 후보를 확정한다")
+  void should_returnConfident_when_sameIntentWorkflowCandidatesOverlap() {
     givenSession();
     given(profileRepository.countActiveProfiles(101L)).willReturn(2);
     given(embeddingClient.embed(anyString(), eq(EmbeddingInputType.SEARCH_QUERY)))
@@ -485,16 +485,17 @@ class WorkflowMatchingServiceTest {
 
     WorkflowMatchResult result = service.match(1L, "환불하고 싶어요", "");
 
-    assertThat(result.status()).isEqualTo("AMBIGUOUS");
+    assertThat(result.status()).isEqualTo("CONFIDENT");
+    assertThat(result.candidates().getFirst().workflowDefinitionId()).isEqualTo(20L);
     assertThat(result.candidates().getFirst().confusionType())
         .isEqualTo("same_intent_workflow_overlap");
     verify(decisionRepository)
         .record(
             eq(1L),
             eq(101L),
-            eq(null),
-            eq(null),
-            eq("AMBIGUOUS"),
+            eq(20L),
+            eq(10L),
+            eq("CONFIDENT"),
             eq(result.candidates().getFirst().confidence()),
             anyString(),
             eq("profile-v1"),
@@ -504,7 +505,7 @@ class WorkflowMatchingServiceTest {
             anyString(),
             org.mockito.ArgumentMatchers.contains("same_intent_workflow_overlap"),
             org.mockito.ArgumentMatchers.contains("same_intent_workflow_overlap"),
-            eq("confusion_same_intent_workflow_overlap"));
+            eq(null));
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Treats close workflow candidates under the same intent as a same-intent workflow overlap instead of asking the user to choose between effectively identical options.
- Confirms the top workflow when it is eligible and above the confident threshold.
- Updates the matching service test to cover the resolved loop behavior.

## Root Cause

The matcher used the global confidence margin even when the top candidates belonged to the same intent. HanaCard's expanded seed can produce many source-specific workflows with nearly identical labels and route evidence, so user confirmation text was reclassified into the same ambiguous state repeatedly.

Closes #862

## Validation

- `cd backend && ./gradlew test --tests com.init.workflowruntime.application.matching.WorkflowMatchingServiceTest`
- `cd backend && ./gradlew spotlessCheck`
