### PR TITLE
fix(ml): #842 Qwen thinking payload 보강

### DIFF
--- a/ml/src/pipeline/stages/domain_candidate_generation/main.py
+++ b/ml/src/pipeline/stages/domain_candidate_generation/main.py
@@ -140,6 +140,7 @@ def _generate_llm_candidates(
             {"role": "user", "content": prompt},
         ],
         "response_format": {"type": "json_object"},
+        "chat_template_kwargs": {"enable_thinking": False},
         "options": {"think": False},
     }
     with httpx.Client(timeout=_llm_timeout()) as client:

--- a/ml/src/pipeline/stages/draft_generation/description_enrichment.py
+++ b/ml/src/pipeline/stages/draft_generation/description_enrichment.py
@@ -409,6 +409,7 @@ def _request_payload(model_name: str, entity: DescriptionEntity, field_name: str
             },
         ],
     }
+    payload["chat_template_kwargs"] = {"enable_thinking": False}
     payload["options"] = {"think": False}
     return payload
 

--- a/ml/src/pipeline/stages/feedback_candidate_generation/review_question_enrichment.py
+++ b/ml/src/pipeline/stages/feedback_candidate_generation/review_question_enrichment.py
@@ -271,6 +271,7 @@ def _request_payload(
             },
         ],
     }
+    payload["chat_template_kwargs"] = {"enable_thinking": False}
     payload["options"] = {"think": False}
     return payload
 

--- a/ml/tests/stages/test_domain_candidate_generation_main.py
+++ b/ml/tests/stages/test_domain_candidate_generation_main.py
@@ -254,6 +254,7 @@ def test_generate_llm_candidates_posts_prompt_and_parses_response(monkeypatch: p
     assert request["headers"]["Authorization"] == "Bearer secret-token"
     assert request["json"]["model"] == "model-a"
     assert request["json"]["max_tokens"] == main.LLM_MAX_TOKENS
+    assert request["json"]["chat_template_kwargs"] == {"enable_thinking": False}
     assert request["json"]["options"] == {"think": False}
 
 

--- a/ml/tests/stages/test_draft_generation_description_enrichment.py
+++ b/ml/tests/stages/test_draft_generation_description_enrichment.py
@@ -242,6 +242,7 @@ def test_description_enrichment_sends_model_options_by_default(monkeypatch, tmp_
 
     assert summary is not None
     assert summary["nameAppliedCount"] == 1
+    assert fake_client.requests[0]["json"]["chat_template_kwargs"] == {"enable_thinking": False}
     assert fake_client.requests[0]["json"]["options"] == {"think": False}
 
 

--- a/ml/tests/stages/test_feedback_candidate_generation_main.py
+++ b/ml/tests/stages/test_feedback_candidate_generation_main.py
@@ -237,6 +237,7 @@ def test_review_question_enrichment_sends_runtime_options_and_respects_limit(
     assert summary["skippedByLimitCount"] == 1
     assert second_question.get("enrichmentStatus") is None
     assert _FakeClient.calls[0]["headers"]["Authorization"] == "Bearer local-token"
+    assert _FakeClient.calls[0]["json"]["chat_template_kwargs"] == {"enable_thinking": False}
     assert _FakeClient.calls[0]["json"]["options"] == {"think": False}
     assert question["enrichmentStatus"] == "applied"
 


### PR DESCRIPTION
## Summary
- add llama.cpp/Qwen3 `chat_template_kwargs.enable_thinking=false` to local LLM requests
- keep existing `options.think=false` for runtime compatibility
- cover domain candidate, review question enrichment, and draft description enrichment payloads

## Evidence
- job 48 reached GPU/LLM successfully, then `domain_candidate_generation` failed after HTTP 200 because `message.content` was empty
- llama.cpp logs showed Qwen chat template `thinking = 1`; the request had only the Ollama-style `options.think=false`

## Tests
- `cd ml && uv run pytest tests/stages/test_domain_candidate_generation_main.py tests/stages/test_feedback_candidate_generation_main.py tests/stages/test_draft_generation_description_enrichment.py`
- `cd ml && uv run ruff check src/pipeline/stages/domain_candidate_generation/main.py src/pipeline/stages/feedback_candidate_generation/review_question_enrichment.py src/pipeline/stages/draft_generation/description_enrichment.py tests/stages/test_domain_candidate_generation_main.py tests/stages/test_feedback_candidate_generation_main.py tests/stages/test_draft_generation_description_enrichment.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Chores**
  * ML 파이프라인의 다양한 스테이지에서 LLM 요청 설정을 업데이트했습니다.

* **Tests**
  * 업데이트된 요청 설정이 올바르게 적용되는지 검증하는 테스트 케이스를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->