### PR TITLE
feat(admin): #877 어드민 콘솔에 로그아웃 버튼 추가

### DIFF
--- a/.agent/specs/877.md
+++ b/.agent/specs/877.md
@@ -1,0 +1,37 @@
+# 877 - 어드민 콘솔(슈퍼어드민)에 로그아웃 버튼 추가
+
+## 배경
+
+슈퍼어드민으로 로그인하면 `/admin/*` 경로의 어드민 콘솔(`AdminLayout`)이 렌더링된다.
+그러나 이 레이아웃에는 로그아웃 진입점이 없어 슈퍼어드민 계정은 UI에서 로그아웃할 방법이 없다.
+일반 대시보드(`DashboardLayout`)에는 `AccountMenu`를 통한 로그아웃이 존재하지만, 어드민 콘솔에만 누락되어 있다.
+
+## 문제
+
+- `frontend/src/pages/admin/ui/AdminLayout.tsx` 사이드바/상단바에 로그아웃 진입점 없음
+- 다른 계정으로 전환하려면 DevTools로 토큰/쿠키를 수동 정리해야 함
+- 리프레시 토큰이 httpOnly 쿠키라 클라이언트 상태만 비우면 자동 재로그인됨 → 서버 로그아웃 호출 필요
+
+## 변경 범위
+
+- `AdminLayout` 사이드바 하단에 로그아웃 버튼 추가
+- 기존 `useLogout` 훅(`frontend/src/features/auth/model/useLogout.ts`)을 재사용하여
+  `POST /api/v1/auth/logout` 호출로 리프레시 토큰까지 무효화하고 `/login`으로 이동
+- `admin-layout.module.css`에 사이드바 푸터/로그아웃 버튼 스타일 추가
+
+## 비범위
+
+- 백엔드 로그아웃 로직 변경 없음 (기존 엔드포인트 재사용)
+- 일반 대시보드(`DashboardLayout`/`AccountMenu`) 변경 없음
+
+## 기대 동작
+
+1. 어드민 콘솔 사이드바 하단의 "로그아웃" 버튼 클릭
+2. `useLogout`이 `POST /api/v1/auth/logout` 호출 → 리프레시 토큰/쿠키 무효화
+3. 클라이언트 세션(localStorage) 정리 후 `/login`으로 이동
+
+## 검증
+
+- 어드민 콘솔에서 로그아웃 버튼이 사이드바 하단에 노출된다
+- 클릭 시 `/login`으로 이동하고, 재접속 시 자동 로그인되지 않는다
+- 프런트엔드 단위 테스트(`AdminLayout` 렌더 및 로그아웃 호출) 통과

--- a/frontend/src/pages/admin/ui/AdminLayout.test.tsx
+++ b/frontend/src/pages/admin/ui/AdminLayout.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { AdminLayout } from "./AdminLayout";
+
+const mocks = vi.hoisted(() => ({
+  logout: vi.fn(),
+}));
+
+vi.mock("@/features/auth/model/useLogout", () => ({
+  useLogout: () => ({ logout: mocks.logout }),
+}));
+
+function renderLayout() {
+  return render(
+    <MemoryRouter initialEntries={["/admin/super-admins"]}>
+      <AdminLayout />
+    </MemoryRouter>,
+  );
+}
+
+describe("AdminLayout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("사이드바에 로그아웃 버튼을 노출한다", () => {
+    renderLayout();
+    expect(screen.getByTestId("admin-logout")).toBeInTheDocument();
+  });
+
+  it("로그아웃 버튼을 누르면 useLogout 의 logout 을 호출한다", async () => {
+    renderLayout();
+    await userEvent.click(screen.getByTestId("admin-logout"));
+    expect(mocks.logout).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/pages/admin/ui/AdminLayout.tsx
+++ b/frontend/src/pages/admin/ui/AdminLayout.tsx
@@ -1,5 +1,6 @@
-import { Building2, CreditCard, Plane, ShieldPlus } from "lucide-react";
+import { Building2, CreditCard, LogOut, Plane, ShieldPlus } from "lucide-react";
 import { NavLink, Outlet } from "react-router-dom";
+import { useLogout } from "@/features/auth/model/useLogout";
 import styles from "./admin-layout.module.css";
 
 const NAV_ITEMS = [
@@ -10,6 +11,8 @@ const NAV_ITEMS = [
 ];
 
 export function AdminLayout() {
+  const { logout } = useLogout();
+
   return (
     <div className={styles.layout}>
       <aside className={styles.sidebar} aria-label="admin navigation">
@@ -34,6 +37,17 @@ export function AdminLayout() {
             );
           })}
         </nav>
+        <div className={styles.footer}>
+          <button
+            type="button"
+            className={styles.logoutButton}
+            onClick={logout}
+            data-testid="admin-logout"
+          >
+            <LogOut size={16} />
+            <span>로그아웃</span>
+          </button>
+        </div>
       </aside>
       <div className={styles.content}>
         <header className={styles.topbar}>

--- a/frontend/src/pages/admin/ui/admin-layout.module.css
+++ b/frontend/src/pages/admin/ui/admin-layout.module.css
@@ -70,6 +70,36 @@
   font-weight: 540;
 }
 
+.footer {
+  margin-top: auto;
+  padding: 0 18px;
+}
+
+.logoutButton {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 10px;
+  min-height: 40px;
+  padding: 0 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-2);
+  background: transparent;
+  color: var(--ink-3);
+  font-family: var(--font-sans);
+  font-size: 13.5px;
+  font-weight: 450;
+  cursor: pointer;
+  transition:
+    background 160ms ease,
+    color 160ms ease;
+}
+
+.logoutButton:hover {
+  background: var(--paper-3);
+  color: var(--ink);
+}
+
 .content {
   display: flex;
   flex: 1;


### PR DESCRIPTION
## 개요

Closes #877

슈퍼어드민으로 로그인하면 렌더링되는 어드민 콘솔(`AdminLayout`)에는 로그아웃 진입점이 없어, UI에서 로그아웃할 방법이 없었다. 일반 대시보드(`DashboardLayout`)에는 `AccountMenu`를 통한 로그아웃이 존재하지만 어드민 콘솔에만 누락되어 있었다.

## 변경 사항

- `AdminLayout` 사이드바 하단에 "로그아웃" 버튼 추가 (`margin-top: auto`로 하단 고정)
- 기존 `useLogout` 훅을 재사용 → `POST /api/v1/auth/logout` 호출로 리프레시 토큰(httpOnly 쿠키)까지 무효화하고 `/login`으로 이동
- `admin-layout.module.css`에 사이드바 푸터/로그아웃 버튼 스타일 추가
- `AdminLayout` 단위 테스트 추가 (버튼 노출 + 클릭 시 `logout` 호출)

## 비범위

- 백엔드 로그아웃 로직 변경 없음 (기존 엔드포인트 재사용)
- 일반 대시보드(`DashboardLayout`/`AccountMenu`) 변경 없음

## 검증

- [x] 어드민 콘솔 사이드바 하단에 로그아웃 버튼 노출
- [x] 클릭 시 `useLogout.logout` 호출 → `/login` 이동, 재접속 시 자동 로그인 안 됨
- [x] 프런트엔드 단위 테스트 통과 (`AdminLayout.test.tsx` 2 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 어드민 콘솔의 사이드바 하단에 로그아웃 버튼을 추가했습니다. 슈퍼어드민이 로그인한 상태에서 사이드바 하단의 로그아웃 버튼을 클릭하여 UI를 통해 직접 로그아웃할 수 있도록 개선되었습니다. 로그아웃 실행 시 기존 인증 메커니즘을 통해 리프레시 토큰까지 안전하게 무효화되고 로그인 페이지로 자동으로 이동합니다.

* **테스트**
  * 로그아웃 버튼의 정상적인 렌더링 및 클릭 시의 동작을 검증하는 자동화 테스트 케이스를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->