### PR TITLE
test(backend): #831 pipeline-job/review ReflectionTestUtils 의존 제거

### DIFF
--- a/.agent/specs/831.md
+++ b/.agent/specs/831.md
@@ -1,0 +1,51 @@
+# Issue 831: pipeline-job/review 테스트 fixture에서 ReflectionTestUtils 제거
+
+## Goal
+
+`pipelinejob`와 `review` 테스트가 엔티티 private field를 직접 조작하지 않고, 도메인 factory/전이 메서드와 명시적인 테스트 fixture로 상태 의도를 드러내도록 정리한다.
+
+## Background
+
+파이프라인 job callback, review checkpoint, replay 흐름 테스트는 생성 ID와 상태를 맞추기 위해 `ReflectionTestUtils`로 `PipelineJob`, `PipelineArtifact`, `ReviewSession`, `ReviewDecision`, `ReviewTask`의 private field를 직접 변경하거나 조회한다. 이 방식은 도메인 불변식과 테스트 의도를 흐리게 만들고, 엔티티 내부 구조 변경에 취약하다.
+
+## Scope
+
+| Area | Change |
+|------|--------|
+| Backend tests | `backend/src/test/java/com/init/pipelinejob/**`와 `backend/src/test/java/com/init/review/**`에서 `ReflectionTestUtils` 사용을 제거한다. |
+| Pipeline job fixtures | 상태별 `PipelineJob` 테스트 fixture를 도메인 factory/전이 메서드 기반으로 구성한다. |
+| Review fixtures | `ReviewSession`, `ReviewDecision`, `ReviewTask` 검증은 public getter, repository captor, 저장소 반환값 구성으로 대체한다. |
+| Domain accessors | 테스트가 private field를 조회하던 값 중 도메인 결과로 공개되어도 안전한 값은 getter로 검증한다. |
+
+## Non-goals
+
+- 프로덕션 파이프라인, review, Airflow callback 동작 변경.
+- JPA 매핑 또는 PostgreSQL schema 변경.
+- 테스트 범위 밖의 레거시 fixture 전면 재작성.
+- 엔티티 public setter 추가.
+
+## Affected Paths
+
+- `backend/src/test/java/com/init/pipelinejob/application`
+- `backend/src/test/java/com/init/pipelinejob/domain/model`
+- `backend/src/test/java/com/init/pipelinejob/infrastructure/corpus`
+- `backend/src/test/java/com/init/review/application`
+- `backend/src/test/java/com/init/review/domain/model`
+- `backend/src/main/java/com/init/pipelinejob/domain/model/PipelineArtifact.java`
+- `backend/src/main/java/com/init/review/domain/model/ReviewDecision.java`
+- `backend/src/main/java/com/init/review/domain/model/ReviewSession.java`
+
+## Acceptance Criteria
+
+- `rg "ReflectionTestUtils" backend/src/test/java/com/init/pipelinejob backend/src/test/java/com/init/review` 결과가 없다.
+- pipeline-job/review 테스트 fixture는 상태 의도를 메서드 이름으로 드러낸다.
+- callback/usecase 테스트는 repository stub, Mockito spy, captor, public getter/result DTO를 사용해 필요한 ID와 결과를 검증한다.
+- private field 직접 조회 검증은 public getter 또는 저장소 호출 검증으로 대체한다.
+- 관련 backend 테스트가 통과한다.
+
+## Validation
+
+| Command | Purpose |
+|---------|---------|
+| `rg "ReflectionTestUtils" backend/src/test/java/com/init/pipelinejob backend/src/test/java/com/init/review` | 대상 테스트 경로에서 금지 helper 제거 확인 |
+| `cd backend && ./gradlew test --tests "com.init.pipelinejob.*" --tests "com.init.review.*"` | pipeline-job/review 관련 H2 테스트 회귀 확인 |

--- a/backend/src/main/java/com/init/pipelinejob/domain/model/PipelineArtifact.java
+++ b/backend/src/main/java/com/init/pipelinejob/domain/model/PipelineArtifact.java
@@ -66,7 +66,27 @@ public class PipelineArtifact {
     return artifactUri;
   }
 
+  public Long getPipelineJobId() {
+    return pipelineJobId;
+  }
+
+  public String getStageName() {
+    return stageName;
+  }
+
+  public String getArtifactType() {
+    return artifactType;
+  }
+
+  public String getContentHash() {
+    return contentHash;
+  }
+
   public String getPayloadJson() {
     return payloadJson;
+  }
+
+  public OffsetDateTime getCreatedAt() {
+    return createdAt;
   }
 }

--- a/backend/src/main/java/com/init/review/domain/model/ReviewDecision.java
+++ b/backend/src/main/java/com/init/review/domain/model/ReviewDecision.java
@@ -69,4 +69,8 @@ public class ReviewDecision {
   public Long getId() {
     return id;
   }
+
+  public String getDecisionPayloadJson() {
+    return decisionPayloadJson;
+  }
 }

--- a/backend/src/main/java/com/init/review/domain/model/ReviewSession.java
+++ b/backend/src/main/java/com/init/review/domain/model/ReviewSession.java
@@ -148,6 +148,18 @@ public class ReviewSession {
     return description;
   }
 
+  public Long getCreatedBy() {
+    return createdBy;
+  }
+
+  public OffsetDateTime getOpenedAt() {
+    return openedAt;
+  }
+
+  public OffsetDateTime getClosedAt() {
+    return closedAt;
+  }
+
   public String getMetaJson() {
     return metaJson;
   }

--- a/backend/src/test/java/com/init/pipelinejob/application/GetAdminPipelineJobListUseCaseTest.java
+++ b/backend/src/test/java/com/init/pipelinejob/application/GetAdminPipelineJobListUseCaseTest.java
@@ -7,7 +7,7 @@ import static org.mockito.BDDMockito.given;
 
 import com.init.pipelinejob.domain.model.PipelineJob;
 import com.init.pipelinejob.domain.repository.PipelineJobRepository;
-import java.lang.reflect.Constructor;
+import com.init.pipelinejob.testfixture.PipelineJobFixtures;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -21,7 +21,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("GetAdminPipelineJobListUseCase")
@@ -86,30 +85,12 @@ class GetAdminPipelineJobListUseCaseTest {
       OffsetDateTime startedAt,
       OffsetDateTime finishedAt,
       Long retriedFromJobId) {
-    PipelineJob job = newPipelineJob();
-    ReflectionTestUtils.setField(job, "id", id);
-    ReflectionTestUtils.setField(job, "workspaceId", 1L);
-    ReflectionTestUtils.setField(job, "datasetId", 7L);
-    ReflectionTestUtils.setField(job, "jobType", PipelineJob.JOB_TYPE_DOMAIN_PACK_GENERATION);
-    ReflectionTestUtils.setField(job, "status", status);
-    ReflectionTestUtils.setField(job, "airflowDagId", "domain_pack_generation");
-    ReflectionTestUtils.setField(job, "airflowRunId", "pipeline_job_" + id);
-    ReflectionTestUtils.setField(job, "requestPayloadJson", "{}");
-    ReflectionTestUtils.setField(job, "resultSummaryJson", "{}");
-    ReflectionTestUtils.setField(job, "requestedAt", requestedAt);
-    ReflectionTestUtils.setField(job, "startedAt", startedAt);
-    ReflectionTestUtils.setField(job, "finishedAt", finishedAt);
-    ReflectionTestUtils.setField(job, "retriedFromJobId", retriedFromJobId);
-    return job;
-  }
-
-  private PipelineJob newPipelineJob() {
-    try {
-      Constructor<PipelineJob> constructor = PipelineJob.class.getDeclaredConstructor();
-      constructor.setAccessible(true);
-      return constructor.newInstance();
-    } catch (ReflectiveOperationException ex) {
-      throw new RuntimeException("PipelineJob 테스트 인스턴스 생성 실패", ex);
-    }
+    return PipelineJobFixtures.domainPackGeneration(id)
+        .status(status)
+        .requestedAt(requestedAt)
+        .startedAt(startedAt)
+        .finishedAt(finishedAt)
+        .retriedFromJobId(retriedFromJobId)
+        .build();
   }
 }

--- a/backend/src/test/java/com/init/pipelinejob/application/GetLatestPipelineJobUseCaseTest.java
+++ b/backend/src/test/java/com/init/pipelinejob/application/GetLatestPipelineJobUseCaseTest.java
@@ -6,9 +6,9 @@ import static org.mockito.BDDMockito.given;
 
 import com.init.pipelinejob.domain.model.PipelineJob;
 import com.init.pipelinejob.domain.repository.PipelineJobRepository;
+import com.init.pipelinejob.testfixture.PipelineJobFixtures;
 import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.NotFoundException;
-import java.lang.reflect.Constructor;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("GetLatestPipelineJobUseCase")
@@ -114,28 +113,13 @@ class GetLatestPipelineJobUseCaseTest {
   }
 
   private PipelineJob pipelineJob() {
-    PipelineJob job = newPipelineJob();
-    ReflectionTestUtils.setField(job, "id", 77L);
-    ReflectionTestUtils.setField(job, "workspaceId", 2L);
-    ReflectionTestUtils.setField(job, "datasetId", 15L);
-    ReflectionTestUtils.setField(job, "jobType", PipelineJob.JOB_TYPE_INGESTION);
-    ReflectionTestUtils.setField(job, "status", PipelineJob.STATUS_RUNNING);
-    ReflectionTestUtils.setField(job, "airflowDagId", "domain_pack_generation");
-    ReflectionTestUtils.setField(job, "airflowRunId", "pipeline_job_77");
-    ReflectionTestUtils.setField(job, "requestPayloadJson", "{}");
-    ReflectionTestUtils.setField(job, "resultSummaryJson", "{}");
-    ReflectionTestUtils.setField(job, "requestedAt", OffsetDateTime.parse("2026-06-05T01:00:00Z"));
-    ReflectionTestUtils.setField(job, "startedAt", OffsetDateTime.parse("2026-06-05T01:01:00Z"));
-    return job;
-  }
-
-  private PipelineJob newPipelineJob() {
-    try {
-      Constructor<PipelineJob> constructor = PipelineJob.class.getDeclaredConstructor();
-      constructor.setAccessible(true);
-      return constructor.newInstance();
-    } catch (ReflectiveOperationException ex) {
-      throw new RuntimeException("PipelineJob 테스트 인스턴스 생성 실패", ex);
-    }
+    return PipelineJobFixtures.ingestion(77L)
+        .workspaceId(2L)
+        .datasetId(15L)
+        .status(PipelineJob.STATUS_RUNNING)
+        .airflowRun("domain_pack_generation", "pipeline_job_77")
+        .requestedAt(OffsetDateTime.parse("2026-06-05T01:00:00Z"))
+        .startedAt(OffsetDateTime.parse("2026-06-05T01:01:00Z"))
+        .build();
   }
 }

--- a/backend/src/test/java/com/init/pipelinejob/application/ReceiveDomainPackDraftCallbackUseCaseTest.java
+++ b/backend/src/test/java/com/init/pipelinejob/application/ReceiveDomainPackDraftCallbackUseCaseTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -20,8 +21,8 @@ import com.init.pipelinejob.domain.model.WebhookReceipt;
 import com.init.pipelinejob.domain.repository.PipelineArtifactRepository;
 import com.init.pipelinejob.domain.repository.PipelineJobRepository;
 import com.init.pipelinejob.domain.repository.WebhookReceiptRepository;
+import com.init.pipelinejob.testfixture.PipelineJobFixtures;
 import com.init.workspace.application.WorkspaceFreeOnboardingService;
-import java.lang.reflect.Constructor;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -35,7 +36,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionStatus;
@@ -139,10 +139,10 @@ class ReceiveDomainPackDraftCallbackUseCaseTest {
   @DisplayName("receipt 저장 충돌 후 다른 webhook type으로 재조회되면 409 예외를 던진다")
   void execute_receiptInsertTypeConflict_throws() {
     WebhookReceipt receipt = receipt(11L, "evt-draft-1", "INTENT_DRAFT_CALLBACK");
+    PipelineJob job = pipelineJob(11L, 3L, PipelineJob.STATUS_RUNNING);
     given(webhookReceiptRepository.findByExternalEventId("evt-draft-1"))
         .willReturn(Optional.empty(), Optional.of(receipt));
-    given(pipelineJobRepository.findById(11L))
-        .willReturn(Optional.of(pipelineJob(11L, 3L, PipelineJob.STATUS_RUNNING)));
+    given(pipelineJobRepository.findById(11L)).willReturn(Optional.of(job));
     given(webhookReceiptRepository.saveAndFlush(any()))
         .willThrow(new DataIntegrityViolationException("unique violation"));
 
@@ -156,11 +156,11 @@ class ReceiveDomainPackDraftCallbackUseCaseTest {
   @DisplayName("receipt 저장 충돌 후 재조회되면 duplicate ignored를 반환한다")
   void execute_duplicateOnReceiptInsert_returnsDuplicateIgnored() {
     WebhookReceipt receipt = webhookReceipt(11L, "evt-draft-1");
+    PipelineJob job = pipelineJob(11L, 3L, PipelineJob.STATUS_RUNNING);
     receipt.markProcessed(OffsetDateTime.now(fixedClock));
     given(webhookReceiptRepository.findByExternalEventId("evt-draft-1"))
         .willReturn(Optional.empty(), Optional.of(receipt));
-    given(pipelineJobRepository.findById(11L))
-        .willReturn(Optional.of(pipelineJob(11L, 3L, PipelineJob.STATUS_RUNNING)));
+    given(pipelineJobRepository.findById(11L)).willReturn(Optional.of(job));
     given(webhookReceiptRepository.saveAndFlush(any()))
         .willThrow(new DataIntegrityViolationException("unique violation"));
 
@@ -214,10 +214,10 @@ class ReceiveDomainPackDraftCallbackUseCaseTest {
   @Test
   @DisplayName("receipt 저장 예외가 중복으로 확인되지 않으면 예외를 그대로 던진다")
   void execute_nonDuplicateReceiptInsertFailure_throws() {
+    PipelineJob job = pipelineJob(11L, 3L, PipelineJob.STATUS_RUNNING);
     given(webhookReceiptRepository.findByExternalEventId("evt-draft-1"))
         .willReturn(Optional.empty(), Optional.empty());
-    given(pipelineJobRepository.findById(11L))
-        .willReturn(Optional.of(pipelineJob(11L, 3L, PipelineJob.STATUS_RUNNING)));
+    given(pipelineJobRepository.findById(11L)).willReturn(Optional.of(job));
     given(webhookReceiptRepository.saveAndFlush(any()))
         .willThrow(new DataIntegrityViolationException("unexpected violation"));
 
@@ -250,10 +250,10 @@ class ReceiveDomainPackDraftCallbackUseCaseTest {
   @Test
   @DisplayName("이미 종료된 job이면 409 예외를 던진다")
   void execute_finalizedJob_throwsConflict() {
+    PipelineJob job = pipelineJob(11L, 3L, PipelineJob.STATUS_SUCCEEDED);
     given(webhookReceiptRepository.findByExternalEventId("evt-draft-1"))
         .willReturn(Optional.empty());
-    given(pipelineJobRepository.findById(11L))
-        .willReturn(Optional.of(pipelineJob(11L, 3L, PipelineJob.STATUS_SUCCEEDED)));
+    given(pipelineJobRepository.findById(11L)).willReturn(Optional.of(job));
 
     assertThatThrownBy(() -> useCase.execute(validCommand()))
         .isInstanceOf(PipelineJobAlreadyFinalizedException.class);
@@ -262,10 +262,10 @@ class ReceiveDomainPackDraftCallbackUseCaseTest {
   @Test
   @DisplayName("이미 중간 상태인 job에 domain-pack callback이 다시 오면 409 예외를 던진다")
   void execute_waitingIntentJob_throwsConflict() {
+    PipelineJob job = pipelineJob(11L, 3L, PipelineJob.STATUS_WAITING_INTENT_CALLBACK);
     given(webhookReceiptRepository.findByExternalEventId("evt-draft-1"))
         .willReturn(Optional.empty());
-    given(pipelineJobRepository.findById(11L))
-        .willReturn(Optional.of(pipelineJob(11L, 3L, PipelineJob.STATUS_WAITING_INTENT_CALLBACK)));
+    given(pipelineJobRepository.findById(11L)).willReturn(Optional.of(job));
 
     ReceiveDomainPackDraftCallbackCommand command = validCommand();
 
@@ -276,8 +276,13 @@ class ReceiveDomainPackDraftCallbackUseCaseTest {
   @Test
   @DisplayName("이미 DomainPack이 연결된 RUNNING job에 domain-pack callback이 다시 오면 409 예외를 던진다")
   void execute_runningJobWithDomainPack_throwsConflict() {
-    PipelineJob job = pipelineJob(11L, 3L, PipelineJob.STATUS_RUNNING);
-    ReflectionTestUtils.setField(job, "domainPackId", 7L);
+    PipelineJob job = mock(PipelineJob.class);
+    lenient().doReturn(11L).when(job).getId();
+    lenient().doReturn(3L).when(job).getWorkspaceId();
+    lenient().doReturn(PipelineJob.STATUS_RUNNING).when(job).getStatus();
+    lenient().doReturn(7L).when(job).getDomainPackId();
+    lenient().doReturn(false).when(job).canAcceptDomainPackDraftCallback();
+    lenient().doReturn(false).when(job).isFinalized();
     given(webhookReceiptRepository.findByExternalEventId("evt-draft-1"))
         .willReturn(Optional.empty());
     given(pipelineJobRepository.findById(11L)).willReturn(Optional.of(job));
@@ -303,22 +308,10 @@ class ReceiveDomainPackDraftCallbackUseCaseTest {
   }
 
   private PipelineJob pipelineJob(Long id, Long workspaceId, String status) {
-    PipelineJob job = newPipelineJob();
-    ReflectionTestUtils.setField(job, "id", id);
-    ReflectionTestUtils.setField(job, "workspaceId", workspaceId);
-    ReflectionTestUtils.setField(job, "status", status);
-    ReflectionTestUtils.setField(job, "resultSummaryJson", "{}");
-    return job;
-  }
-
-  private PipelineJob newPipelineJob() {
-    try {
-      Constructor<PipelineJob> constructor = PipelineJob.class.getDeclaredConstructor();
-      constructor.setAccessible(true);
-      return constructor.newInstance();
-    } catch (ReflectiveOperationException ex) {
-      throw new RuntimeException("PipelineJob 테스트 인스턴스 생성 실패", ex);
-    }
+    return PipelineJobFixtures.domainPackGeneration(id)
+        .workspaceId(workspaceId)
+        .status(status)
+        .build();
   }
 
   private WebhookReceipt webhookReceipt(Long jobId, String externalEventId) {
@@ -329,7 +322,6 @@ class ReceiveDomainPackDraftCallbackUseCaseTest {
     WebhookReceipt receipt =
         WebhookReceipt.receive(
             jobId, externalEventId, webhookType, "{}", "{}", OffsetDateTime.now(fixedClock));
-    ReflectionTestUtils.setField(receipt, "id", 1L);
     return receipt;
   }
 }

--- a/backend/src/test/java/com/init/pipelinejob/application/ReceiveIntentDraftCallbackUseCaseTest.java
+++ b/backend/src/test/java/com/init/pipelinejob/application/ReceiveIntentDraftCallbackUseCaseTest.java
@@ -20,8 +20,8 @@ import com.init.pipelinejob.domain.model.PipelineJob;
 import com.init.pipelinejob.domain.model.WebhookReceipt;
 import com.init.pipelinejob.domain.repository.PipelineJobRepository;
 import com.init.pipelinejob.domain.repository.WebhookReceiptRepository;
+import com.init.pipelinejob.testfixture.PipelineJobFixtures;
 import com.init.workspace.application.WorkspaceFreeOnboardingService;
-import java.lang.reflect.Constructor;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -36,7 +36,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionStatus;
@@ -134,10 +133,10 @@ class ReceiveIntentDraftCallbackUseCaseTest {
   @DisplayName("receipt 저장 충돌 후 다른 webhook type으로 재조회되면 409 예외를 던진다")
   void execute_receiptInsertTypeConflict_throws() {
     WebhookReceipt receipt = receipt(11L, "evt-1", "DOMAIN_PACK_DRAFT_CALLBACK");
+    PipelineJob job = pipelineJob(11L, 3L, PipelineJob.STATUS_WAITING_INTENT_CALLBACK);
     given(webhookReceiptRepository.findByExternalEventId("evt-1"))
         .willReturn(Optional.empty(), Optional.of(receipt));
-    given(pipelineJobRepository.findById(11L))
-        .willReturn(Optional.of(pipelineJob(11L, 3L, PipelineJob.STATUS_WAITING_INTENT_CALLBACK)));
+    given(pipelineJobRepository.findById(11L)).willReturn(Optional.of(job));
     given(webhookReceiptRepository.saveAndFlush(any()))
         .willThrow(new DataIntegrityViolationException("unique violation"));
 
@@ -151,11 +150,11 @@ class ReceiveIntentDraftCallbackUseCaseTest {
   @DisplayName("receipt 저장 충돌 후 재조회되면 duplicate ignored를 반환한다")
   void execute_duplicateOnReceiptInsert_returnsDuplicateIgnored() {
     WebhookReceipt receipt = webhookReceipt(11L, "evt-1");
+    PipelineJob job = pipelineJob(11L, 3L, PipelineJob.STATUS_WAITING_INTENT_CALLBACK);
     receipt.markProcessed(OffsetDateTime.now(fixedClock));
     given(webhookReceiptRepository.findByExternalEventId("evt-1"))
         .willReturn(Optional.empty(), Optional.of(receipt));
-    given(pipelineJobRepository.findById(11L))
-        .willReturn(Optional.of(pipelineJob(11L, 3L, PipelineJob.STATUS_WAITING_INTENT_CALLBACK)));
+    given(pipelineJobRepository.findById(11L)).willReturn(Optional.of(job));
     given(webhookReceiptRepository.saveAndFlush(any()))
         .willThrow(new DataIntegrityViolationException("unique violation"));
 
@@ -209,10 +208,10 @@ class ReceiveIntentDraftCallbackUseCaseTest {
   @Test
   @DisplayName("receipt 저장 예외가 중복으로 확인되지 않으면 예외를 그대로 던진다")
   void execute_nonDuplicateReceiptInsertFailure_throws() {
+    PipelineJob job = pipelineJob(11L, 3L, PipelineJob.STATUS_WAITING_INTENT_CALLBACK);
     given(webhookReceiptRepository.findByExternalEventId("evt-1"))
         .willReturn(Optional.empty(), Optional.empty());
-    given(pipelineJobRepository.findById(11L))
-        .willReturn(Optional.of(pipelineJob(11L, 3L, PipelineJob.STATUS_WAITING_INTENT_CALLBACK)));
+    given(pipelineJobRepository.findById(11L)).willReturn(Optional.of(job));
     given(webhookReceiptRepository.saveAndFlush(any()))
         .willThrow(new DataIntegrityViolationException("unexpected violation"));
 
@@ -244,9 +243,9 @@ class ReceiveIntentDraftCallbackUseCaseTest {
   @Test
   @DisplayName("이미 종료된 job이면 409 예외를 던진다")
   void execute_finalizedJob_throwsConflict() {
+    PipelineJob job = pipelineJob(11L, 3L, PipelineJob.STATUS_SUCCEEDED);
     given(webhookReceiptRepository.findByExternalEventId("evt-1")).willReturn(Optional.empty());
-    given(pipelineJobRepository.findById(11L))
-        .willReturn(Optional.of(pipelineJob(11L, 3L, PipelineJob.STATUS_SUCCEEDED)));
+    given(pipelineJobRepository.findById(11L)).willReturn(Optional.of(job));
 
     assertThatThrownBy(() -> useCase.execute(validCommand()))
         .isInstanceOf(PipelineJobAlreadyFinalizedException.class);
@@ -255,9 +254,9 @@ class ReceiveIntentDraftCallbackUseCaseTest {
   @Test
   @DisplayName("중간 상태가 아닌 job에 intent callback이 오면 409 예외를 던진다")
   void execute_nonWaitingJob_throwsConflict() {
+    PipelineJob job = pipelineJob(11L, 3L, PipelineJob.STATUS_RUNNING);
     given(webhookReceiptRepository.findByExternalEventId("evt-1")).willReturn(Optional.empty());
-    given(pipelineJobRepository.findById(11L))
-        .willReturn(Optional.of(pipelineJob(11L, 3L, PipelineJob.STATUS_RUNNING)));
+    given(pipelineJobRepository.findById(11L)).willReturn(Optional.of(job));
 
     assertThatThrownBy(() -> useCase.execute(validCommand()))
         .isInstanceOf(PipelineJobCallbackNotAllowedException.class);
@@ -298,22 +297,10 @@ class ReceiveIntentDraftCallbackUseCaseTest {
   }
 
   private PipelineJob pipelineJob(Long id, Long workspaceId, String status) {
-    PipelineJob job = newPipelineJob();
-    ReflectionTestUtils.setField(job, "id", id);
-    ReflectionTestUtils.setField(job, "workspaceId", workspaceId);
-    ReflectionTestUtils.setField(job, "status", status);
-    ReflectionTestUtils.setField(job, "resultSummaryJson", "{}");
-    return job;
-  }
-
-  private PipelineJob newPipelineJob() {
-    try {
-      Constructor<PipelineJob> constructor = PipelineJob.class.getDeclaredConstructor();
-      constructor.setAccessible(true);
-      return constructor.newInstance();
-    } catch (ReflectiveOperationException ex) {
-      throw new RuntimeException("PipelineJob 테스트 인스턴스 생성 실패", ex);
-    }
+    return PipelineJobFixtures.domainPackGeneration(id)
+        .workspaceId(workspaceId)
+        .status(status)
+        .build();
   }
 
   private WebhookReceipt webhookReceipt(Long jobId, String externalEventId) {
@@ -324,7 +311,6 @@ class ReceiveIntentDraftCallbackUseCaseTest {
     WebhookReceipt receipt =
         WebhookReceipt.receive(
             jobId, externalEventId, webhookType, "{}", "{}", OffsetDateTime.now(fixedClock));
-    ReflectionTestUtils.setField(receipt, "id", 1L);
     return receipt;
   }
 }

--- a/backend/src/test/java/com/init/pipelinejob/application/ReceivePipelineJobFailureCallbackUseCaseTest.java
+++ b/backend/src/test/java/com/init/pipelinejob/application/ReceivePipelineJobFailureCallbackUseCaseTest.java
@@ -15,8 +15,8 @@ import com.init.pipelinejob.domain.model.PipelineJob;
 import com.init.pipelinejob.domain.model.WebhookReceipt;
 import com.init.pipelinejob.domain.repository.PipelineJobRepository;
 import com.init.pipelinejob.domain.repository.WebhookReceiptRepository;
+import com.init.pipelinejob.testfixture.PipelineJobFixtures;
 import com.init.workspace.application.WorkspaceFreeOnboardingService;
-import java.lang.reflect.Constructor;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionStatus;
@@ -246,17 +245,15 @@ class ReceivePipelineJobFailureCallbackUseCaseTest {
   }
 
   private PipelineJob pipelineJob(String status) {
-    PipelineJob job = newPipelineJob();
-    ReflectionTestUtils.setField(job, "id", 123L);
-    ReflectionTestUtils.setField(job, "workspaceId", 1L);
-    ReflectionTestUtils.setField(job, "datasetId", 7L);
-    ReflectionTestUtils.setField(job, "jobType", PipelineJob.JOB_TYPE_DOMAIN_PACK_GENERATION);
-    ReflectionTestUtils.setField(job, "status", status);
-    ReflectionTestUtils.setField(job, "airflowDagId", "domain_pack_generation");
-    ReflectionTestUtils.setField(job, "airflowRunId", "pipeline_job_123");
-    ReflectionTestUtils.setField(job, "requestPayloadJson", "{}");
-    ReflectionTestUtils.setField(job, "resultSummaryJson", "{}");
-    return job;
+    if (PipelineJob.STATUS_CANCELLED.equals(status)) {
+      return PipelineJobFixtures.cancelledDomainPackGeneration(123L, 1L, 7L);
+    }
+    return PipelineJobFixtures.domainPackGeneration(123L)
+        .workspaceId(1L)
+        .datasetId(7L)
+        .status(status)
+        .airflowRun("domain_pack_generation", "pipeline_job_123")
+        .build();
   }
 
   private WebhookReceipt receipt(String externalEventId) {
@@ -267,15 +264,5 @@ class ReceivePipelineJobFailureCallbackUseCaseTest {
         "{}",
         "{}",
         OffsetDateTime.now(fixedClock));
-  }
-
-  private PipelineJob newPipelineJob() {
-    try {
-      Constructor<PipelineJob> constructor = PipelineJob.class.getDeclaredConstructor();
-      constructor.setAccessible(true);
-      return constructor.newInstance();
-    } catch (ReflectiveOperationException ex) {
-      throw new RuntimeException("PipelineJob 테스트 인스턴스 생성 실패", ex);
-    }
   }
 }

--- a/backend/src/test/java/com/init/pipelinejob/application/ReceiveWorkflowDraftCallbackUseCaseTest.java
+++ b/backend/src/test/java/com/init/pipelinejob/application/ReceiveWorkflowDraftCallbackUseCaseTest.java
@@ -19,8 +19,8 @@ import com.init.pipelinejob.domain.model.WebhookReceipt;
 import com.init.pipelinejob.domain.repository.PipelineArtifactRepository;
 import com.init.pipelinejob.domain.repository.PipelineJobRepository;
 import com.init.pipelinejob.domain.repository.WebhookReceiptRepository;
+import com.init.pipelinejob.testfixture.PipelineJobFixtures;
 import com.init.workspace.application.WorkspaceFreeOnboardingService;
-import java.lang.reflect.Constructor;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionStatus;
@@ -220,10 +219,10 @@ class ReceiveWorkflowDraftCallbackUseCaseTest {
   @Test
   @DisplayName("WAITING_WORKFLOW_CALLBACK이 아니면 409 예외를 던진다")
   void execute_notAllowedStatus_throws() {
+    PipelineJob job = pipelineJob(11L, 3L, PipelineJob.STATUS_WAITING_INTENT_CALLBACK);
     given(webhookReceiptRepository.findByExternalEventId("evt-workflow-1"))
         .willReturn(Optional.empty());
-    given(pipelineJobRepository.findById(11L))
-        .willReturn(Optional.of(pipelineJob(11L, 3L, PipelineJob.STATUS_WAITING_INTENT_CALLBACK)));
+    given(pipelineJobRepository.findById(11L)).willReturn(Optional.of(job));
 
     assertThatThrownBy(() -> useCase.execute(validCommand()))
         .isInstanceOf(PipelineJobCallbackNotAllowedException.class);
@@ -283,23 +282,11 @@ class ReceiveWorkflowDraftCallbackUseCaseTest {
   }
 
   private PipelineJob pipelineJob(Long id, Long workspaceId, String status) {
-    PipelineJob job = newPipelineJob();
-    ReflectionTestUtils.setField(job, "id", id);
-    ReflectionTestUtils.setField(job, "workspaceId", workspaceId);
-    ReflectionTestUtils.setField(job, "domainPackId", 7L);
-    ReflectionTestUtils.setField(job, "status", status);
-    ReflectionTestUtils.setField(job, "resultSummaryJson", "{}");
-    return job;
-  }
-
-  private PipelineJob newPipelineJob() {
-    try {
-      Constructor<PipelineJob> constructor = PipelineJob.class.getDeclaredConstructor();
-      constructor.setAccessible(true);
-      return constructor.newInstance();
-    } catch (ReflectiveOperationException ex) {
-      throw new RuntimeException("PipelineJob 테스트 인스턴스 생성 실패", ex);
-    }
+    return PipelineJobFixtures.domainPackGeneration(id)
+        .workspaceId(workspaceId)
+        .domainPackId(7L)
+        .status(status)
+        .build();
   }
 
   private WebhookReceipt workflowReceipt(Long jobId, String externalEventId) {
@@ -314,7 +301,6 @@ class ReceiveWorkflowDraftCallbackUseCaseTest {
     WebhookReceipt receipt =
         WebhookReceipt.receive(
             jobId, externalEventId, webhookType, "{}", "{}", OffsetDateTime.now(fixedClock));
-    ReflectionTestUtils.setField(receipt, "id", 1L);
     return receipt;
   }
 

--- a/backend/src/test/java/com/init/pipelinejob/application/RetryAdminPipelineJobUseCaseTest.java
+++ b/backend/src/test/java/com/init/pipelinejob/application/RetryAdminPipelineJobUseCaseTest.java
@@ -11,7 +11,7 @@ import com.init.pipelinejob.application.exception.PipelineJobRetryInputMissingEx
 import com.init.pipelinejob.application.exception.PipelineJobRetryNotAllowedException;
 import com.init.pipelinejob.domain.model.PipelineJob;
 import com.init.pipelinejob.domain.repository.PipelineJobRepository;
-import java.lang.reflect.Constructor;
+import com.init.pipelinejob.testfixture.PipelineJobFixtures;
 import java.time.OffsetDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("RetryAdminPipelineJobUseCase")
@@ -45,7 +44,6 @@ class RetryAdminPipelineJobUseCaseTest {
     PipelineJob sourceJob =
         pipelineJob(
             11L,
-            PipelineJob.JOB_TYPE_DOMAIN_PACK_GENERATION,
             PipelineJob.STATUS_FAILED,
             """
             {"objectKey":"workspaces/1/datasets/7/raw.json"}
@@ -81,14 +79,8 @@ class RetryAdminPipelineJobUseCaseTest {
   @Test
   @DisplayName("FAILED가 아니면 재시도를 거부한다")
   void execute_nonFailed_throwsNotAllowed() {
-    given(pipelineJobRepository.findById(11L))
-        .willReturn(
-            Optional.of(
-                pipelineJob(
-                    11L,
-                    PipelineJob.JOB_TYPE_DOMAIN_PACK_GENERATION,
-                    PipelineJob.STATUS_RUNNING,
-                    "{}")));
+    PipelineJob job = pipelineJob(11L, PipelineJob.STATUS_RUNNING, "{}");
+    given(pipelineJobRepository.findById(11L)).willReturn(Optional.of(job));
 
     assertThatThrownBy(() -> useCase.execute(11L, 99L))
         .isInstanceOf(PipelineJobRetryNotAllowedException.class);
@@ -97,14 +89,8 @@ class RetryAdminPipelineJobUseCaseTest {
   @Test
   @DisplayName("원본 objectKey가 없으면 입력 누락 오류를 반환한다")
   void execute_missingObjectKey_throwsInputMissing() {
-    given(pipelineJobRepository.findById(11L))
-        .willReturn(
-            Optional.of(
-                pipelineJob(
-                    11L,
-                    PipelineJob.JOB_TYPE_DOMAIN_PACK_GENERATION,
-                    PipelineJob.STATUS_FAILED,
-                    "{}")));
+    PipelineJob job = pipelineJob(11L, PipelineJob.STATUS_FAILED, "{}");
+    given(pipelineJobRepository.findById(11L)).willReturn(Optional.of(job));
 
     assertThatThrownBy(() -> useCase.execute(11L, 99L))
         .isInstanceOf(PipelineJobRetryInputMissingException.class);
@@ -113,27 +99,11 @@ class RetryAdminPipelineJobUseCaseTest {
   private final ArgumentCaptor<TriggerDomainPackGenerationCommand> commandCaptor =
       ArgumentCaptor.forClass(TriggerDomainPackGenerationCommand.class);
 
-  private PipelineJob pipelineJob(
-      Long id, String jobType, String status, String requestPayloadJson) {
-    PipelineJob job = newPipelineJob();
-    ReflectionTestUtils.setField(job, "id", id);
-    ReflectionTestUtils.setField(job, "workspaceId", 1L);
-    ReflectionTestUtils.setField(job, "datasetId", 7L);
-    ReflectionTestUtils.setField(job, "jobType", jobType);
-    ReflectionTestUtils.setField(job, "status", status);
-    ReflectionTestUtils.setField(job, "requestPayloadJson", requestPayloadJson);
-    ReflectionTestUtils.setField(job, "resultSummaryJson", "{}");
-    ReflectionTestUtils.setField(job, "requestedAt", OffsetDateTime.parse("2026-06-03T01:00:00Z"));
-    return job;
-  }
-
-  private PipelineJob newPipelineJob() {
-    try {
-      Constructor<PipelineJob> constructor = PipelineJob.class.getDeclaredConstructor();
-      constructor.setAccessible(true);
-      return constructor.newInstance();
-    } catch (ReflectiveOperationException ex) {
-      throw new RuntimeException("PipelineJob 테스트 인스턴스 생성 실패", ex);
-    }
+  private PipelineJob pipelineJob(Long id, String status, String requestPayloadJson) {
+    return PipelineJobFixtures.domainPackGeneration(id)
+        .status(status)
+        .requestPayloadJson(requestPayloadJson)
+        .requestedAt(OffsetDateTime.parse("2026-06-03T01:00:00Z"))
+        .build();
   }
 }

--- a/backend/src/test/java/com/init/pipelinejob/application/TriggerDomainPackGenerationUseCaseTest.java
+++ b/backend/src/test/java/com/init/pipelinejob/application/TriggerDomainPackGenerationUseCaseTest.java
@@ -16,11 +16,11 @@ import com.init.pipelinejob.application.exception.AirflowTriggerFailedException;
 import com.init.pipelinejob.application.exception.PipelineJobWorkspaceAccessDeniedException;
 import com.init.pipelinejob.domain.model.PipelineJob;
 import com.init.pipelinejob.domain.repository.PipelineJobRepository;
+import com.init.pipelinejob.testfixture.PipelineJobFixtures;
 import com.init.shared.application.exception.NotFoundException;
 import com.init.shared.application.exception.QuotaExceededException;
 import com.init.shared.application.quota.WorkspaceQuotaValidator;
 import com.init.workspace.application.WorkspaceFreeOnboardingService;
-import java.lang.reflect.Constructor;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionStatus;
@@ -71,7 +70,7 @@ class TriggerDomainPackGenerationUseCaseTest {
             invocation -> {
               PipelineJob job = invocation.getArgument(0);
               if (job.getId() == null) {
-                ReflectionTestUtils.setField(job, "id", 123L);
+                job = PipelineJobFixtures.persisted(job, 123L);
               }
               savedJob.set(job);
               return job;
@@ -163,8 +162,9 @@ class TriggerDomainPackGenerationUseCaseTest {
   @DisplayName("active job이 있으면 기존 job을 반환하고 새 Airflow trigger를 만들지 않는다")
   void execute_activeJob_returnsExistingJob() {
     allowAccess();
+    PipelineJob activeJob = pipelineJob(11L, PipelineJob.STATUS_RUNNING);
     given(pipelineJobRepository.findActiveDomainPackGenerationJob(1L, 7L))
-        .willReturn(Optional.of(pipelineJob(11L, PipelineJob.STATUS_RUNNING)));
+        .willReturn(Optional.of(activeJob));
 
     TriggerDomainPackGenerationResult result = useCase.execute(command());
 
@@ -312,22 +312,6 @@ class TriggerDomainPackGenerationUseCaseTest {
   }
 
   private PipelineJob pipelineJob(Long id, String status) {
-    PipelineJob job = newPipelineJob();
-    ReflectionTestUtils.setField(job, "id", id);
-    ReflectionTestUtils.setField(job, "workspaceId", 1L);
-    ReflectionTestUtils.setField(job, "datasetId", 7L);
-    ReflectionTestUtils.setField(job, "jobType", PipelineJob.JOB_TYPE_DOMAIN_PACK_GENERATION);
-    ReflectionTestUtils.setField(job, "status", status);
-    return job;
-  }
-
-  private PipelineJob newPipelineJob() {
-    try {
-      Constructor<PipelineJob> constructor = PipelineJob.class.getDeclaredConstructor();
-      constructor.setAccessible(true);
-      return constructor.newInstance();
-    } catch (ReflectiveOperationException ex) {
-      throw new RuntimeException("PipelineJob 테스트 인스턴스 생성 실패", ex);
-    }
+    return PipelineJobFixtures.domainPackGeneration(id).status(status).build();
   }
 }

--- a/backend/src/test/java/com/init/pipelinejob/application/TriggerIngestionUseCaseTest.java
+++ b/backend/src/test/java/com/init/pipelinejob/application/TriggerIngestionUseCaseTest.java
@@ -14,6 +14,7 @@ import com.init.pipelinejob.application.exception.AirflowConfigurationInvalidExc
 import com.init.pipelinejob.application.exception.AirflowTriggerFailedException;
 import com.init.pipelinejob.domain.model.PipelineJob;
 import com.init.pipelinejob.domain.repository.PipelineJobRepository;
+import com.init.pipelinejob.testfixture.PipelineJobFixtures;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -27,7 +28,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionStatus;
@@ -61,7 +61,7 @@ class TriggerIngestionUseCaseTest {
             invocation -> {
               PipelineJob job = invocation.getArgument(0);
               if (job.getId() == null) {
-                ReflectionTestUtils.setField(job, "id", 99L);
+                job = PipelineJobFixtures.persisted(job, 99L);
                 saveCallCount.set(0);
               }
               savedJob.set(job);

--- a/backend/src/test/java/com/init/pipelinejob/domain/model/PipelineArtifactTest.java
+++ b/backend/src/test/java/com/init/pipelinejob/domain/model/PipelineArtifactTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @DisplayName("PipelineArtifact")
 class PipelineArtifactTest {
@@ -25,13 +24,11 @@ class PipelineArtifactTest {
             "{\"ok\":true}",
             createdAt);
 
-    assertThat(ReflectionTestUtils.getField(artifact, "pipelineJobId")).isEqualTo(7L);
-    assertThat(ReflectionTestUtils.getField(artifact, "stageName"))
-        .isEqualTo("domain_confirmation");
-    assertThat(ReflectionTestUtils.getField(artifact, "artifactType"))
-        .isEqualTo("DOMAIN_CANDIDATES");
-    assertThat(ReflectionTestUtils.getField(artifact, "contentHash")).isEqualTo("hash");
-    assertThat(ReflectionTestUtils.getField(artifact, "createdAt")).isEqualTo(createdAt);
+    assertThat(artifact.getPipelineJobId()).isEqualTo(7L);
+    assertThat(artifact.getStageName()).isEqualTo("domain_confirmation");
+    assertThat(artifact.getArtifactType()).isEqualTo("DOMAIN_CANDIDATES");
+    assertThat(artifact.getContentHash()).isEqualTo("hash");
+    assertThat(artifact.getCreatedAt()).isEqualTo(createdAt);
     assertThat(artifact.getArtifactUri()).isEqualTo("s3://bucket/a.json");
     assertThat(artifact.getPayloadJson()).isEqualTo("{\"ok\":true}");
   }
@@ -46,7 +43,6 @@ class PipelineArtifactTest {
 
     assertThat(artifact.getArtifactUri()).isNull();
     assertThat(artifact.getPayloadJson()).isEqualTo("{}");
-    assertThat((OffsetDateTime) ReflectionTestUtils.getField(artifact, "createdAt"))
-        .isAfter(before);
+    assertThat(artifact.getCreatedAt()).isAfter(before);
   }
 }

--- a/backend/src/test/java/com/init/pipelinejob/infrastructure/corpus/CorpusIngestionDatasetStatusAdapterTest.java
+++ b/backend/src/test/java/com/init/pipelinejob/infrastructure/corpus/CorpusIngestionDatasetStatusAdapterTest.java
@@ -2,6 +2,7 @@ package com.init.pipelinejob.infrastructure.corpus;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -14,7 +15,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("CorpusIngestionDatasetStatusAdapter")
@@ -41,8 +41,9 @@ class CorpusIngestionDatasetStatusAdapterTest {
   @Test
   @DisplayName("이미 DONE dataset이면 상태를 바꾸거나 저장하지 않는다")
   void markIngestionTriggerFailed_fromDone_doesNotSave() {
-    Dataset dataset = Dataset.createUploading(1L, "key", "테스트", "CRM", 1L);
-    ReflectionTestUtils.setField(dataset, "status", DatasetStatus.DONE);
+    Dataset dataset = mock(Dataset.class);
+    given(dataset.markIngestionTriggerFailed()).willReturn(false);
+    given(dataset.getStatus()).willReturn(DatasetStatus.DONE);
     given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L))
         .willReturn(Optional.of(dataset));
     CorpusIngestionDatasetStatusAdapter adapter =

--- a/backend/src/test/java/com/init/pipelinejob/testfixture/PipelineJobFixtures.java
+++ b/backend/src/test/java/com/init/pipelinejob/testfixture/PipelineJobFixtures.java
@@ -1,0 +1,179 @@
+package com.init.pipelinejob.testfixture;
+
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+import com.init.pipelinejob.domain.model.PipelineJob;
+import java.time.OffsetDateTime;
+
+public final class PipelineJobFixtures {
+
+  private static final OffsetDateTime DEFAULT_REQUESTED_AT =
+      OffsetDateTime.parse("2026-06-01T00:00:00Z");
+
+  private PipelineJobFixtures() {}
+
+  public static PipelineJob persisted(PipelineJob job, Long id) {
+    PipelineJob persisted = spy(job);
+    lenient().doReturn(id).when(persisted).getId();
+    return persisted;
+  }
+
+  public static Builder domainPackGeneration(Long id) {
+    return new Builder(id, PipelineJob.JOB_TYPE_DOMAIN_PACK_GENERATION);
+  }
+
+  public static Builder ingestion(Long id) {
+    return new Builder(id, PipelineJob.JOB_TYPE_INGESTION);
+  }
+
+  public static PipelineJob cancelledDomainPackGeneration(
+      Long id, Long workspaceId, Long datasetId) {
+    PipelineJob job = mock(PipelineJob.class);
+    lenient().doReturn(id).when(job).getId();
+    lenient().doReturn(workspaceId).when(job).getWorkspaceId();
+    lenient().doReturn(datasetId).when(job).getDatasetId();
+    lenient().doReturn(PipelineJob.JOB_TYPE_DOMAIN_PACK_GENERATION).when(job).getJobType();
+    lenient().doReturn(PipelineJob.STATUS_CANCELLED).when(job).getStatus();
+    lenient().doReturn("domain_pack_generation").when(job).getAirflowDagId();
+    lenient().doReturn("pipeline_job_" + id).when(job).getAirflowRunId();
+    lenient().doReturn(true).when(job).isCancelled();
+    lenient().doReturn(true).when(job).isFinalized();
+    return job;
+  }
+
+  public static final class Builder {
+
+    private final Long id;
+    private final String jobType;
+    private Long workspaceId = 1L;
+    private Long datasetId = 7L;
+    private Long triggeredBy = 9L;
+    private Long domainPackId = 7L;
+    private Long retriedFromJobId;
+    private String status = PipelineJob.STATUS_RUNNING;
+    private String requestPayloadJson = "{}";
+    private String resultSummaryJson = "{}";
+    private String airflowDagId = "domain_pack_generation";
+    private String airflowRunId;
+    private OffsetDateTime requestedAt = DEFAULT_REQUESTED_AT;
+    private OffsetDateTime startedAt;
+    private OffsetDateTime finishedAt;
+
+    private Builder(Long id, String jobType) {
+      this.id = id;
+      this.jobType = jobType;
+      this.airflowRunId = "pipeline_job_" + id;
+    }
+
+    public Builder workspaceId(Long workspaceId) {
+      this.workspaceId = workspaceId;
+      return this;
+    }
+
+    public Builder datasetId(Long datasetId) {
+      this.datasetId = datasetId;
+      return this;
+    }
+
+    public Builder triggeredBy(Long triggeredBy) {
+      this.triggeredBy = triggeredBy;
+      return this;
+    }
+
+    public Builder domainPackId(Long domainPackId) {
+      this.domainPackId = domainPackId;
+      return this;
+    }
+
+    public Builder retriedFromJobId(Long retriedFromJobId) {
+      this.retriedFromJobId = retriedFromJobId;
+      return this;
+    }
+
+    public Builder status(String status) {
+      this.status = status;
+      return this;
+    }
+
+    public Builder requestPayloadJson(String requestPayloadJson) {
+      this.requestPayloadJson = requestPayloadJson;
+      return this;
+    }
+
+    public Builder resultSummaryJson(String resultSummaryJson) {
+      this.resultSummaryJson = resultSummaryJson;
+      return this;
+    }
+
+    public Builder airflowRun(String airflowDagId, String airflowRunId) {
+      this.airflowDagId = airflowDagId;
+      this.airflowRunId = airflowRunId;
+      return this;
+    }
+
+    public Builder requestedAt(OffsetDateTime requestedAt) {
+      this.requestedAt = requestedAt;
+      return this;
+    }
+
+    public Builder startedAt(OffsetDateTime startedAt) {
+      this.startedAt = startedAt;
+      return this;
+    }
+
+    public Builder finishedAt(OffsetDateTime finishedAt) {
+      this.finishedAt = finishedAt;
+      return this;
+    }
+
+    public PipelineJob build() {
+      PipelineJob job =
+          PipelineJob.JOB_TYPE_INGESTION.equals(jobType)
+              ? PipelineJob.createIngestion(workspaceId, datasetId, requestedAt)
+              : PipelineJob.createDomainPackGeneration(
+                  workspaceId,
+                  datasetId,
+                  triggeredBy,
+                  requestPayloadJson,
+                  requestedAt,
+                  retriedFromJobId);
+      applyStatus(job);
+      return persisted(job, id);
+    }
+
+    private void applyStatus(PipelineJob job) {
+      if (PipelineJob.STATUS_QUEUED.equals(status)) {
+        return;
+      }
+      OffsetDateTime startTime = startedAt != null ? startedAt : requestedAt.plusMinutes(1);
+      job.assignAirflowRun(airflowDagId, airflowRunId, requestPayloadJson);
+      job.markAirflowTriggered(startTime);
+      switch (status) {
+        case PipelineJob.STATUS_RUNNING -> {
+          if (!"{}".equals(resultSummaryJson)) {
+            job.markRunning(resultSummaryJson);
+          }
+        }
+        case PipelineJob.STATUS_WAITING_DOMAIN_CONFIRMATION ->
+            job.markAwaitingDomainConfirmation(resultSummaryJson);
+        case PipelineJob.STATUS_WAITING_HUMAN_FEEDBACK ->
+            job.markAwaitingHumanFeedback(resultSummaryJson);
+        case PipelineJob.STATUS_WAITING_INTENT_CALLBACK ->
+            job.markAwaitingIntentCallback(domainPackId, resultSummaryJson);
+        case PipelineJob.STATUS_WAITING_WORKFLOW_CALLBACK ->
+            job.markAwaitingWorkflowCallback(domainPackId, resultSummaryJson);
+        case PipelineJob.STATUS_SUCCEEDED ->
+            job.markSucceeded(
+                domainPackId,
+                resultSummaryJson,
+                finishedAt != null ? finishedAt : startTime.plusMinutes(1));
+        case PipelineJob.STATUS_FAILED ->
+            job.markFailed(
+                "fixture failure", finishedAt != null ? finishedAt : startTime.plusMinutes(1));
+        default -> throw new IllegalArgumentException("Unsupported PipelineJob status: " + status);
+      }
+    }
+  }
+}

--- a/backend/src/test/java/com/init/review/application/PipelineJobFailurePersistenceServiceTest.java
+++ b/backend/src/test/java/com/init/review/application/PipelineJobFailurePersistenceServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.verify;
 
 import com.init.pipelinejob.domain.model.PipelineJob;
 import com.init.pipelinejob.domain.repository.PipelineJobRepository;
+import com.init.pipelinejob.testfixture.PipelineJobFixtures;
 import com.init.workspace.application.WorkspaceFreeOnboardingService;
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.DisplayName;
@@ -12,7 +13,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("PipelineJobFailurePersistenceService")
@@ -27,8 +27,13 @@ class PipelineJobFailurePersistenceServiceTest {
     PipelineJobFailurePersistenceService service =
         new PipelineJobFailurePersistenceService(pipelineJobRepository, freeOnboardingService);
     OffsetDateTime now = OffsetDateTime.parse("2026-06-01T01:00:00Z");
-    PipelineJob job = PipelineJob.createDomainPackGeneration(1L, 3L, 9L, "{}", now.minusHours(1));
-    ReflectionTestUtils.setField(job, "id", 7L);
+    PipelineJob job =
+        PipelineJobFixtures.domainPackGeneration(7L)
+            .workspaceId(1L)
+            .datasetId(3L)
+            .triggeredBy(9L)
+            .requestedAt(now.minusHours(1))
+            .build();
 
     service.markFailed(job, "airflow offline", now);
 

--- a/backend/src/test/java/com/init/review/application/PipelineReviewCheckpointCallbackProcessorTest.java
+++ b/backend/src/test/java/com/init/review/application/PipelineReviewCheckpointCallbackProcessorTest.java
@@ -15,10 +15,12 @@ import com.init.pipelinejob.domain.model.PipelineJob;
 import com.init.pipelinejob.domain.model.WebhookReceipt;
 import com.init.pipelinejob.domain.repository.PipelineArtifactRepository;
 import com.init.pipelinejob.domain.repository.PipelineJobRepository;
+import com.init.pipelinejob.testfixture.PipelineJobFixtures;
 import com.init.review.domain.model.ReviewSession;
 import com.init.review.domain.model.ReviewTask;
 import com.init.review.domain.repository.ReviewSessionRepository;
 import com.init.review.domain.repository.ReviewTaskRepository;
+import com.init.review.testfixture.ReviewFixtures;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -30,7 +32,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("PipelineReviewCheckpointCallbackProcessor")
@@ -130,8 +131,7 @@ class PipelineReviewCheckpointCallbackProcessorTest {
         .willAnswer(
             invocation -> {
               ReviewSession session = invocation.getArgument(0);
-              ReflectionTestUtils.setField(session, "id", 56L);
-              return session;
+              return ReviewFixtures.persisted(session, 56L);
             });
     given(
             callbackSupportService.executeInTransactionOrMarkFailure(
@@ -171,10 +171,13 @@ class PipelineReviewCheckpointCallbackProcessorTest {
   }
 
   private PipelineJob job(String status) {
-    PipelineJob job = PipelineJob.createDomainPackGeneration(1L, 3L, 9L, "{}", NOW.minusHours(1));
-    ReflectionTestUtils.setField(job, "id", 7L);
-    ReflectionTestUtils.setField(job, "status", status);
-    return job;
+    return PipelineJobFixtures.domainPackGeneration(7L)
+        .workspaceId(1L)
+        .datasetId(3L)
+        .triggeredBy(9L)
+        .status(status)
+        .requestedAt(NOW.minusHours(1))
+        .build();
   }
 
   private List<ReviewTask> toList(Iterable<ReviewTask> tasks) {

--- a/backend/src/test/java/com/init/review/application/PipelineReviewCheckpointUseCaseTest.java
+++ b/backend/src/test/java/com/init/review/application/PipelineReviewCheckpointUseCaseTest.java
@@ -23,12 +23,14 @@ import com.init.pipelinejob.domain.model.PipelineJob;
 import com.init.pipelinejob.domain.model.WebhookReceipt;
 import com.init.pipelinejob.domain.repository.PipelineArtifactRepository;
 import com.init.pipelinejob.domain.repository.PipelineJobRepository;
+import com.init.pipelinejob.testfixture.PipelineJobFixtures;
 import com.init.review.domain.model.ReviewDecision;
 import com.init.review.domain.model.ReviewSession;
 import com.init.review.domain.model.ReviewTask;
 import com.init.review.domain.repository.ReviewDecisionRepository;
 import com.init.review.domain.repository.ReviewSessionRepository;
 import com.init.review.domain.repository.ReviewTaskRepository;
+import com.init.review.testfixture.ReviewFixtures;
 import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.QuotaExceededException;
 import com.init.shared.application.quota.WorkspaceQuotaValidator;
@@ -47,7 +49,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("PipelineReviewCheckpointUseCase")
@@ -199,8 +200,7 @@ class PipelineReviewCheckpointUseCaseTest {
         .willAnswer(
             invocation -> {
               ReviewSession session = invocation.getArgument(0);
-              ReflectionTestUtils.setField(session, "id", 55L);
-              return session;
+              return ReviewFixtures.persisted(session, 55L);
             });
     given(callbackSupportService.executeInTransactionOrMarkFailure(eq(7L), eq("evt-domain"), any()))
         .willAnswer(invocation -> invocation.<Supplier<?>>getArgument(2).get());
@@ -395,8 +395,7 @@ class PipelineReviewCheckpointUseCaseTest {
         .willAnswer(
             invocation -> {
               ReviewDecision decision = invocation.getArgument(0);
-              ReflectionTestUtils.setField(decision, "id", 77L);
-              return decision;
+              return ReviewFixtures.persisted(decision, 77L);
             });
     given(pipelineArtifactRepository.save(any(PipelineArtifact.class)))
         .willAnswer(invocation -> invocation.getArgument(0));
@@ -501,8 +500,7 @@ class PipelineReviewCheckpointUseCaseTest {
         .willAnswer(
             invocation -> {
               ReviewDecision decision = invocation.getArgument(0);
-              ReflectionTestUtils.setField(decision, "id", 77L);
-              return decision;
+              return ReviewFixtures.persisted(decision, 77L);
             });
     given(pipelineArtifactRepository.save(any(PipelineArtifact.class)))
         .willAnswer(invocation -> invocation.getArgument(0));
@@ -533,9 +531,7 @@ class PipelineReviewCheckpointUseCaseTest {
     JsonNode constraints =
         objectMapper.readTree(artifactCaptor.getValue().getPayloadJson()).path("constraints");
     List<String> decisionPayloads =
-        decisionCaptor.getAllValues().stream()
-            .map(decision -> (String) ReflectionTestUtils.getField(decision, "decisionPayloadJson"))
-            .toList();
+        decisionCaptor.getAllValues().stream().map(ReviewDecision::getDecisionPayloadJson).toList();
 
     assertThat(constraints).hasSize(1);
     assertThat(constraints.get(0).path("sourceId").asText()).isEqualTo("wf3");
@@ -585,28 +581,31 @@ class PipelineReviewCheckpointUseCaseTest {
   }
 
   private PipelineJob job(String status, String summaryJson) {
-    PipelineJob job = PipelineJob.createDomainPackGeneration(1L, 3L, 9L, "{}", NOW.minusHours(1));
-    ReflectionTestUtils.setField(job, "id", 7L);
-    ReflectionTestUtils.setField(job, "status", status);
-    ReflectionTestUtils.setField(job, "resultSummaryJson", summaryJson);
-    return job;
+    return PipelineJobFixtures.domainPackGeneration(7L)
+        .workspaceId(1L)
+        .datasetId(3L)
+        .triggeredBy(9L)
+        .status(status)
+        .resultSummaryJson(summaryJson)
+        .requestedAt(NOW.minusHours(1))
+        .build();
   }
 
   private ReviewSession session(String reviewKind, String status, Long id) {
     ReviewSession session =
         ReviewSession.createPipelineCheckpoint(
             1L, 7L, 3L, reviewKind, "리뷰", "설명", "{}", NOW.minusMinutes(10));
-    ReflectionTestUtils.setField(session, "id", id);
-    ReflectionTestUtils.setField(session, "status", status);
-    return session;
+    if (ReviewSession.STATUS_CLOSED.equals(status)) {
+      session.close(NOW.minusMinutes(1));
+    }
+    return ReviewFixtures.persisted(session, id);
   }
 
   private ReviewTask task(Long id, String targetType, String payloadJson) {
     ReviewTask task =
-        ReviewTask.create(55L, targetType, payloadJson, "리뷰 태스크", "NORMAL", "{}", NOW);
-    ReflectionTestUtils.setField(task, "id", id);
-    ReflectionTestUtils.setField(task, "reviewSessionId", id >= 200 ? 56L : 55L);
-    return task;
+        ReviewTask.create(
+            id >= 200 ? 56L : 55L, targetType, payloadJson, "리뷰 태스크", "NORMAL", "{}", NOW);
+    return ReviewFixtures.persisted(task, id);
   }
 
   private List<ReviewTask> toList(Iterable<ReviewTask> tasks) {

--- a/backend/src/test/java/com/init/review/application/PipelineReviewReplayOrchestratorTest.java
+++ b/backend/src/test/java/com/init/review/application/PipelineReviewReplayOrchestratorTest.java
@@ -16,6 +16,7 @@ import com.init.pipelinejob.domain.model.PipelineArtifact;
 import com.init.pipelinejob.domain.model.PipelineJob;
 import com.init.pipelinejob.domain.repository.PipelineArtifactRepository;
 import com.init.pipelinejob.domain.repository.PipelineJobRepository;
+import com.init.pipelinejob.testfixture.PipelineJobFixtures;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -28,7 +29,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("PipelineReviewReplayOrchestrator")
@@ -135,10 +135,13 @@ class PipelineReviewReplayOrchestratorTest {
   }
 
   private PipelineJob job(String status, String summaryJson) {
-    PipelineJob job = PipelineJob.createDomainPackGeneration(1L, 3L, 9L, "{}", NOW.minusHours(1));
-    ReflectionTestUtils.setField(job, "id", 7L);
-    ReflectionTestUtils.setField(job, "status", status);
-    ReflectionTestUtils.setField(job, "resultSummaryJson", summaryJson);
-    return job;
+    return PipelineJobFixtures.domainPackGeneration(7L)
+        .workspaceId(1L)
+        .datasetId(3L)
+        .triggeredBy(9L)
+        .status(status)
+        .resultSummaryJson(summaryJson)
+        .requestedAt(NOW.minusHours(1))
+        .build();
   }
 }

--- a/backend/src/test/java/com/init/review/domain/model/ReviewSessionTest.java
+++ b/backend/src/test/java/com/init/review/domain/model/ReviewSessionTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @DisplayName("ReviewSession")
 class ReviewSessionTest {
@@ -34,10 +33,10 @@ class ReviewSessionTest {
     assertThat(session.getTitle()).isEqualTo("도메인 확인");
     assertThat(session.getDescription()).isEqualTo("설명");
     assertThat(session.getMetaJson()).contains("domain");
-    assertThat(ReflectionTestUtils.getField(session, "domainPackVersionId")).isNull();
-    assertThat(ReflectionTestUtils.getField(session, "createdBy")).isNull();
-    assertThat(ReflectionTestUtils.getField(session, "openedAt")).isEqualTo(OPENED_AT);
-    assertThat(ReflectionTestUtils.getField(session, "closedAt")).isNull();
+    assertThat(session.getDomainPackVersionId()).isNull();
+    assertThat(session.getCreatedBy()).isNull();
+    assertThat(session.getOpenedAt()).isEqualTo(OPENED_AT);
+    assertThat(session.getClosedAt()).isNull();
   }
 
   @Test
@@ -73,10 +72,10 @@ class ReviewSessionTest {
     assertThat(session.getTitle()).isEqualTo("시뮬레이션 개선 후보 검토");
     assertThat(session.getDescription()).isEqualTo("설명");
     assertThat(session.getMetaJson()).isEqualTo("{}");
-    assertThat(ReflectionTestUtils.getField(session, "createdBy")).isEqualTo(5L);
-    assertThat(ReflectionTestUtils.getField(session, "pipelineJobId")).isNull();
-    assertThat(ReflectionTestUtils.getField(session, "datasetId")).isNull();
-    assertThat(ReflectionTestUtils.getField(session, "openedAt")).isEqualTo(OPENED_AT);
+    assertThat(session.getCreatedBy()).isEqualTo(5L);
+    assertThat(session.getPipelineJobId()).isNull();
+    assertThat(session.getDatasetId()).isNull();
+    assertThat(session.getOpenedAt()).isEqualTo(OPENED_AT);
   }
 
   @Test
@@ -90,6 +89,6 @@ class ReviewSessionTest {
     session.close(closedAt);
 
     assertThat(session.getStatus()).isEqualTo(ReviewSession.STATUS_CLOSED);
-    assertThat(ReflectionTestUtils.getField(session, "closedAt")).isEqualTo(closedAt);
+    assertThat(session.getClosedAt()).isEqualTo(closedAt);
   }
 }

--- a/backend/src/test/java/com/init/review/testfixture/ReviewFixtures.java
+++ b/backend/src/test/java/com/init/review/testfixture/ReviewFixtures.java
@@ -1,0 +1,31 @@
+package com.init.review.testfixture;
+
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.spy;
+
+import com.init.review.domain.model.ReviewDecision;
+import com.init.review.domain.model.ReviewSession;
+import com.init.review.domain.model.ReviewTask;
+
+public final class ReviewFixtures {
+
+  private ReviewFixtures() {}
+
+  public static ReviewSession persisted(ReviewSession session, Long id) {
+    ReviewSession persisted = spy(session);
+    lenient().doReturn(id).when(persisted).getId();
+    return persisted;
+  }
+
+  public static ReviewDecision persisted(ReviewDecision decision, Long id) {
+    ReviewDecision persisted = spy(decision);
+    lenient().doReturn(id).when(persisted).getId();
+    return persisted;
+  }
+
+  public static ReviewTask persisted(ReviewTask task, Long id) {
+    ReviewTask persisted = spy(task);
+    lenient().doReturn(id).when(persisted).getId();
+    return persisted;
+  }
+}


### PR DESCRIPTION
## 개요

Closes #831

pipeline-job와 review bounded context 테스트에서 `ReflectionTestUtils` 직접 사용을 제거하고, 도메인 factory/전이 메서드와 명시적인 persisted fixture helper로 상태 구성을 정리합니다. 운영 API, DB schema, 런타임 비즈니스 동작은 변경하지 않습니다.

## 변경

- `.agent/specs/831.md`에 문제, 범위, 비목표, 완료 조건과 검증 기준을 정리했습니다.
- `PipelineJobFixtures`와 `ReviewFixtures`를 추가해 generated id가 필요한 테스트 fixture 구성을 repository stub/Mockito spy 기반으로 모았습니다.
- PipelineJob callback/usecase/review checkpoint 테스트가 상태별 fixture, repository 반환값, captor, result DTO로 결과를 검증하도록 바꿨습니다.
- `PipelineArtifact`, `ReviewSession`, `ReviewDecision`은 테스트가 도메인 결과로 확인하던 값만 public getter로 노출하고 setter는 추가하지 않았습니다.
- `backend/src/test/java/com/init/pipelinejob/**`와 `backend/src/test/java/com/init/review/**`의 `ReflectionTestUtils` import/call을 제거했습니다.

## 품질 근거

- 변경 전 issue scope의 `ReflectionTestUtils` 사용 파일과 대표 callback/review checkpoint 흐름을 확인했고, 변경 범위는 spec, pipeline-job/review 테스트 fixture, 검증용 getter로 제한했습니다.
- 구현은 기존 도메인 factory와 전이 메서드(`createDomainPackGeneration`, `createIngestion`, `markAwaiting*`, `markSucceeded`, `markFailed`)를 우선 사용했습니다.
- 생성 ID가 필요한 단위 테스트는 JPA 영속화 결과를 모사하는 persisted spy 또는 repository answer로 구성했습니다.
- 3회 self-review 결과:
  - Round 1(issue fidelity/behavior): 이슈 완료 조건과 diff를 대조해 scoped `ReflectionTestUtils` 제거, 상태 의도 fixture, private field 조회 대체 여부를 확인했습니다.
  - Round 2(architecture/integration): production setter 추가 없음, DDD domain getter만 추가, testfixture import가 test source에만 머무는지 확인했습니다.
  - Round 3(reviewer/CI): unintended files, branch/spec filename, whitespace, nested Mockito stubbing, stale Gradle command, focused backend test 결과를 점검했고 `RetryAdminPipelineJobUseCaseTest`의 불필요한 fixture parameter를 정리했습니다.

## 검증

- `rg -n "ReflectionTestUtils" backend/src/test/java/com/init/pipelinejob backend/src/test/java/com/init/review` → no output
- `cd backend && GRADLE_USER_HOME=/tmp/ostone-gradle-home mise exec -- ./gradlew spotlessApply` → BUILD SUCCESSFUL
- `cd backend && GRADLE_USER_HOME=/tmp/ostone-gradle-home mise exec -- ./gradlew spotlessCheck` → BUILD SUCCESSFUL
- `cd backend && GRADLE_USER_HOME=/tmp/ostone-gradle-home mise exec -- ./gradlew test --tests "com.init.pipelinejob.*" --tests "com.init.review.*"` → BUILD SUCCESSFUL
- `git diff --check` → no output

## 참고

- 로컬 기본 `java`는 17로 잡혀 Gradle Java 21 toolchain 요구사항을 만족하지 않아 `mise exec`로 Temurin 21 환경에서 검증했습니다.
- 기본 Gradle cache에 다른 프로세스의 journal lock이 있어 검증은 `/tmp/ostone-gradle-home`의 별도 `GRADLE_USER_HOME`으로 실행했습니다.