### PR TITLE
feat(workflow-runtime): #879 시뮬레이션 구조적 Domain Pack 패치 계약 정의

### DIFF
--- a/.agent/specs/879.md
+++ b/.agent/specs/879.md
@@ -1,0 +1,119 @@
+# Backend Spec — #879 Structural Domain Pack Patch Contract
+
+## Goal
+
+시뮬레이션 실패·골든 리플레이 근거가 LLM이 생성하고 백엔드가 검증할 수 있는 구조적 Domain Pack 패치 문서(`simulation-structural-patch.v1`)로 표현되도록, 파싱·검증 전용 value object와 parser를 정의한다. 이 이슈는 계약(contract)과 안전 검증만 만들고, 실제 DB 반영은 다루지 않는다.
+
+## Scope
+
+- `simulation-structural-patch.v1` 구조적 패치 JSON을 표현하는 도메인 value object 추가.
+- JSON 문자열을 도메인 VO로 변환하는 application-layer parser 추가.
+- 스키마 버전·operation 비어있음·target·evidence·미지원 operation에 대한 fail-closed 검증.
+- MVP operation 13종 전부에 대한 valid/invalid 단위 테스트.
+
+## Non-goals (이슈 명시)
+
+- LLM 생성 로직 구현하지 않는다.
+- workflow 그래프 mutation을 실제로 적용하지 않는다.
+- 프론트엔드 diff UI를 만들지 않는다.
+- 기존 `simulation-candidate-draft-patch.v1` (UPDATE_DESCRIPTION) 동작은 변경하지 않는다.
+
+## Affected Modules
+
+- `backend` / `workflow-runtime` bounded context
+  - `domain`: 구조적 패치 VO, operation 타입/카테고리 enum, 검증 예외.
+  - `application`: JSON → 도메인 VO parser.
+
+검증한 기존 경로:
+- `backend/src/main/java/com/init/workflowruntime/domain/SimulationImprovementCandidate.java` (`draftPatchJson` 보관)
+- `backend/src/main/java/com/init/workflowruntime/application/SimulationImprovementCandidateService.java:171` (기존 `simulation-candidate-draft-patch.v1` 생성)
+- `backend/src/main/java/com/init/workflowruntime/application/SimulationImprovementDraftPatchService.java` (기존 description patch 적용)
+- `backend/src/main/java/com/init/shared/application/exception/BadRequestException.java`
+
+## Patch Schema (`simulation-structural-patch.v1`)
+
+```json
+{
+  "schemaVersion": "simulation-structural-patch.v1",
+  "summary": "예약 전에 픽업 일자를 묻도록 workflow를 보강합니다.",
+  "evidence": {
+    "feedbackId": 123,
+    "simulationSessionId": 456,
+    "goldenCaseId": 789,
+    "replayResultId": 790,
+    "failureSummary": "actionType expected ASK_SLOT but was NEED_INTENT"
+  },
+  "operations": [
+    { "op": "MARK_SLOT_REQUIRED", "slotCode": "pickupDate", "reason": "예약 전 필수" }
+  ]
+}
+```
+
+### MVP Operations
+
+| op | target 식별자 | payload 필드 |
+|----|---------------|--------------|
+| UPDATE_INTENT_DESCRIPTION | `intentCode` 또는 `targetId` | `description` |
+| ADD_INTENT_EXAMPLE | `intentCode` 또는 `targetId` | `example` |
+| UPDATE_SLOT_DESCRIPTION | `slotCode` 또는 `targetId` | `description` |
+| MARK_SLOT_REQUIRED | `slotCode` 또는 `targetId` | (없음) |
+| UPDATE_SLOT_VALIDATION | `slotCode` 또는 `targetId` | `validation` |
+| UPDATE_POLICY_CONDITION | `policyCode` 또는 `targetId` | `condition` |
+| UPDATE_RISK_TRIGGER | `riskCode` 또는 `targetId` | `trigger` |
+| UPDATE_RESPONSE_COPY | `responseCode` 또는 `targetId` | `copy` |
+| ADD_WORKFLOW_NODE | `workflowCode` 또는 `workflowDefinitionId` | `nodeId`, `nodeType`, (`slotCode`, `prompt` 선택) |
+| UPDATE_WORKFLOW_NODE | `workflowCode` 또는 `workflowDefinitionId` | `nodeId`, `nodeType`, (`slotCode`, `prompt` 선택) |
+| ADD_TRANSITION | `workflowCode` 또는 `workflowDefinitionId` | `from`, `to`, (`condition` 선택) |
+| UPDATE_TRANSITION | `workflowCode` 또는 `workflowDefinitionId` | `from`, `to`, (`condition` 선택) |
+| REMOVE_TRANSITION | `workflowCode` 또는 `workflowDefinitionId` | `from`, `to` |
+
+모든 operation은 `reason`이 필수다.
+
+## Class Design
+
+- `StructuralPatchTargetCategory` (enum): INTENT, SLOT, POLICY, RISK, RESPONSE, WORKFLOW.
+- `StructuralPatchOperationType` (enum): MVP 13종. 각 상수는 record kind(ELEMENT/WORKFLOW_NODE/WORKFLOW_TRANSITION), target category, code 필드명, value 필드명을 보유.
+- `StructuralPatchOperation` (sealed interface): `type()`, `reason()`. permits:
+  - `ElementAttribute(type, category, targetCode, targetId, value, reason)`
+  - `WorkflowNode(type, workflowCode, workflowDefinitionId, nodeId, nodeType, slotCode, prompt, reason)`
+  - `WorkflowTransition(type, workflowCode, workflowDefinitionId, from, to, condition, reason)`
+  - 각 record의 compact constructor가 자신의 불변식을 검증한다.
+- `StructuralDomainPackPatch` (record): `schemaVersion`, `summary`, `StructuralPatchEvidence evidence`, `List<StructuralPatchOperation> operations`. `SCHEMA_VERSION` 상수 보유, operations는 불변 복사.
+- `StructuralPatchEvidence` (record): `feedbackId`, `simulationSessionId`, `goldenCaseId`, `replayResultId`, `failureSummary`(필수).
+- `InvalidStructuralPatchException extends BadRequestException` (code `INVALID_STRUCTURAL_PATCH`).
+- `StructuralDomainPackPatchParser` (application `@Component`): `ObjectMapper`로 JSON 문자열을 읽어 위 VO로 변환. 파싱 단계에서 어떤 DB 접근도 하지 않는다.
+
+## Validation Rules (fail closed)
+
+- `schemaVersion`이 `simulation-structural-patch.v1`이 아니면 거절.
+- JSON이 object가 아니거나 malformed면 거절.
+- `operations`가 배열이 아니거나 비어 있으면 거절.
+- 알 수 없는 `op` 문자열은 거절(미지원 operation fail closed).
+- ELEMENT operation은 category별 code 또는 `targetId` 중 하나 이상이 있어야 한다.
+- WORKFLOW operation은 `workflowCode` 또는 `workflowDefinitionId` 중 하나 이상이 있어야 한다.
+- value가 필요한 operation은 payload 값이 비어 있으면 거절.
+- workflow node operation은 `nodeId`/`nodeType`이 필수, transition operation은 `from`/`to`가 필수.
+- 모든 operation은 `reason` 필수.
+- `evidence`가 없거나 `failureSummary`가 비어 있으면 거절.
+
+## Tests
+
+`StructuralDomainPackPatchParserTest` (application):
+- 정상: MVP 13종 operation 각각 유효 문서 파싱 성공 및 필드 검증.
+- 미인식 schemaVersion 거절.
+- operations 누락/빈 배열 거절.
+- 알 수 없는 op 거절.
+- target 누락(code/id 모두 없음) 거절 — element/workflow.
+- value 필요한 op의 value 누락 거절.
+- workflow node/transition 필수 필드 누락 거절.
+- reason 누락 거절.
+- evidence 누락 / failureSummary 누락 거절.
+- malformed JSON 거절.
+
+## Acceptance Criteria
+
+- 구조적 패치 JSON에 대한 백엔드 value object/parser가 존재한다.
+- 잘못된 스키마, 알 수 없는 operation, target 누락, malformed evidence가 명확한 비즈니스 에러로 거절된다.
+- 기존 description patch 동작은 그대로 유지된다.
+- MVP operation 전부에 대해 valid/invalid 단위 테스트가 존재한다.
+- 파싱/검증만으로는 어떤 DB mutation도 발생하지 않는다.

--- a/backend/src/main/java/com/init/workflowruntime/application/StructuralDomainPackPatchParser.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/StructuralDomainPackPatchParser.java
@@ -1,0 +1,153 @@
+package com.init.workflowruntime.application;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.workflowruntime.domain.InvalidStructuralPatchException;
+import com.init.workflowruntime.domain.StructuralDomainPackPatch;
+import com.init.workflowruntime.domain.StructuralPatchEvidence;
+import com.init.workflowruntime.domain.StructuralPatchOperation;
+import com.init.workflowruntime.domain.StructuralPatchOperationType;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+/**
+ * {@code simulation-structural-patch.v1} JSON 문자열을 도메인 value object로 변환한다. JSON 구조/타입 오류와 미지원
+ * operation을 fail-closed로 거절하며, 도메인 불변식은 VO compact constructor에 위임한다. 파싱은 어떤 DB 접근도 하지 않는다.
+ */
+@Component
+public class StructuralDomainPackPatchParser {
+
+  private final ObjectMapper objectMapper;
+
+  public StructuralDomainPackPatchParser(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  public StructuralDomainPackPatch parse(String json) {
+    if (json == null || json.isBlank()) {
+      throw new InvalidStructuralPatchException("patch 문서가 비어 있습니다.");
+    }
+    JsonNode root = readTree(json);
+    if (!root.isObject()) {
+      throw new InvalidStructuralPatchException("patch 문서는 JSON object여야 합니다.");
+    }
+
+    String schemaVersion = readText(root, "schemaVersion");
+    String summary = readText(root, "summary");
+    StructuralPatchEvidence evidence = parseEvidence(root.get("evidence"));
+    List<StructuralPatchOperation> operations = parseOperations(root.get("operations"));
+
+    return new StructuralDomainPackPatch(schemaVersion, summary, evidence, operations);
+  }
+
+  private JsonNode readTree(String json) {
+    try {
+      return objectMapper.readTree(json);
+    } catch (JsonProcessingException e) {
+      throw new InvalidStructuralPatchException("patch 문서를 JSON으로 파싱할 수 없습니다.");
+    }
+  }
+
+  private StructuralPatchEvidence parseEvidence(JsonNode node) {
+    if (node == null || node.isNull()) {
+      throw new InvalidStructuralPatchException("evidence는 필수입니다.");
+    }
+    if (!node.isObject()) {
+      throw new InvalidStructuralPatchException("evidence는 JSON object여야 합니다.");
+    }
+    return new StructuralPatchEvidence(
+        readLong(node, "feedbackId"),
+        readLong(node, "simulationSessionId"),
+        readLong(node, "goldenCaseId"),
+        readLong(node, "replayResultId"),
+        readText(node, "failureSummary"));
+  }
+
+  private List<StructuralPatchOperation> parseOperations(JsonNode node) {
+    if (node == null || !node.isArray()) {
+      throw new InvalidStructuralPatchException("operations는 JSON 배열이어야 합니다.");
+    }
+    List<StructuralPatchOperation> operations = new ArrayList<>();
+    for (JsonNode operationNode : node) {
+      operations.add(parseOperation(operationNode));
+    }
+    return operations;
+  }
+
+  private StructuralPatchOperation parseOperation(JsonNode node) {
+    if (node == null || !node.isObject()) {
+      throw new InvalidStructuralPatchException("operation은 JSON object여야 합니다.");
+    }
+    String rawOp = readText(node, "op");
+    StructuralPatchOperationType type =
+        StructuralPatchOperationType.from(rawOp)
+            .orElseThrow(
+                () -> new InvalidStructuralPatchException("지원하지 않는 operation입니다: " + rawOp));
+    String reason = readText(node, "reason");
+
+    return switch (type.getKind()) {
+      case ELEMENT -> parseElementOperation(node, type, reason);
+      case WORKFLOW_NODE -> parseWorkflowNodeOperation(node, type, reason);
+      case WORKFLOW_TRANSITION -> parseWorkflowTransitionOperation(node, type, reason);
+    };
+  }
+
+  private StructuralPatchOperation parseElementOperation(
+      JsonNode node, StructuralPatchOperationType type, String reason) {
+    String targetCode = readText(node, type.getCodeFieldName());
+    Long targetId = readLong(node, "targetId");
+    String value =
+        type.getValueFieldName() == null ? null : readText(node, type.getValueFieldName());
+    return new StructuralPatchOperation.ElementAttribute(
+        type, type.getCategory(), targetCode, targetId, value, reason);
+  }
+
+  private StructuralPatchOperation parseWorkflowNodeOperation(
+      JsonNode node, StructuralPatchOperationType type, String reason) {
+    return new StructuralPatchOperation.WorkflowNode(
+        type,
+        readText(node, "workflowCode"),
+        readLong(node, "workflowDefinitionId"),
+        readText(node, "nodeId"),
+        readText(node, "nodeType"),
+        readText(node, "slotCode"),
+        readText(node, "prompt"),
+        reason);
+  }
+
+  private StructuralPatchOperation parseWorkflowTransitionOperation(
+      JsonNode node, StructuralPatchOperationType type, String reason) {
+    return new StructuralPatchOperation.WorkflowTransition(
+        type,
+        readText(node, "workflowCode"),
+        readLong(node, "workflowDefinitionId"),
+        readText(node, "from"),
+        readText(node, "to"),
+        readText(node, "condition"),
+        reason);
+  }
+
+  private String readText(JsonNode node, String field) {
+    if (field == null) {
+      return null;
+    }
+    JsonNode value = node.get(field);
+    if (value == null || value.isNull() || !value.isTextual()) {
+      return null;
+    }
+    return value.asText();
+  }
+
+  private Long readLong(JsonNode node, String field) {
+    JsonNode value = node.get(field);
+    if (value == null || value.isNull()) {
+      return null;
+    }
+    if (!value.isIntegralNumber()) {
+      throw new InvalidStructuralPatchException(field + "는 정수여야 합니다.");
+    }
+    return value.asLong();
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/domain/InvalidStructuralPatchException.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/InvalidStructuralPatchException.java
@@ -1,0 +1,10 @@
+package com.init.workflowruntime.domain;
+
+import com.init.shared.application.exception.BadRequestException;
+
+public class InvalidStructuralPatchException extends BadRequestException {
+
+  public InvalidStructuralPatchException(String message) {
+    super("INVALID_STRUCTURAL_PATCH", message);
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/domain/StructuralDomainPackPatch.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/StructuralDomainPackPatch.java
@@ -1,0 +1,30 @@
+package com.init.workflowruntime.domain;
+
+import java.util.List;
+
+/**
+ * 시뮬레이션 근거로부터 도출된 구조적 Domain Pack 패치 문서({@code simulation-structural-patch.v1}). 검증을 통과한 인스턴스는 스키마
+ * 버전, evidence, 비어있지 않은 operation 목록을 보장한다. 이 타입은 계약(contract)만 표현하며 어떤 DB 변경도 수행하지 않는다.
+ */
+public record StructuralDomainPackPatch(
+    String schemaVersion,
+    String summary,
+    StructuralPatchEvidence evidence,
+    List<StructuralPatchOperation> operations) {
+
+  public static final String SCHEMA_VERSION = "simulation-structural-patch.v1";
+
+  public StructuralDomainPackPatch {
+    if (!SCHEMA_VERSION.equals(schemaVersion)) {
+      throw new InvalidStructuralPatchException("지원하지 않는 schemaVersion입니다: " + schemaVersion);
+    }
+    if (evidence == null) {
+      throw new InvalidStructuralPatchException("evidence는 필수입니다.");
+    }
+    if (operations == null || operations.isEmpty()) {
+      throw new InvalidStructuralPatchException("operations는 최소 1개 이상이어야 합니다.");
+    }
+    summary = summary == null || summary.isBlank() ? null : summary.strip();
+    operations = List.copyOf(operations);
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/domain/StructuralPatchEvidence.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/StructuralPatchEvidence.java
@@ -1,0 +1,17 @@
+package com.init.workflowruntime.domain;
+
+/** 구조적 패치를 뒷받침하는 시뮬레이션 근거. id 참조는 선택이지만, 리뷰 UI에서 사람이 읽을 수 있도록 {@code failureSummary}는 필수다. */
+public record StructuralPatchEvidence(
+    Long feedbackId,
+    Long simulationSessionId,
+    Long goldenCaseId,
+    Long replayResultId,
+    String failureSummary) {
+
+  public StructuralPatchEvidence {
+    if (failureSummary == null || failureSummary.isBlank()) {
+      throw new InvalidStructuralPatchException("evidence.failureSummary는 필수입니다.");
+    }
+    failureSummary = failureSummary.strip();
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/domain/StructuralPatchOperation.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/StructuralPatchOperation.java
@@ -1,0 +1,130 @@
+package com.init.workflowruntime.domain;
+
+/**
+ * {@code simulation-structural-patch.v1} 의 단일 operation. 각 변형은 자신의 불변식(필수 target/필드)을 compact
+ * constructor에서 검증하므로, 검증을 통과한 인스턴스는 항상 적용 가능한 형태를 보장한다.
+ */
+public sealed interface StructuralPatchOperation
+    permits StructuralPatchOperation.ElementAttribute,
+        StructuralPatchOperation.WorkflowNode,
+        StructuralPatchOperation.WorkflowTransition {
+
+  StructuralPatchOperationType type();
+
+  String reason();
+
+  /** intent/slot/policy/risk/response 요소의 단일 속성을 바꾸는 operation. */
+  record ElementAttribute(
+      StructuralPatchOperationType type,
+      StructuralPatchTargetCategory category,
+      String targetCode,
+      Long targetId,
+      String value,
+      String reason)
+      implements StructuralPatchOperation {
+
+    public ElementAttribute {
+      requireType(type);
+      requireReason(reason);
+      if (isBlank(targetCode) && targetId == null) {
+        throw new InvalidStructuralPatchException(
+            type + " operation은 " + type.getCodeFieldName() + " 또는 targetId가 필요합니다.");
+      }
+      if (type.requiresValue() && isBlank(value)) {
+        throw new InvalidStructuralPatchException(
+            type + " operation은 " + type.getValueFieldName() + " 값이 필요합니다.");
+      }
+      targetCode = normalize(targetCode);
+      value = normalize(value);
+      reason = reason.strip();
+    }
+  }
+
+  /** workflow 그래프에 노드를 추가하거나 수정하는 operation. */
+  record WorkflowNode(
+      StructuralPatchOperationType type,
+      String workflowCode,
+      Long workflowDefinitionId,
+      String nodeId,
+      String nodeType,
+      String slotCode,
+      String prompt,
+      String reason)
+      implements StructuralPatchOperation {
+
+    public WorkflowNode {
+      requireType(type);
+      requireReason(reason);
+      requireWorkflowTarget(type, workflowCode, workflowDefinitionId);
+      if (isBlank(nodeId)) {
+        throw new InvalidStructuralPatchException(type + " operation은 nodeId가 필요합니다.");
+      }
+      if (isBlank(nodeType)) {
+        throw new InvalidStructuralPatchException(type + " operation은 nodeType이 필요합니다.");
+      }
+      workflowCode = normalize(workflowCode);
+      nodeId = nodeId.strip();
+      nodeType = nodeType.strip();
+      slotCode = normalize(slotCode);
+      prompt = normalize(prompt);
+      reason = reason.strip();
+    }
+  }
+
+  /** workflow 그래프의 전이(transition)를 추가/수정/삭제하는 operation. */
+  record WorkflowTransition(
+      StructuralPatchOperationType type,
+      String workflowCode,
+      Long workflowDefinitionId,
+      String from,
+      String to,
+      String condition,
+      String reason)
+      implements StructuralPatchOperation {
+
+    public WorkflowTransition {
+      requireType(type);
+      requireReason(reason);
+      requireWorkflowTarget(type, workflowCode, workflowDefinitionId);
+      if (isBlank(from)) {
+        throw new InvalidStructuralPatchException(type + " operation은 from이 필요합니다.");
+      }
+      if (isBlank(to)) {
+        throw new InvalidStructuralPatchException(type + " operation은 to가 필요합니다.");
+      }
+      workflowCode = normalize(workflowCode);
+      from = from.strip();
+      to = to.strip();
+      condition = normalize(condition);
+      reason = reason.strip();
+    }
+  }
+
+  private static void requireType(StructuralPatchOperationType type) {
+    if (type == null) {
+      throw new InvalidStructuralPatchException("operation type은 필수입니다.");
+    }
+  }
+
+  private static void requireReason(String reason) {
+    if (isBlank(reason)) {
+      throw new InvalidStructuralPatchException("operation reason은 필수입니다.");
+    }
+  }
+
+  private static void requireWorkflowTarget(
+      StructuralPatchOperationType type, String workflowCode, Long workflowDefinitionId) {
+    if (isBlank(workflowCode) && workflowDefinitionId == null) {
+      throw new InvalidStructuralPatchException(
+          type + " operation은 workflowCode 또는 workflowDefinitionId가 필요합니다.");
+    }
+  }
+
+  private static boolean isBlank(String value) {
+    return value == null || value.isBlank();
+  }
+
+  private static String normalize(String value) {
+    return value == null || value.isBlank() ? null : value.strip();
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/domain/StructuralPatchOperationType.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/StructuralPatchOperationType.java
@@ -1,0 +1,85 @@
+package com.init.workflowruntime.domain;
+
+import java.util.Optional;
+
+/**
+ * {@code simulation-structural-patch.v1} 에서 지원하는 MVP operation 집합. 각 상수는 어떤 record 형태로 파싱되는지(kind),
+ * 어떤 Domain Pack 요소를 가리키는지(category), 그리고 ELEMENT operation의 JSON code/value 필드명을 보유한다.
+ */
+public enum StructuralPatchOperationType {
+  UPDATE_INTENT_DESCRIPTION(
+      Kind.ELEMENT, StructuralPatchTargetCategory.INTENT, "intentCode", "description"),
+  ADD_INTENT_EXAMPLE(Kind.ELEMENT, StructuralPatchTargetCategory.INTENT, "intentCode", "example"),
+  UPDATE_SLOT_DESCRIPTION(
+      Kind.ELEMENT, StructuralPatchTargetCategory.SLOT, "slotCode", "description"),
+  MARK_SLOT_REQUIRED(Kind.ELEMENT, StructuralPatchTargetCategory.SLOT, "slotCode", null),
+  UPDATE_SLOT_VALIDATION(
+      Kind.ELEMENT, StructuralPatchTargetCategory.SLOT, "slotCode", "validation"),
+  UPDATE_POLICY_CONDITION(
+      Kind.ELEMENT, StructuralPatchTargetCategory.POLICY, "policyCode", "condition"),
+  UPDATE_RISK_TRIGGER(Kind.ELEMENT, StructuralPatchTargetCategory.RISK, "riskCode", "trigger"),
+  UPDATE_RESPONSE_COPY(
+      Kind.ELEMENT, StructuralPatchTargetCategory.RESPONSE, "responseCode", "copy"),
+  ADD_WORKFLOW_NODE(Kind.WORKFLOW_NODE, StructuralPatchTargetCategory.WORKFLOW, null, null),
+  UPDATE_WORKFLOW_NODE(Kind.WORKFLOW_NODE, StructuralPatchTargetCategory.WORKFLOW, null, null),
+  ADD_TRANSITION(Kind.WORKFLOW_TRANSITION, StructuralPatchTargetCategory.WORKFLOW, null, null),
+  UPDATE_TRANSITION(Kind.WORKFLOW_TRANSITION, StructuralPatchTargetCategory.WORKFLOW, null, null),
+  REMOVE_TRANSITION(Kind.WORKFLOW_TRANSITION, StructuralPatchTargetCategory.WORKFLOW, null, null);
+
+  public enum Kind {
+    ELEMENT,
+    WORKFLOW_NODE,
+    WORKFLOW_TRANSITION
+  }
+
+  private final Kind kind;
+  private final StructuralPatchTargetCategory category;
+  private final String codeFieldName;
+  private final String valueFieldName;
+
+  StructuralPatchOperationType(
+      Kind kind,
+      StructuralPatchTargetCategory category,
+      String codeFieldName,
+      String valueFieldName) {
+    this.kind = kind;
+    this.category = category;
+    this.codeFieldName = codeFieldName;
+    this.valueFieldName = valueFieldName;
+  }
+
+  public Kind getKind() {
+    return kind;
+  }
+
+  public StructuralPatchTargetCategory getCategory() {
+    return category;
+  }
+
+  /** ELEMENT operation에서 target code를 담는 JSON 필드명. workflow operation이면 null. */
+  public String getCodeFieldName() {
+    return codeFieldName;
+  }
+
+  /** ELEMENT operation에서 변경 값을 담는 JSON 필드명. 값이 없는 operation이면 null. */
+  public String getValueFieldName() {
+    return valueFieldName;
+  }
+
+  public boolean requiresValue() {
+    return kind == Kind.ELEMENT && valueFieldName != null;
+  }
+
+  /** 미지원 operation은 비워서 반환해 fail-closed 검증을 유도한다. */
+  public static Optional<StructuralPatchOperationType> from(String raw) {
+    if (raw == null) {
+      return Optional.empty();
+    }
+    for (StructuralPatchOperationType type : values()) {
+      if (type.name().equals(raw)) {
+        return Optional.of(type);
+      }
+    }
+    return Optional.empty();
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/domain/StructuralPatchTargetCategory.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/StructuralPatchTargetCategory.java
@@ -1,0 +1,10 @@
+package com.init.workflowruntime.domain;
+
+public enum StructuralPatchTargetCategory {
+  INTENT,
+  SLOT,
+  POLICY,
+  RISK,
+  RESPONSE,
+  WORKFLOW
+}

--- a/backend/src/test/java/com/init/workflowruntime/application/StructuralDomainPackPatchParserTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/StructuralDomainPackPatchParserTest.java
@@ -1,0 +1,471 @@
+package com.init.workflowruntime.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.workflowruntime.domain.InvalidStructuralPatchException;
+import com.init.workflowruntime.domain.StructuralDomainPackPatch;
+import com.init.workflowruntime.domain.StructuralPatchOperation;
+import com.init.workflowruntime.domain.StructuralPatchOperationType;
+import com.init.workflowruntime.domain.StructuralPatchTargetCategory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("StructuralDomainPackPatchParser")
+class StructuralDomainPackPatchParserTest {
+
+  private final StructuralDomainPackPatchParser parser =
+      new StructuralDomainPackPatchParser(new ObjectMapper());
+
+  // ---- 정상: 봉투(envelope) ----
+
+  @Test
+  @DisplayName("parse: 스키마/요약/evidence/operations를 검증된 VO로 변환한다")
+  void shouldParseEnvelope() {
+    String json =
+        envelope(
+            "{\"op\":\"MARK_SLOT_REQUIRED\",\"slotCode\":\"pickupDate\",\"reason\":\"예약 전 필수\"}");
+
+    StructuralDomainPackPatch patch = parser.parse(json);
+
+    assertThat(patch.schemaVersion()).isEqualTo(StructuralDomainPackPatch.SCHEMA_VERSION);
+    assertThat(patch.summary()).isEqualTo("workflow 보강");
+    assertThat(patch.evidence().feedbackId()).isEqualTo(123L);
+    assertThat(patch.evidence().simulationSessionId()).isEqualTo(456L);
+    assertThat(patch.evidence().goldenCaseId()).isEqualTo(789L);
+    assertThat(patch.evidence().replayResultId()).isEqualTo(790L);
+    assertThat(patch.evidence().failureSummary())
+        .isEqualTo("expected ASK_SLOT but was NEED_INTENT");
+    assertThat(patch.operations()).hasSize(1);
+  }
+
+  @Test
+  @DisplayName("parse: operations는 불변 목록으로 노출된다")
+  void shouldExposeImmutableOperations() {
+    StructuralDomainPackPatch patch =
+        parser.parse(
+            envelope(
+                "{\"op\":\"MARK_SLOT_REQUIRED\",\"slotCode\":\"pickupDate\",\"reason\":\"필수\"}"));
+
+    assertThatThrownBy(() -> patch.operations().clear())
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  // ---- 정상: ELEMENT operation 전체 ----
+
+  @Test
+  @DisplayName("parse: UPDATE_INTENT_DESCRIPTION을 intentCode/description으로 파싱한다")
+  void shouldParseUpdateIntentDescription() {
+    StructuralPatchOperation.ElementAttribute op =
+        parseSingleElement(
+            "{\"op\":\"UPDATE_INTENT_DESCRIPTION\",\"intentCode\":\"book_pickup\","
+                + "\"description\":\"픽업 예약 의도\",\"reason\":\"의미 명확화\"}");
+
+    assertThat(op.type()).isEqualTo(StructuralPatchOperationType.UPDATE_INTENT_DESCRIPTION);
+    assertThat(op.category()).isEqualTo(StructuralPatchTargetCategory.INTENT);
+    assertThat(op.targetCode()).isEqualTo("book_pickup");
+    assertThat(op.value()).isEqualTo("픽업 예약 의도");
+    assertThat(op.reason()).isEqualTo("의미 명확화");
+  }
+
+  @Test
+  @DisplayName("parse: ADD_INTENT_EXAMPLE을 example 값으로 파싱한다")
+  void shouldParseAddIntentExample() {
+    StructuralPatchOperation.ElementAttribute op =
+        parseSingleElement(
+            "{\"op\":\"ADD_INTENT_EXAMPLE\",\"intentCode\":\"book_pickup\","
+                + "\"example\":\"공항 픽업 예약하고 싶어요\",\"reason\":\"표현 보강\"}");
+
+    assertThat(op.type()).isEqualTo(StructuralPatchOperationType.ADD_INTENT_EXAMPLE);
+    assertThat(op.value()).isEqualTo("공항 픽업 예약하고 싶어요");
+  }
+
+  @Test
+  @DisplayName("parse: UPDATE_SLOT_DESCRIPTION을 slotCode/description으로 파싱한다")
+  void shouldParseUpdateSlotDescription() {
+    StructuralPatchOperation.ElementAttribute op =
+        parseSingleElement(
+            "{\"op\":\"UPDATE_SLOT_DESCRIPTION\",\"slotCode\":\"pickupDate\","
+                + "\"description\":\"픽업 날짜\",\"reason\":\"설명 보강\"}");
+
+    assertThat(op.category()).isEqualTo(StructuralPatchTargetCategory.SLOT);
+    assertThat(op.targetCode()).isEqualTo("pickupDate");
+    assertThat(op.value()).isEqualTo("픽업 날짜");
+  }
+
+  @Test
+  @DisplayName("parse: MARK_SLOT_REQUIRED는 값 없이 slotCode만으로 파싱한다")
+  void shouldParseMarkSlotRequired() {
+    StructuralPatchOperation.ElementAttribute op =
+        parseSingleElement(
+            "{\"op\":\"MARK_SLOT_REQUIRED\",\"slotCode\":\"pickupDate\",\"reason\":\"필수\"}");
+
+    assertThat(op.type()).isEqualTo(StructuralPatchOperationType.MARK_SLOT_REQUIRED);
+    assertThat(op.value()).isNull();
+  }
+
+  @Test
+  @DisplayName("parse: UPDATE_SLOT_VALIDATION을 validation 값으로 파싱한다")
+  void shouldParseUpdateSlotValidation() {
+    StructuralPatchOperation.ElementAttribute op =
+        parseSingleElement(
+            "{\"op\":\"UPDATE_SLOT_VALIDATION\",\"slotCode\":\"pickupDate\","
+                + "\"validation\":\"future_date\",\"reason\":\"미래 날짜만 허용\"}");
+
+    assertThat(op.value()).isEqualTo("future_date");
+  }
+
+  @Test
+  @DisplayName("parse: UPDATE_POLICY_CONDITION을 policyCode/condition으로 파싱한다")
+  void shouldParseUpdatePolicyCondition() {
+    StructuralPatchOperation.ElementAttribute op =
+        parseSingleElement(
+            "{\"op\":\"UPDATE_POLICY_CONDITION\",\"policyCode\":\"refund_window\","
+                + "\"condition\":\"days <= 7\",\"reason\":\"환불 기한 명시\"}");
+
+    assertThat(op.category()).isEqualTo(StructuralPatchTargetCategory.POLICY);
+    assertThat(op.targetCode()).isEqualTo("refund_window");
+    assertThat(op.value()).isEqualTo("days <= 7");
+  }
+
+  @Test
+  @DisplayName("parse: UPDATE_RISK_TRIGGER을 riskCode/trigger로 파싱한다")
+  void shouldParseUpdateRiskTrigger() {
+    StructuralPatchOperation.ElementAttribute op =
+        parseSingleElement(
+            "{\"op\":\"UPDATE_RISK_TRIGGER\",\"riskCode\":\"angry_customer\","
+                + "\"trigger\":\"sentiment < -0.5\",\"reason\":\"이관 조건 강화\"}");
+
+    assertThat(op.category()).isEqualTo(StructuralPatchTargetCategory.RISK);
+    assertThat(op.value()).isEqualTo("sentiment < -0.5");
+  }
+
+  @Test
+  @DisplayName("parse: UPDATE_RESPONSE_COPY를 responseCode/copy로 파싱한다")
+  void shouldParseUpdateResponseCopy() {
+    StructuralPatchOperation.ElementAttribute op =
+        parseSingleElement(
+            "{\"op\":\"UPDATE_RESPONSE_COPY\",\"responseCode\":\"greeting\","
+                + "\"copy\":\"안녕하세요, 무엇을 도와드릴까요?\",\"reason\":\"문구 개선\"}");
+
+    assertThat(op.category()).isEqualTo(StructuralPatchTargetCategory.RESPONSE);
+    assertThat(op.targetCode()).isEqualTo("greeting");
+    assertThat(op.value()).isEqualTo("안녕하세요, 무엇을 도와드릴까요?");
+  }
+
+  @Test
+  @DisplayName("parse: ELEMENT operation은 code 없이 targetId로도 식별된다")
+  void shouldParseElementByTargetId() {
+    StructuralPatchOperation.ElementAttribute op =
+        parseSingleElement(
+            "{\"op\":\"UPDATE_SLOT_DESCRIPTION\",\"targetId\":42,"
+                + "\"description\":\"픽업 날짜\",\"reason\":\"설명 보강\"}");
+
+    assertThat(op.targetCode()).isNull();
+    assertThat(op.targetId()).isEqualTo(42L);
+  }
+
+  // ---- 정상: WORKFLOW operation 전체 ----
+
+  @Test
+  @DisplayName("parse: ADD_WORKFLOW_NODE를 노드 필드와 함께 파싱한다")
+  void shouldParseAddWorkflowNode() {
+    StructuralPatchOperation.WorkflowNode op =
+        parseSingleNode(
+            "{\"op\":\"ADD_WORKFLOW_NODE\",\"workflowCode\":\"airport_pickup_flow\","
+                + "\"nodeId\":\"ask_pickup_date\",\"nodeType\":\"ASK_SLOT\","
+                + "\"slotCode\":\"pickupDate\",\"prompt\":\"픽업 날짜를 알려주세요\",\"reason\":\"날짜 수집\"}");
+
+    assertThat(op.type()).isEqualTo(StructuralPatchOperationType.ADD_WORKFLOW_NODE);
+    assertThat(op.workflowCode()).isEqualTo("airport_pickup_flow");
+    assertThat(op.nodeId()).isEqualTo("ask_pickup_date");
+    assertThat(op.nodeType()).isEqualTo("ASK_SLOT");
+    assertThat(op.slotCode()).isEqualTo("pickupDate");
+    assertThat(op.prompt()).isEqualTo("픽업 날짜를 알려주세요");
+  }
+
+  @Test
+  @DisplayName("parse: UPDATE_WORKFLOW_NODE는 workflowDefinitionId와 선택 필드 없이도 파싱한다")
+  void shouldParseUpdateWorkflowNodeByDefinitionId() {
+    StructuralPatchOperation.WorkflowNode op =
+        parseSingleNode(
+            "{\"op\":\"UPDATE_WORKFLOW_NODE\",\"workflowDefinitionId\":7,"
+                + "\"nodeId\":\"ask_pickup_date\",\"nodeType\":\"ASK_SLOT\",\"reason\":\"프롬프트 수정\"}");
+
+    assertThat(op.workflowCode()).isNull();
+    assertThat(op.workflowDefinitionId()).isEqualTo(7L);
+    assertThat(op.slotCode()).isNull();
+    assertThat(op.prompt()).isNull();
+  }
+
+  @Test
+  @DisplayName("parse: ADD_TRANSITION을 from/to/condition으로 파싱한다")
+  void shouldParseAddTransition() {
+    StructuralPatchOperation.WorkflowTransition op =
+        parseSingleTransition(
+            "{\"op\":\"ADD_TRANSITION\",\"workflowCode\":\"airport_pickup_flow\","
+                + "\"from\":\"start\",\"to\":\"ask_pickup_date\","
+                + "\"condition\":\"missing(pickupDate)\",\"reason\":\"분기 추가\"}");
+
+    assertThat(op.type()).isEqualTo(StructuralPatchOperationType.ADD_TRANSITION);
+    assertThat(op.from()).isEqualTo("start");
+    assertThat(op.to()).isEqualTo("ask_pickup_date");
+    assertThat(op.condition()).isEqualTo("missing(pickupDate)");
+  }
+
+  @Test
+  @DisplayName("parse: UPDATE_TRANSITION을 파싱한다")
+  void shouldParseUpdateTransition() {
+    StructuralPatchOperation.WorkflowTransition op =
+        parseSingleTransition(
+            "{\"op\":\"UPDATE_TRANSITION\",\"workflowCode\":\"airport_pickup_flow\","
+                + "\"from\":\"start\",\"to\":\"ask_pickup_date\",\"reason\":\"조건 변경\"}");
+
+    assertThat(op.type()).isEqualTo(StructuralPatchOperationType.UPDATE_TRANSITION);
+    assertThat(op.condition()).isNull();
+  }
+
+  @Test
+  @DisplayName("parse: REMOVE_TRANSITION은 condition 없이 from/to만으로 파싱한다")
+  void shouldParseRemoveTransition() {
+    StructuralPatchOperation.WorkflowTransition op =
+        parseSingleTransition(
+            "{\"op\":\"REMOVE_TRANSITION\",\"workflowCode\":\"airport_pickup_flow\","
+                + "\"from\":\"start\",\"to\":\"ask_pickup_date\",\"reason\":\"불필요한 전이 제거\"}");
+
+    assertThat(op.type()).isEqualTo(StructuralPatchOperationType.REMOVE_TRANSITION);
+  }
+
+  // ---- 거절: 봉투(envelope) ----
+
+  @Test
+  @DisplayName("parse: 비어 있는 문서를 거절한다")
+  void shouldRejectBlankDocument() {
+    assertThatThrownBy(() -> parser.parse("  "))
+        .isInstanceOf(InvalidStructuralPatchException.class)
+        .hasMessageContaining("비어 있습니다");
+  }
+
+  @Test
+  @DisplayName("parse: malformed JSON을 거절한다")
+  void shouldRejectMalformedJson() {
+    assertThatThrownBy(() -> parser.parse("{not json"))
+        .isInstanceOf(InvalidStructuralPatchException.class)
+        .hasMessageContaining("JSON으로 파싱할 수 없습니다");
+  }
+
+  @Test
+  @DisplayName("parse: object가 아닌 문서를 거절한다")
+  void shouldRejectNonObjectDocument() {
+    assertThatThrownBy(() -> parser.parse("[]"))
+        .isInstanceOf(InvalidStructuralPatchException.class)
+        .hasMessageContaining("JSON object여야 합니다");
+  }
+
+  @Test
+  @DisplayName("parse: 인식되지 않는 schemaVersion을 거절한다")
+  void shouldRejectUnknownSchemaVersion() {
+    String json =
+        "{\"schemaVersion\":\"simulation-structural-patch.v2\",\"evidence\":{\"failureSummary\":\"x\"},"
+            + "\"operations\":[{\"op\":\"MARK_SLOT_REQUIRED\",\"slotCode\":\"a\",\"reason\":\"r\"}]}";
+
+    assertThatThrownBy(() -> parser.parse(json))
+        .isInstanceOf(InvalidStructuralPatchException.class)
+        .hasMessageContaining("schemaVersion");
+  }
+
+  @Test
+  @DisplayName("parse: operations가 배열이 아니면 거절한다")
+  void shouldRejectNonArrayOperations() {
+    String json =
+        "{\"schemaVersion\":\""
+            + StructuralDomainPackPatch.SCHEMA_VERSION
+            + "\","
+            + "\"evidence\":{\"failureSummary\":\"x\"},\"operations\":{}}";
+
+    assertThatThrownBy(() -> parser.parse(json))
+        .isInstanceOf(InvalidStructuralPatchException.class)
+        .hasMessageContaining("배열이어야 합니다");
+  }
+
+  @Test
+  @DisplayName("parse: operations가 비어 있으면 거절한다")
+  void shouldRejectEmptyOperations() {
+    String json =
+        "{\"schemaVersion\":\""
+            + StructuralDomainPackPatch.SCHEMA_VERSION
+            + "\","
+            + "\"evidence\":{\"failureSummary\":\"x\"},\"operations\":[]}";
+
+    assertThatThrownBy(() -> parser.parse(json))
+        .isInstanceOf(InvalidStructuralPatchException.class)
+        .hasMessageContaining("최소 1개");
+  }
+
+  @Test
+  @DisplayName("parse: evidence가 없으면 거절한다")
+  void shouldRejectMissingEvidence() {
+    String json =
+        "{\"schemaVersion\":\""
+            + StructuralDomainPackPatch.SCHEMA_VERSION
+            + "\","
+            + "\"operations\":[{\"op\":\"MARK_SLOT_REQUIRED\",\"slotCode\":\"a\",\"reason\":\"r\"}]}";
+
+    assertThatThrownBy(() -> parser.parse(json))
+        .isInstanceOf(InvalidStructuralPatchException.class)
+        .hasMessageContaining("evidence는 필수");
+  }
+
+  @Test
+  @DisplayName("parse: evidence.failureSummary가 없으면 거절한다")
+  void shouldRejectMissingFailureSummary() {
+    String json =
+        "{\"schemaVersion\":\""
+            + StructuralDomainPackPatch.SCHEMA_VERSION
+            + "\","
+            + "\"evidence\":{\"feedbackId\":1},"
+            + "\"operations\":[{\"op\":\"MARK_SLOT_REQUIRED\",\"slotCode\":\"a\",\"reason\":\"r\"}]}";
+
+    assertThatThrownBy(() -> parser.parse(json))
+        .isInstanceOf(InvalidStructuralPatchException.class)
+        .hasMessageContaining("failureSummary");
+  }
+
+  @Test
+  @DisplayName("parse: 정수가 아닌 evidence id를 거절한다")
+  void shouldRejectNonIntegerEvidenceId() {
+    String json =
+        "{\"schemaVersion\":\""
+            + StructuralDomainPackPatch.SCHEMA_VERSION
+            + "\","
+            + "\"evidence\":{\"feedbackId\":\"oops\",\"failureSummary\":\"x\"},"
+            + "\"operations\":[{\"op\":\"MARK_SLOT_REQUIRED\",\"slotCode\":\"a\",\"reason\":\"r\"}]}";
+
+    assertThatThrownBy(() -> parser.parse(json))
+        .isInstanceOf(InvalidStructuralPatchException.class)
+        .hasMessageContaining("정수여야 합니다");
+  }
+
+  // ---- 거절: operation ----
+
+  @Test
+  @DisplayName("parse: 지원하지 않는 operation을 fail-closed로 거절한다")
+  void shouldRejectUnsupportedOperation() {
+    assertThatThrownBy(
+            () -> parser.parse(envelope("{\"op\":\"DELETE_EVERYTHING\",\"reason\":\"r\"}")))
+        .isInstanceOf(InvalidStructuralPatchException.class)
+        .hasMessageContaining("지원하지 않는 operation");
+  }
+
+  @Test
+  @DisplayName("parse: reason이 없으면 거절한다")
+  void shouldRejectMissingReason() {
+    assertThatThrownBy(
+            () -> parser.parse(envelope("{\"op\":\"MARK_SLOT_REQUIRED\",\"slotCode\":\"a\"}")))
+        .isInstanceOf(InvalidStructuralPatchException.class)
+        .hasMessageContaining("reason");
+  }
+
+  @Test
+  @DisplayName("parse: ELEMENT operation에 code/targetId가 모두 없으면 거절한다")
+  void shouldRejectElementWithoutTarget() {
+    assertThatThrownBy(
+            () ->
+                parser.parse(
+                    envelope(
+                        "{\"op\":\"UPDATE_SLOT_DESCRIPTION\",\"description\":\"x\",\"reason\":\"r\"}")))
+        .isInstanceOf(InvalidStructuralPatchException.class)
+        .hasMessageContaining("slotCode 또는 targetId");
+  }
+
+  @Test
+  @DisplayName("parse: value가 필요한 ELEMENT operation에 값이 없으면 거절한다")
+  void shouldRejectElementWithoutValue() {
+    assertThatThrownBy(
+            () ->
+                parser.parse(
+                    envelope(
+                        "{\"op\":\"UPDATE_INTENT_DESCRIPTION\",\"intentCode\":\"a\",\"reason\":\"r\"}")))
+        .isInstanceOf(InvalidStructuralPatchException.class)
+        .hasMessageContaining("description 값이 필요");
+  }
+
+  @Test
+  @DisplayName("parse: workflow operation에 workflow 식별자가 없으면 거절한다")
+  void shouldRejectWorkflowWithoutTarget() {
+    assertThatThrownBy(
+            () ->
+                parser.parse(
+                    envelope(
+                        "{\"op\":\"ADD_WORKFLOW_NODE\",\"nodeId\":\"n\",\"nodeType\":\"ASK_SLOT\",\"reason\":\"r\"}")))
+        .isInstanceOf(InvalidStructuralPatchException.class)
+        .hasMessageContaining("workflowCode 또는 workflowDefinitionId");
+  }
+
+  @Test
+  @DisplayName("parse: workflow node operation에 nodeId가 없으면 거절한다")
+  void shouldRejectWorkflowNodeWithoutNodeId() {
+    assertThatThrownBy(
+            () ->
+                parser.parse(
+                    envelope(
+                        "{\"op\":\"ADD_WORKFLOW_NODE\",\"workflowCode\":\"w\",\"nodeType\":\"ASK_SLOT\",\"reason\":\"r\"}")))
+        .isInstanceOf(InvalidStructuralPatchException.class)
+        .hasMessageContaining("nodeId");
+  }
+
+  @Test
+  @DisplayName("parse: workflow node operation에 nodeType이 없으면 거절한다")
+  void shouldRejectWorkflowNodeWithoutNodeType() {
+    assertThatThrownBy(
+            () ->
+                parser.parse(
+                    envelope(
+                        "{\"op\":\"ADD_WORKFLOW_NODE\",\"workflowCode\":\"w\",\"nodeId\":\"n\",\"reason\":\"r\"}")))
+        .isInstanceOf(InvalidStructuralPatchException.class)
+        .hasMessageContaining("nodeType");
+  }
+
+  @Test
+  @DisplayName("parse: transition operation에 from/to가 없으면 거절한다")
+  void shouldRejectTransitionWithoutEndpoints() {
+    assertThatThrownBy(
+            () ->
+                parser.parse(
+                    envelope(
+                        "{\"op\":\"ADD_TRANSITION\",\"workflowCode\":\"w\",\"to\":\"b\",\"reason\":\"r\"}")))
+        .isInstanceOf(InvalidStructuralPatchException.class)
+        .hasMessageContaining("from");
+  }
+
+  // ---- helpers ----
+
+  private StructuralPatchOperation.ElementAttribute parseSingleElement(String operationJson) {
+    return (StructuralPatchOperation.ElementAttribute) parseSingle(operationJson);
+  }
+
+  private StructuralPatchOperation.WorkflowNode parseSingleNode(String operationJson) {
+    return (StructuralPatchOperation.WorkflowNode) parseSingle(operationJson);
+  }
+
+  private StructuralPatchOperation.WorkflowTransition parseSingleTransition(String operationJson) {
+    return (StructuralPatchOperation.WorkflowTransition) parseSingle(operationJson);
+  }
+
+  private StructuralPatchOperation parseSingle(String operationJson) {
+    StructuralDomainPackPatch patch = parser.parse(envelope(operationJson));
+    return patch.operations().get(0);
+  }
+
+  private static String envelope(String operationJson) {
+    return "{\"schemaVersion\":\""
+        + StructuralDomainPackPatch.SCHEMA_VERSION
+        + "\",\"summary\":\"workflow 보강\","
+        + "\"evidence\":{\"feedbackId\":123,\"simulationSessionId\":456,\"goldenCaseId\":789,"
+        + "\"replayResultId\":790,\"failureSummary\":\"expected ASK_SLOT but was NEED_INTENT\"},"
+        + "\"operations\":["
+        + operationJson
+        + "]}";
+  }
+}


### PR DESCRIPTION
## Summary
- 시뮬레이션 실패·골든 리플레이 근거를 LLM이 생성하고 백엔드가 검증할 수 있는 `simulation-structural-patch.v1` 구조적 패치 문서의 파싱·검증 전용 value object와 parser를 추가합니다. (closes #879)
- `StructuralDomainPackPatch` / `StructuralPatchOperation`(sealed: ElementAttribute·WorkflowNode·WorkflowTransition) / `StructuralPatchEvidence` / `StructuralPatchOperationType`·`StructuralPatchTargetCategory` enum으로 계약을 표현합니다.
- application 계층 `StructuralDomainPackPatchParser`가 JSON 문자열을 도메인 VO로 변환하며, JSON 구조/타입 오류와 미지원 operation을 fail-closed로 거절합니다.

## Scope / Non-goals
- 이슈 비목표대로 LLM 생성, workflow 그래프 mutation 실제 적용, 프론트엔드 diff UI는 다루지 않습니다.
- 기존 `simulation-candidate-draft-patch.v1`(UPDATE_DESCRIPTION) 동작은 손대지 않았습니다(신규 파일만 추가).

## Validation rules (fail closed)
- 미인식 `schemaVersion`, `operations` 누락/빈 배열/비배열, 알 수 없는 `op`, ELEMENT target(code/targetId) 누락, workflow 식별자(workflowCode/workflowDefinitionId) 누락, value 필요 op의 값 누락, node `nodeId`/`nodeType`·transition `from`/`to`·모든 op `reason` 누락, `evidence` 또는 `failureSummary` 누락, malformed JSON을 모두 `InvalidStructuralPatchException`(`INVALID_STRUCTURAL_PATCH`, 400)으로 거절합니다.
- 파싱/검증 단계는 어떤 repository에도 의존하지 않아 DB mutation이 발생하지 않습니다.

## Reviewer context
- 도메인 VO는 Jackson 의존 없는 순수 record로 두고, JSON 파싱(Jackson)은 application 계층 parser에 격리했습니다.
- `InvalidStructuralPatchException`은 기존 `InvalidSimulationImprovementCandidateException`과 동일하게 도메인 패키지에서 `BadRequestException`을 확장하는 패턴을 따릅니다.

## Quality evidence
- 자기 코드 리뷰 3라운드 수행: (1) 이슈 수용 기준·동작, (2) DDD 계층/예외 매핑/불변성, (3) checkstyle·spotless·테스트 누락. 신규 파일은 checkstyle 위반 0건(테스트 1건은 repo 전반에 존재하는 spotless↔checkstyle `RightCurlyAlone` 경고, 비차단).
- MVP operation 13종 valid + 카테고리별 invalid 케이스 포함 단위 테스트 33개 통과.

## Tests
- `cd backend && ./gradlew test --tests "com.init.workflowruntime.application.StructuralDomainPackPatchParserTest"` (33 passed)
- `cd backend && ./gradlew spotlessApply spotlessCheck checkstyleMain checkstyleTest` (BUILD SUCCESSFUL)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 워크플로우 구조 변경사항에 대한 검증 및 파싱 체계 추가
  * AI 생성 패치에 대한 fail-closed 검증으로 데이터 무결성 강화

* **테스트**
  * 구조 패치 파싱 및 검증의 정상/오류 케이스에 대한 포괄적 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->