### PR TITLE
fix: 상담 시뮬레이션 자동매칭·기대 intent 자동완성·Replay·세션 초기화 QA 수정

### DIFF
--- a/backend/src/main/java/com/init/workflowruntime/application/LlmToolService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/LlmToolService.java
@@ -110,7 +110,9 @@ public class LlmToolService {
       GetCurrentWorkflowCommand command, Long userId) {
     ChatSession session = findSession(command.sessionId());
     validateWorkspaceMembership(session.getWorkspaceId(), userId);
-    return getCurrentWorkflow(command, session);
+    // 운영자 노출 상태는 정직해야 한다. 실행이 없으면 임의의 첫 워크플로우를 PENDING 으로 위조하지 않고
+    // 미선택 상태(null) 로 반환해 UI 가 "미매칭/대기" 로 렌더하도록 한다.
+    return getCurrentWorkflow(command, session, false);
   }
 
   @SuppressWarnings("java:S2201") // false positive: PESSIMISTIC_WRITE lock only, return ignored
@@ -118,11 +120,11 @@ public class LlmToolService {
   public LlmToolWorkflowResponse getCurrentWorkflow(GetCurrentWorkflowCommand command) {
     Long sessionId = command.sessionId();
     ChatSession session = findSession(sessionId);
-    return getCurrentWorkflow(command, session);
+    return getCurrentWorkflow(command, session, true);
   }
 
   private LlmToolWorkflowResponse getCurrentWorkflow(
-      GetCurrentWorkflowCommand command, ChatSession session) {
+      GetCurrentWorkflowCommand command, ChatSession session, boolean fabricateDefaultWhenMissing) {
     Long sessionId = command.sessionId();
     WorkflowExecution execution = findExecution(sessionId);
 
@@ -139,7 +141,9 @@ public class LlmToolService {
                   workflowDefinitionId, session.getDomainPackVersionId())
               .orElse(null);
     }
-    if (definition == null && session.getDomainPackVersionId() != null) {
+    if (fabricateDefaultWhenMissing
+        && definition == null
+        && session.getDomainPackVersionId() != null) {
       List<WorkflowDefinition> candidates =
           workflowDefinitionRepository.findAllByDomainPackVersionId(
               session.getDomainPackVersionId());

--- a/backend/src/main/java/com/init/workflowruntime/application/matching/WorkflowMatchingService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/matching/WorkflowMatchingService.java
@@ -75,7 +75,10 @@ public class WorkflowMatchingService {
       if (!candidateProvider.hasActiveProfiles(session.getDomainPackVersionId())) {
         decisionRecorder.recordNoCandidate(session, textHash, "profile_missing");
         metrics.recordProfileMissing();
-        return WorkflowMatchResult.unknown("아직 이 도메인팩의 매칭 프로필이 준비되지 않았습니다.");
+        // 임베딩 매칭 프로필이 아직 없으면 임베딩 매칭을 dead-end(UNKNOWN) 로 끝내지 않고 UNAVAILABLE 로
+        // 반환한다. 그래야 IntentClassificationService 가 키워드 기반 폴백 분류를 수행한다. (시드 도메인팩은
+        // prod 에서 profile build 를 의도적으로 건너뛰므로, 프로필이 없을 때 키워드 매칭으로 우아하게 저하한다.)
+        return WorkflowMatchResult.unavailable();
       }
 
       WorkflowMatchingEvaluation evaluation =

--- a/backend/src/test/java/com/init/workflowruntime/application/IntentClassificationServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/IntentClassificationServiceTest.java
@@ -2,12 +2,14 @@ package com.init.workflowruntime.application;
 
 import static com.init.workflowruntime.support.WorkflowRuntimeTestObjects.chatSessionWithId;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 import com.init.domainpack.domain.model.IntentDefinition;
 import com.init.domainpack.domain.repository.IntentDefinitionRepository;
 import com.init.workflowruntime.application.command.IntentClassificationCommand;
 import com.init.workflowruntime.application.dto.IntentClassificationResult;
+import com.init.workflowruntime.application.matching.WorkflowMatchResult;
 import com.init.workflowruntime.application.matching.WorkflowMatchingService;
 import com.init.workflowruntime.domain.ChatSession;
 import com.init.workflowruntime.domain.ChatSessionRepository;
@@ -70,6 +72,35 @@ class IntentClassificationServiceTest {
     assertThat(result.status()).isEqualTo("AMBIGUOUS");
     assertThat(result.candidates()).hasSize(2);
     assertThat(result.confirmationQuestion()).contains("중 어떤 문의");
+  }
+
+  @Test
+  @DisplayName("classify: 임베딩이 켜져 있어도 매칭 결과가 UNAVAILABLE이면 키워드 분류로 폴백한다")
+  void should_fallBackToKeyword_when_embeddingEnabledButMatchingUnavailable() {
+    // prod 처럼 임베딩 매칭이 켜져 있지만 프로필이 없어 UNAVAILABLE 이 반환되는 상황(Fix D). dead-end 대신
+    // 키워드 기반 분류로 폴백해 의도를 매칭해야 한다.
+    givenSession();
+    given(workflowMatchingService.isEnabled()).willReturn(true);
+    given(workflowMatchingService.match(any(), any(), any()))
+        .willReturn(WorkflowMatchResult.unavailable());
+    given(intentDefinitionRepository.findByDomainPackVersionId(101L))
+        .willReturn(
+            List.of(
+                intent(
+                    "cancellation_refund_change_policy",
+                    "취소 환불 및 변경 규정",
+                    "예약 취소, 환불, 변경 절차",
+                    "PUBLISHED"),
+                intent(
+                    "travel_recommendation_consulting",
+                    "여행 상품 및 숙소 추천",
+                    "예산과 지역에 맞는 호텔·리조트·상품 추천",
+                    "PUBLISHED")));
+
+    IntentClassificationResult result = service.classify(command("취소하고 환불받고 싶어요", ""));
+
+    assertThat(result.status()).isEqualTo("CONFIDENT");
+    assertThat(result.intentCode()).isEqualTo("cancellation_refund_change_policy");
   }
 
   @Test

--- a/backend/src/test/java/com/init/workflowruntime/application/LlmToolServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/LlmToolServiceTest.java
@@ -155,6 +155,31 @@ class LlmToolServiceTest {
   }
 
   @Test
+  @DisplayName(
+      "getCurrentWorkflowForOperator: execution이 없으면 첫 workflow로 위조하지 않고 미선택(null) 상태를 반환한다")
+  void should_returnNoFabricatedWorkflow_when_operatorAndNoExecution() {
+    ChatSession session = createSession(1L, 10L, 101L);
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(10L, 7L))
+        .willReturn(Optional.of(WorkspaceMember.create(10L, 7L, WorkspaceMemberRole.OPERATOR)));
+    given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L))
+        .willReturn(Optional.empty());
+
+    LlmToolWorkflowResponse result =
+        service.getCurrentWorkflowForOperator(new GetCurrentWorkflowCommand(1L), 7L);
+
+    // 운영자 뷰는 실행이 없으면 임의의 첫 workflow를 PENDING으로 위조하지 않는다(미매칭/대기로 렌더되도록 null).
+    assertThat(result.executionId()).isNull();
+    assertThat(result.executionStatus()).isNull();
+    assertThat(result.currentState()).isNull();
+    assertThat(result.workflowDefinitionId()).isNull();
+    assertThat(result.workflowCode()).isNull();
+    assertThat(result.workflowName()).isNull();
+    assertThat(result.graphJson()).isNull();
+    verify(workflowDefinitionRepository, never()).findAllByDomainPackVersionId(101L);
+  }
+
+  @Test
   @DisplayName("getContext: 세션 기준 slot 정의와 저장 값을 함께 반환한다")
   void should_returnContextWithSlotsAndValues() {
     // given

--- a/backend/src/test/java/com/init/workflowruntime/application/matching/WorkflowMatchingServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/matching/WorkflowMatchingServiceTest.java
@@ -508,14 +508,16 @@ class WorkflowMatchingServiceTest {
   }
 
   @Test
-  @DisplayName("active profile이 없으면 UNKNOWN과 profile_missing audit을 남긴다")
-  void should_returnUnknown_when_profileMissing() {
+  @DisplayName("active profile이 없으면 UNAVAILABLE로 키워드 폴백을 유도하고 profile_missing audit을 남긴다")
+  void should_returnUnavailableForKeywordFallback_when_profileMissing() {
     givenSession();
     given(profileRepository.countActiveProfiles(101L)).willReturn(0);
 
     WorkflowMatchResult result = service.match(1L, "환불하고 싶어요", "");
 
-    assertThat(result.status()).isEqualTo("UNKNOWN");
+    // 프로필이 없으면 dead-end(UNKNOWN) 가 아니라 UNAVAILABLE 을 반환해 상위 classify 가 키워드 매칭으로
+    // 폴백하도록 한다. embedding 결정 audit 자체는 여전히 UNKNOWN/profile_missing 으로 기록된다.
+    assertThat(result.status()).isEqualTo("UNAVAILABLE");
     verify(decisionRepository)
         .record(
             eq(1L),

--- a/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.qa-fixes.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.qa-fixes.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { ApiRequestError } from "@/shared/api";
 import {
@@ -8,8 +8,10 @@ import {
   goldenCase,
   mockedSimulationApi,
   openCandidateTab,
+  otherSession,
   renderPage,
   replayResult,
+  session,
   toast,
 } from "./WorkspaceSimulationPage.test-helper";
 
@@ -129,6 +131,68 @@ describe("WorkspaceSimulationPage QA fixes", () => {
     expect(workflowOptions?.querySelector('option[value="refund.standard"]')).not.toBeNull();
     expect(stateOptions?.querySelector('option[value="ask_order_no"]')).not.toBeNull();
     expect(stateOptions?.querySelector('option[value="collect_order_no"]')).not.toBeNull();
+  });
+
+  it("matched intent가 없어도 도메인팩 intent 목록으로 기대 intent 자동완성을 채운다", async () => {
+    // 자동 매칭 세션은 워크플로우 시작 전 matchedWorkflow.intentCode가 비어 있다. 이때도 도메인팩 버전의
+    // intent 목록(useListIntents)으로 datalist를 채워야 한다(기대 intent 자동완성 회귀 방지).
+    mockedSimulationApi.getSession.mockResolvedValue({
+      ...detail,
+      matchedWorkflow: {
+        ...detail.matchedWorkflow,
+        intentCode: null,
+        workflowCode: null,
+        workflowName: null,
+        currentState: null,
+        executionStatus: null,
+      },
+    });
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("기대 intent")).toBeInTheDocument();
+    });
+    const intentOptions = document.getElementById("expected-intent-options");
+    // travel_recommend는 matched에 없으므로 오직 intent 목록(useListIntents)에서만 올 수 있다.
+    expect(intentOptions?.querySelector('option[value="travel_recommend"]')).not.toBeNull();
+    expect(intentOptions?.querySelector('option[value="refund_request"]')).not.toBeNull();
+  });
+
+  it("세션을 전환하면 로딩 중 이전 세션의 Runtime State가 즉시 비워진다", async () => {
+    mockedSimulationApi.listSessions.mockResolvedValue({
+      content: [session, otherSession],
+      page: 0,
+      size: 20,
+      totalElements: 2,
+      totalPages: 1,
+    });
+    let resolveOther!: (value: unknown) => void;
+    const pendingDetail = new Promise((resolve) => {
+      resolveOther = resolve;
+    });
+    mockedSimulationApi.getSession.mockImplementation(async (_workspaceId, sessionId) => {
+      if (sessionId === otherSession.id) {
+        await pendingDetail;
+      }
+      return detail;
+    });
+    renderPage();
+
+    const statePanel = () =>
+      document.getElementById("simulation-side-panel-state") as HTMLElement;
+    await waitFor(() => {
+      expect(within(statePanel()).getByText("환불 처리")).toBeInTheDocument();
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: /다른 고객/ }));
+
+    // 상세 로딩이 끝나기 전에 이전 세션의 Runtime State(환불 처리)가 즉시 사라지고 미매칭으로 비워진다.
+    await waitFor(() => {
+      expect(within(statePanel()).queryByText("환불 처리")).toBeNull();
+    });
+    expect(within(statePanel()).getAllByText("미매칭").length).toBeGreaterThan(0);
+
+    resolveOther(detail);
   });
 
   it("리뷰 입력 placeholder를 중립 문구로 표시한다", async () => {

--- a/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.test-helper.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.test-helper.tsx
@@ -9,6 +9,7 @@ import {
   type SimulationImprovementCandidate,
 } from "@/features/simulation";
 import { useListAllWorkspaceWorkflows } from "@/entities/workflow";
+import { useListIntents } from "@/shared/api/generated/endpoints/intent-definition-controller/intent-definition-controller";
 
 const setCrumbs = vi.fn();
 const { toast } = vi.hoisted(() => ({
@@ -36,6 +37,13 @@ vi.mock("@/entities/workflow", () => ({
   useListAllWorkspaceWorkflows: vi.fn(),
 }));
 
+vi.mock(
+  "@/shared/api/generated/endpoints/intent-definition-controller/intent-definition-controller",
+  () => ({
+    useListIntents: vi.fn(),
+  }),
+);
+
 vi.mock("@/features/simulation", () => ({
   simulationApi: {
     listSessions: vi.fn(),
@@ -62,6 +70,15 @@ vi.mock("sonner", () => ({
 
 const mockedWorkflows = vi.mocked(useListAllWorkspaceWorkflows);
 const mockedSimulationApi = vi.mocked(simulationApi);
+const mockedIntents = vi.mocked(useListIntents);
+
+function intentsResult(
+  data: Array<{ id: number; intentCode: string; name: string }>,
+): ReturnType<typeof useListIntents> {
+  return { data, isLoading: false, isError: false, error: null } as unknown as ReturnType<
+    typeof useListIntents
+  >;
+}
 
 const session = {
   id: 10,
@@ -296,6 +313,12 @@ beforeEach(() => {
       },
     ],
   });
+  mockedIntents.mockReturnValue(
+    intentsResult([
+      { id: 301, intentCode: "refund_request", name: "환불 요청" },
+      { id: 302, intentCode: "travel_recommend", name: "여행 추천" },
+    ]),
+  );
   mockedSimulationApi.listSessions.mockResolvedValue({
     content: [session],
     page: 0,
@@ -372,6 +395,8 @@ export {
   failedReplayResult,
   feedbackWithType,
   goldenCase,
+  intentsResult,
+  mockedIntents,
   mockedSimulationApi,
   mockedWorkflows,
   openCandidateTab,

--- a/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.tsx
@@ -36,7 +36,9 @@ import {
 } from "@/features/simulation";
 import type { ChatMessage, ChatSession } from "@/features/consultation/api/consultationApi";
 import { parseRouteId } from "@/shared/lib/parseRouteId";
-import { ApiRequestError } from "@/shared/api";
+import { ApiRequestError, selectApiList } from "@/shared/api";
+import { useListIntents } from "@/shared/api/generated/endpoints/intent-definition-controller/intent-definition-controller";
+import type { IntentDefinitionSummary } from "@/shared/api/generated/zod";
 import type { ShellContext } from "@/shared/ui/ostone/chrome";
 import { Button } from "@/shared/ui/button";
 import { NativeSelect, NativeSelectOption } from "@/shared/ui/native-select";
@@ -807,6 +809,24 @@ export function WorkspaceSimulationPage() {
     return null;
   }, [detail?.matchedWorkflow, selectedWorkflow, simulationTarget, targetWorkflow]);
   const matched = detail?.matchedWorkflow ?? null;
+  // 기대 intent 자동완성 옵션을 위해 시뮬레이션 대상 도메인팩 버전의 intent 목록을 불러온다. 세션의
+  // matchedWorkflow 버전을 우선 사용하고, 없으면 시작 target/워크스페이스 워크플로우에서 pack·version을 찾는다.
+  const intentLookupSource = useMemo(() => {
+    const versionId = matched?.domainPackVersionId ?? simulationTarget?.versionId ?? null;
+    const entry =
+      workflows.entries.find((wf) => wf.versionId === versionId) ?? workflows.entries[0] ?? null;
+    return entry ? { packId: entry.packId, versionId: entry.versionId } : null;
+  }, [matched?.domainPackVersionId, simulationTarget?.versionId, workflows.entries]);
+  const workspaceIntents = useListIntents(
+    parsedWorkspaceId ?? -1,
+    intentLookupSource?.packId ?? -1,
+    intentLookupSource?.versionId ?? -1,
+    {
+      query: {
+        enabled: parsedWorkspaceId !== null && intentLookupSource !== null,
+      },
+    },
+  );
   const expectedWorkflowOptions = useMemo(() => {
     const codes = new Set<string>();
     workflows.entries.forEach((entry) => {
@@ -823,9 +843,12 @@ export function WorkspaceSimulationPage() {
   }, [matched?.graphJson, matched?.currentState]);
   const expectedIntentOptions = useMemo(() => {
     const codes = new Set<string>();
+    selectApiList<IntentDefinitionSummary>(workspaceIntents.data).forEach((intent) => {
+      if (intent.intentCode) codes.add(intent.intentCode);
+    });
     if (matched?.intentCode) codes.add(matched.intentCode);
     return Array.from(codes);
-  }, [matched?.intentCode]);
+  }, [workspaceIntents.data, matched?.intentCode]);
   const isTargetContextConfirmed = matchesTargetContext(targetWorkflow, simulationTarget);
   const targetPackLabel =
     (isTargetContextConfirmed ? targetWorkflow?.packName : null) ??
@@ -1063,6 +1086,8 @@ export function WorkspaceSimulationPage() {
     }
 
     let active = true;
+    // 세션을 전환하면 이전 세션의 Runtime State/기대값이 잔존하지 않도록 즉시 비운 뒤 다시 불러온다.
+    setDetail(null);
     setIsLoadingDetail(true);
     setError(null);
     simulationApi


### PR DESCRIPTION
## 배경

상담 시뮬레이션(SIMULATION LAB) 화면 QA 4건. **production(app.ajou-cstone.com) API 재현 + CloudWatch 로그**로 근본 원인을 확정한 뒤 수정했다.

| QA | 증상 | 근본 원인 |
| --- | --- | --- |
| ① 자동매칭 미동작 | auto-match 세션이 임의 워크플로우(취소·환불)를 PENDING으로 표시 + LLM이 요청 거절 | (A) 표시 위조 + (D) 매칭 dead-end |
| ② 기대 intent 자동완성 미동작 | datalist가 비어 있음 | matchedWorkflow.intentCode만 옵션화 |
| ③ Replay 미동작 (actual 전부 null) | 재생 세션에서 워크플로우 미시작 | (D)와 동일 원인 (LLM 매처 재실행) |
| ④ 새 세션 RUNTIME STATE 상속 | 이전 상태가 남음 | (A) 위조 fallback + FE 미초기화 |

## 근본 원인 (production 확정)

- **표시(A)**: `LlmToolService.getCurrentWorkflow`가 실행이 없는 세션에 대해 버전의 **첫 워크플로우**를 `PENDING`으로 위조 반환 → 운영자 RUNTIME STATE에 임의 워크플로우가 매칭된 것처럼 보임.
- **매칭(D)**: prod 로그 `Seed domain pack 'activeventure-travel' seeded as version 105 (profileBuildEnqueue=false)` — 시드 도메인팩은 prod에서 임베딩 매칭 프로필 build를 **의도적으로 skip**. `WorkflowMatchingService.match()`가 프로필 미존재 시 `unknown()` **dead-end**를 반환해 `IntentClassificationService`의 키워드 폴백(`UNAVAILABLE`에서만 진입)에 도달 못함 → auto-match에서 워크플로우가 시작되지 않아 LLM이 거절. **시뮬레이션·/demo 공통**(QA의 "demo는 정상" 가정은 재현 결과 거짓).

## 변경

- **Fix A** `LlmToolService`: `fabricateDefaultWhenMissing` 플래그 추가, 운영자 경로는 위조 없이 미선택(null) 반환 → FE가 미매칭/대기로 렌더. (①④)
- **Fix D** `WorkflowMatchingService`: 프로필 미존재 시 `unavailable()` 반환 → 키워드 분류로 우아하게 저하(설계 정합: prod는 의도적으로 임베딩 skip). (①③) — 별도 prod profile backfill 불필요.
- **Fix B** `WorkspaceSimulationPage`: `useListIntents`로 도메인팩 버전 intent 목록을 불러와 기대 intent datalist를 채움. (②)
- **Fix C** `WorkspaceSimulationPage`: 세션 전환 시 상세 재요청 전 `detail`을 즉시 비워 잔존 상태 제거. (④)

## 검증

- **Backend**: `LlmToolServiceTest`(운영자 무실행 시 전부 null / no-userId fallback 유지), `WorkflowMatchingServiceTest`(profile_missing → `UNAVAILABLE`), `IntentClassificationServiceTest`(임베딩 ON + `UNAVAILABLE` → 키워드 CONFIDENT 폴백).
- **Frontend**: `WorkspaceSimulationPage.qa-fixes` 등 52 테스트 — matched.intentCode 없이도 intent datalist 채워짐, 세션 전환 시 RUNTIME STATE 즉시 초기화.
- **로컬 런타임**: 새 jar로 재기동 후 auto-match `createSession` matchedWorkflow 전부 null 확인(Fix A). (로컬 LLM(OpenAI) 키 미설정으로 LLM 구동 흐름은 미검증, 키워드 매칭 경로는 단위테스트로 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 워크스페이스 시뮬레이션에서 의도(Intent) 자동완성 기능 추가
  * 도메인팩 정의를 기반으로 한 의도 옵션 목록 제공

* **버그 수정**
  * 세션 전환 시 이전 세션의 런타임 상태가 화면에 남는 문제 해결
  * 워크플로우 매칭 불가능 시 키워드 기반 폴백 동작 개선

* **테스트**
  * 의도 분류 및 워크플로우 관련 테스트 케이스 추가
  * 세션 전환 및 의도 자동완성 동작 검증 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->