### PR TITLE
feat(ml): #886 flow splitting replay에 workflow feedback constraint 반영

### DIFF
--- a/.agent/specs/886.md
+++ b/.agent/specs/886.md
@@ -1,0 +1,125 @@
+# 886 — flow splitting replay에 workflow feedback constraint 반영
+
+## Goal
+
+`flow_splitting` 단계가 workflow-scope feedback constraint(`same_workflow` / `separate_workflow`)를 읽어 workflow entrypoint의 merge/split 결정에 반영하고, 적용·무시 내역과 메트릭을 artifact에 남기게 한다. 이로써 "피드백 반영 후 replay"가 실제 workflow 구조 개선 루프로 동작한다.
+
+## Problem
+
+- intent-scope feedback(`must_link`/`cannot_link`)은 `PIPELINE_FEEDBACK_CONSTRAINTS_PATH` → `intent_discovery`의 same-intent graph에 반영된다.
+- 운영자가 review checkpoint에서 "같은 workflow로 합치기"(`same_workflow`) 또는 "같은 intent지만 workflow는 분리"(`same_intent_separate_workflow`)를 선택해도, 그 결정은 두 곳에서 끊긴다.
+  1. **Backend**: `PipelineReviewCheckpointUseCase`는 workflow-scope 결정을 `feedback_constraints.json`의 `constraints` 배열에 **전혀 기록하지 않는다**. workflow scope면 `constraintType`을 빈 문자열로 강제해 constraint emission을 건너뛴다.
+  2. **ML**: `flow_splitting`은 `PIPELINE_FEEDBACK_CONSTRAINTS_PATH`를 받지도, workflow constraint를 적용하지도 않는다.
+- 결과적으로 workflow boundary 피드백은 다음 draft의 entrypoint 구조에 아무 영향을 주지 못한다.
+
+## Scope
+
+backend(review) 최소 emission + ML(flow_splitting) consumption의 mixed 변경.
+
+### In scope
+- Backend: workflow-scope 결정(`same_workflow`, `same_intent_separate_workflow`)을 `feedback_constraints.json`에 `scope:"workflow"` + `type:"same_workflow"|"separate_workflow"` constraint로 emit.
+- ML: workflow constraint loader 추가, DAG의 `flow_splitting`에 constraint path 전달, group reconciliation, 메트릭/리포트.
+
+### Non-goals
+- intent-scope 처리(`must_link`/`cannot_link`/`different_intent`) 동작 변경. `different_intent`는 이미 intent scope `cannot_link`로 emit되어 intent_discovery에서 처리되므로 flow_splitting은 중복 적용하지 않는다(workflow loader가 애초에 받지 않음).
+- frontend, review question 생성 로직, draft_generation 이후 단계 변경.
+- 새 review UI / 새 answer option 추가.
+
+## Affected modules (verified paths)
+
+- `ml/src/dags/domain_pack_generation.py` — `flow_splitting` task에 feedback constraint env 전달.
+- `ml/src/pipeline/stages/intent_discovery/feedback_constraints.py` — workflow constraint loader 추가(공용 row helper 재사용).
+- `ml/src/pipeline/stages/flow_splitting/workflow_feedback.py` — **신규**. group reconciliation + 메트릭/리포트.
+- `ml/src/pipeline/stages/flow_splitting/main.py` — reconciler 연결, 메트릭/리포트 병합.
+- `backend/src/main/java/com/init/review/application/PipelineReviewCheckpointUseCase.java` — workflow-scope constraint emission.
+
+## Contract: workflow-scope feedback constraint
+
+`feedback_constraints.json`의 `constraints` 항목:
+
+```json
+{
+  "sourceId": "conv-1",
+  "targetId": "conv-2",
+  "type": "same_workflow",
+  "scope": "workflow",
+  "confidence": 1.0,
+  "reviewTaskId": 17,
+  "decisionId": 31
+}
+```
+
+- `type`: `same_workflow` 또는 `separate_workflow`. backend decision `same_intent_separate_workflow`는 emit 시 `separate_workflow`로 정규화한다. loader는 `same_intent_separate_workflow` 별칭도 수용한다.
+- `scope`: `workflow`. 그 외 scope(`intent` 등)는 workflow loader가 무시한다.
+- `sourceId`/`targetId`: conversation(caselet) id. intent constraint와 동일한 id 공간.
+
+## Reconciliation 규칙 (per source cluster)
+
+base flow group 분할(`_flow_groups`) 후 다음을 적용한다. workflow entrypoint = source cluster 내 flow group이다.
+
+1. **actionability**: constraint의 두 endpoint가 **같은 candidate cluster**의 member일 때만 적용 대상. 그 외는 무시(reason 기록).
+2. **same_workflow**: 두 endpoint가 같은 workflow entrypoint에 속하도록 둘이 위치한 base group을 하나로 merge. 이미 같은 group이면 `already_same`(구조 변경 없음, applied).
+3. **separate_workflow**: 두 endpoint가 다른 workflow entrypoint에 속하도록 한다. 이미 다른 group이면 `already_separate`(applied). 같은 group이면 target endpoint를 파생 group(`workflow_feedback_separate`)으로 분리(`split`).
+4. **conflict**: 동일 두 endpoint를 `same_workflow`가 (직·간접) 묶었는데 `separate_workflow`가 분리를 요구하면 separate를 무시(reason `conflicts_with_same_workflow`).
+5. **different_intent**: workflow loader가 받지 않으므로 flow_splitting에서 처리·중복 적용하지 않는다(intent_discovery `cannot_link`가 담당).
+
+### Ignore reasons
+- `endpoints_in_different_clusters` — 두 endpoint가 서로 다른 source cluster에 속함.
+- `endpoint_not_in_candidate` — endpoint가 어떤 candidate cluster member에도 없음(드롭/outlier 등).
+- `conflicts_with_same_workflow` — 위 4.
+
+## Metrics (artifact: flow_split_report.json / clusters.json `flow_split_metrics`)
+
+완료 조건의 5개 키를 flat하게 포함한다.
+
+- `workflowConstraintCount` — 로드된 workflow constraint 총수.
+- `appliedWorkflowConstraintCount` — actionable + 반영(merge/split/already_same/already_separate)된 수.
+- `ignoredWorkflowConstraintCount` — 무시된 수(= 총수 − applied).
+- `workflowMergeByFeedbackCount` — 실제로 group을 병합한 `same_workflow` 수.
+- `workflowSplitByFeedbackCount` — 실제로 group을 분리한 `separate_workflow` 수.
+
+추적용 상세(`workflowFeedback`):
+
+```json
+{
+  "applied": [
+    {"sourceId": "...", "targetId": "...", "type": "same_workflow",
+     "effect": "merged", "sourceClusterId": 7,
+     "sourceEntryPointId": "entrypoint-0", "targetEntryPointId": "entrypoint-0"}
+  ],
+  "ignored": [
+    {"sourceId": "...", "targetId": "...", "type": "separate_workflow",
+     "reason": "conflicts_with_same_workflow"}
+  ]
+}
+```
+
+- applied 항목마다 source/target과 결과 workflow entrypoint id를 추적할 수 있다.
+- ignored 항목은 reason과 함께 보고된다(조용히 무시하지 않음).
+
+## Validation / Acceptance
+
+- feedback constraint가 없으면 기존 결과 동일(reconciler no-op, 메트릭 0/빈 리스트). 기존 flow_splitting 테스트 green.
+- workflow constraints 주입 시:
+  - `same_workflow`가 두 entrypoint를 하나로 합친다(merge count↑).
+  - `separate_workflow`가 한 entrypoint를 둘로 나눈다(split count↑).
+  - 적용 불가 constraint가 reason과 함께 ignored에 남는다.
+  - 5개 메트릭 키가 artifact에 존재한다.
+- backend: workflow 결정이 `feedback-constraints.v1`의 `constraints`에 `scope:"workflow"`로 포함된다. intent 결정은 기존대로 emit된다.
+
+## Test plan
+
+- ML unit: `test_feedback_constraints.py` — workflow loader가 workflow row만 파싱, alias/scope 필터 검증.
+- ML unit: `test_flow_splitting_workflow_feedback.py` — reconciler merge/split/already/conflict/ignore + 메트릭.
+- ML integration: `test_flow_splitting_stage_run.py` — `PIPELINE_FEEDBACK_CONSTRAINTS_PATH` 주입 시 entrypoint 구조·메트릭 반영, 미주입 시 동일.
+- Backend: `PipelineReviewCheckpointUseCaseTest` — workflow 결정이 `scope:"workflow"` constraint로 emit됨.
+
+## Verification commands
+
+- `cd ml && uv run pytest tests/stages/test_feedback_constraints.py tests/stages/test_flow_splitting_workflow_feedback.py tests/stages/test_flow_splitting_stage_run.py`
+- `cd ml && uv run ruff check . && uv run ruff format --check . && uv run mypy .`
+- `./gradlew :backend:test --tests "*PipelineReviewCheckpointUseCaseTest*"` (또는 `pnpm run ci:backend`)
+
+## Open questions
+
+- separate_workflow가 같은 group의 두 endpoint를 분리할 때 target만 파생 group으로 이동하므로 소형(1-member) entrypoint가 생길 수 있다. 운영자의 명시적 hard 결정으로 간주하고 허용하며, label은 기존 single-member 규칙대로 `needs_review`로 강등된다.

--- a/backend/src/main/java/com/init/review/application/PipelineReviewCheckpointUseCase.java
+++ b/backend/src/main/java/com/init/review/application/PipelineReviewCheckpointUseCase.java
@@ -204,15 +204,13 @@ public class PipelineReviewCheckpointUseCase {
               jsonSupport.toJson(decisionPayload(decisionMapping, question)),
               now);
       savedDecision = reviewDecisionRepository.save(savedDecision);
-      if (!decisionMapping.constraintType().isBlank()) {
-        ObjectNode constraint = constraints.addObject();
-        constraint.put("sourceId", jsonSupport.text(question, "sourceId"));
-        constraint.put("targetId", jsonSupport.text(question, "targetId"));
-        constraint.put("type", decisionMapping.constraintType());
-        constraint.put("confidence", 1.0);
-        constraint.put("scope", "intent");
-        constraint.put("reviewTaskId", task.getId());
-        constraint.put("decisionId", savedDecision.getId());
+      String intentConstraintType = decisionMapping.constraintType();
+      String workflowConstraintType = workflowConstraintType(decisionMapping);
+      if (!intentConstraintType.isBlank()) {
+        addConstraint(constraints, question, intentConstraintType, "intent", task, savedDecision);
+      } else if (!workflowConstraintType.isBlank()) {
+        addConstraint(
+            constraints, question, workflowConstraintType, "workflow", task, savedDecision);
       }
     }
     ObjectNode payload = jsonSupport.objectNode();
@@ -396,6 +394,34 @@ public class PipelineReviewCheckpointUseCase {
       case "must_link", "cannot_link" -> "intent";
       case "same_workflow", "same_intent_separate_workflow" -> "workflow";
       default -> firstPresent(questionDecisionScope, "none");
+    };
+  }
+
+  private void addConstraint(
+      ArrayNode constraints,
+      JsonNode question,
+      String type,
+      String scope,
+      ReviewTask task,
+      ReviewDecision savedDecision) {
+    ObjectNode constraint = constraints.addObject();
+    constraint.put("sourceId", jsonSupport.text(question, "sourceId"));
+    constraint.put("targetId", jsonSupport.text(question, "targetId"));
+    constraint.put("type", type);
+    constraint.put("confidence", 1.0);
+    constraint.put("scope", scope);
+    constraint.put("reviewTaskId", task.getId());
+    constraint.put("decisionId", savedDecision.getId());
+  }
+
+  private String workflowConstraintType(FeedbackDecisionMapping decisionMapping) {
+    if (!"workflow".equals(decisionMapping.decisionScope())) {
+      return "";
+    }
+    return switch (decisionMapping.decisionType()) {
+      case "same_workflow" -> "same_workflow";
+      case "same_intent_separate_workflow" -> "separate_workflow";
+      default -> "";
     };
   }
 

--- a/backend/src/test/java/com/init/review/application/PipelineReviewCheckpointUseCaseTest.java
+++ b/backend/src/test/java/com/init/review/application/PipelineReviewCheckpointUseCaseTest.java
@@ -435,9 +435,8 @@ class PipelineReviewCheckpointUseCaseTest {
   }
 
   @Test
-  @DisplayName(
-      "workflow boundary feedback preserves decision scope without direct intent constraint")
-  void submitFeedback_workflowBoundaryFeedback_mapsOnlyExplicitIntentDecisionToConstraint()
+  @DisplayName("workflow boundary feedback emits workflow-scope and intent-scope constraints")
+  void submitFeedback_workflowBoundaryFeedback_emitsWorkflowAndIntentConstraints()
       throws Exception {
     PipelineJob job =
         job(
@@ -533,9 +532,15 @@ class PipelineReviewCheckpointUseCaseTest {
     List<String> decisionPayloads =
         decisionCaptor.getAllValues().stream().map(ReviewDecision::getDecisionPayloadJson).toList();
 
-    assertThat(constraints).hasSize(1);
-    assertThat(constraints.get(0).path("sourceId").asText()).isEqualTo("wf3");
-    assertThat(constraints.get(0).path("type").asText()).isEqualTo("cannot_link");
+    assertThat(constraints).hasSize(2);
+    JsonNode workflowConstraint = constraintBySource(constraints, "wf1");
+    assertThat(workflowConstraint.path("type").asText()).isEqualTo("same_workflow");
+    assertThat(workflowConstraint.path("scope").asText()).isEqualTo("workflow");
+    assertThat(workflowConstraint.path("targetId").asText()).isEqualTo("wf2");
+    JsonNode intentConstraint = constraintBySource(constraints, "wf3");
+    assertThat(intentConstraint.path("type").asText()).isEqualTo("cannot_link");
+    assertThat(intentConstraint.path("scope").asText()).isEqualTo("intent");
+    assertThat(intentConstraint.path("targetId").asText()).isEqualTo("wf4");
     assertThat(decisionPayloads.getFirst())
         .contains(
             "\"decisionType\":\"same_workflow\"",
@@ -573,6 +578,15 @@ class PipelineReviewCheckpointUseCaseTest {
     assertThat(view.tasks()).hasSize(1);
     assertThat(view.tasks().getFirst().payload().path("questionText").asText())
         .isEqualTo("이 두 상담은 같은 업무인가?");
+  }
+
+  private static JsonNode constraintBySource(JsonNode constraints, String sourceId) {
+    for (JsonNode constraint : constraints) {
+      if (sourceId.equals(constraint.path("sourceId").asText())) {
+        return constraint;
+      }
+    }
+    throw new AssertionError("constraint not found for sourceId=" + sourceId);
   }
 
   private void givenReviewAccess(PipelineJob job) {

--- a/ml/src/dags/domain_pack_generation.py
+++ b/ml/src/dags/domain_pack_generation.py
@@ -445,10 +445,16 @@ def domain_pack_generation() -> None:  # pragma: no cover - Airflow imports this
 
     @task(task_id="flow_splitting")
     def flow_splitting(intent_discovery_result: dict[str, str]) -> dict[str, str]:
-        return _run_stage(
-            "flow_splitting",
-            upstream_manifest_path=intent_discovery_result["artifact_manifest_path"],
-        )
+        with _stage_env(
+            {
+                "PIPELINE_FEEDBACK_CONSTRAINTS_PATH": _conf_value("feedback_constraints_path")
+                or _conf_json_file("feedback_constraints_json", "feedback_constraints.json"),
+            }
+        ):
+            return _run_stage(
+                "flow_splitting",
+                upstream_manifest_path=intent_discovery_result["artifact_manifest_path"],
+            )
 
     @task(task_id="start_llm_service")
     def start_llm_service(flow_splitting_result: dict[str, str]) -> dict[str, str]:

--- a/ml/src/pipeline/stages/flow_splitting/main.py
+++ b/ml/src/pipeline/stages/flow_splitting/main.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 from pipeline.common.artifacts import ensure_stage_directory, write_stage_manifest
 from pipeline.common.config import PipelineRuntimeConfig
 from pipeline.common.exceptions import PipelineStageError
+from pipeline.stages.intent_discovery.feedback_constraints import load_workflow_feedback_constraints_from_env
 from pipeline.stages.preprocessing.io import read_stage_context
 
 # redundant alias import는 stage 분해 이전 경로를 쓰는 테스트를 위해 이 모듈로 re-export한다.
@@ -97,6 +98,7 @@ from .splitting import (
     _apply_regenerated_label_metadata,
     _flow_groups,
 )
+from .workflow_feedback import WorkflowFeedbackReconciler
 
 
 def run(upstream_manifest_path: str | None = None) -> dict[str, object]:
@@ -126,12 +128,16 @@ def run(upstream_manifest_path: str | None = None) -> dict[str, object]:
         min_size=NOVEL_REVIEW_CANDIDATE_MIN_SIZE,
     )
     candidate_clusters = quality_filtered_clusters + novel_review_clusters
+    workflow_reconciler = WorkflowFeedbackReconciler(
+        load_workflow_feedback_constraints_from_env(),
+        candidate_clusters,
+    )
 
     split_clusters: list[dict[str, Any]] = []
     entrypoints: list[dict[str, Any]] = []
     split_count = 0
     next_cluster_id = 0
-    for cluster in candidate_clusters:
+    for cluster_index, cluster in enumerate(candidate_clusters):
         if not isinstance(cluster, dict):
             continue
         groups = _flow_groups(
@@ -140,6 +146,7 @@ def run(upstream_manifest_path: str | None = None) -> dict[str, object]:
             strategy=split_strategy,
             min_split_size=min_split_size,
         )
+        groups = workflow_reconciler.reconcile(cluster_index, groups)
         if len(groups) <= 1:
             group_key = next(iter(groups), "single_flow")
             split_reason = "mixed_flow" if group_key == "mixed_flow" else group_key
@@ -208,6 +215,7 @@ def run(upstream_manifest_path: str | None = None) -> dict[str, object]:
     output_payload["clusters"] = split_clusters
     output_payload["workflow_entrypoints_path"] = WORKFLOW_ENTRYPOINTS_ARTIFACT
     confidence_report = _workflow_confidence_report(split_clusters)
+    workflow_feedback_report = workflow_reconciler.report(entrypoints)
     report = {
         "schemaVersion": "flow-splitting.v2",
         "inputClusterCount": len(clusters),
@@ -232,6 +240,7 @@ def run(upstream_manifest_path: str | None = None) -> dict[str, object]:
         "workflowSeparability": _workflow_separability(entrypoints),
         **entrypoint_semantic_report,
         **confidence_report,
+        **workflow_feedback_report,
     }
     output_payload["flow_split_metrics"] = report
     clusters_path = output_dir / CLUSTERS_ARTIFACT

--- a/ml/src/pipeline/stages/flow_splitting/workflow_feedback.py
+++ b/ml/src/pipeline/stages/flow_splitting/workflow_feedback.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any
+
+from pipeline.stages.intent_discovery.feedback_constraints import WorkflowFeedbackConstraint
+
+from .helpers import _string_list
+
+SEPARATE_GROUP_PREFIX = "workflow_feedback_separate"
+
+REASON_DIFFERENT_CLUSTERS = "endpoints_in_different_clusters"
+REASON_NOT_IN_CANDIDATE = "endpoint_not_in_candidate"
+REASON_CONFLICT = "conflicts_with_same_workflow"
+
+EFFECT_MERGED = "merged"
+EFFECT_ALREADY_SAME = "already_same"
+EFFECT_SPLIT = "split"
+EFFECT_ALREADY_SEPARATE = "already_separate"
+
+
+@dataclass
+class _Outcome:
+    constraint: WorkflowFeedbackConstraint
+    applied: bool
+    effect: str
+    reason: str
+    source_cluster_id: Any = None
+
+
+class _UnionFind:
+    def __init__(self, items: list[Any]) -> None:
+        self._parent: dict[Any, Any] = {item: item for item in items}
+
+    def find(self, item: Any) -> Any:
+        root = item
+        while self._parent[root] != root:
+            root = self._parent[root]
+        while self._parent[item] != root:
+            self._parent[item], item = root, self._parent[item]
+        return root
+
+    def union(self, left: Any, right: Any) -> None:
+        self._parent[self.find(right)] = self.find(left)
+
+
+class WorkflowFeedbackReconciler:
+    """flow group을 workflow-scope feedback constraint에 맞게 merge/split한다.
+
+    workflow entrypoint = source cluster 내 flow group이므로, 두 endpoint가 같은
+    candidate cluster에 속할 때만 적용한다. 적용 불가 constraint는 reason과 함께
+    무시 내역으로 남긴다.
+    """
+
+    def __init__(
+        self,
+        constraints: list[WorkflowFeedbackConstraint],
+        candidate_clusters: list[dict[str, Any]],
+    ) -> None:
+        self._constraint_count = len(constraints)
+        self._outcomes: list[_Outcome] = []
+        self._by_cluster: dict[int, list[WorkflowFeedbackConstraint]] = defaultdict(list)
+        member_to_cluster: dict[str, int] = {}
+        source_id_by_index: dict[int, Any] = {}
+        for index, cluster in enumerate(candidate_clusters):
+            if not isinstance(cluster, dict):
+                continue
+            source_id_by_index[index] = cluster.get("cluster_id")
+            for member in _string_list(cluster.get("member_conv_ids")):
+                member_to_cluster.setdefault(member, index)
+        self._source_id_by_index = source_id_by_index
+        for constraint in constraints:
+            self._classify(constraint, member_to_cluster)
+
+    def _classify(self, constraint: WorkflowFeedbackConstraint, member_to_cluster: dict[str, int]) -> None:
+        source_cluster = member_to_cluster.get(constraint.source_id)
+        target_cluster = member_to_cluster.get(constraint.target_id)
+        if source_cluster is None or target_cluster is None:
+            self._outcomes.append(_Outcome(constraint, False, "", REASON_NOT_IN_CANDIDATE))
+        elif source_cluster != target_cluster:
+            self._outcomes.append(_Outcome(constraint, False, "", REASON_DIFFERENT_CLUSTERS))
+        else:
+            self._by_cluster[source_cluster].append(constraint)
+
+    def reconcile(self, cluster_index: int, groups: dict[str, list[str]]) -> dict[str, list[str]]:
+        constraints = self._by_cluster.get(cluster_index)
+        if not constraints:
+            return groups
+        source_cluster_id = self._source_id_by_index.get(cluster_index)
+        member_to_key = {member: key for key, members in groups.items() for member in members}
+        same_links = _UnionFind(list(member_to_key))
+        for constraint in constraints:
+            if constraint.type == "same_workflow":
+                same_links.union(constraint.source_id, constraint.target_id)
+
+        merged = self._apply_same_workflow(constraints, groups, member_to_key, source_cluster_id)
+        return self._apply_separate_workflow(constraints, merged, same_links, source_cluster_id)
+
+    def _apply_same_workflow(
+        self,
+        constraints: list[WorkflowFeedbackConstraint],
+        groups: dict[str, list[str]],
+        member_to_key: dict[str, str],
+        source_cluster_id: Any,
+    ) -> dict[str, list[str]]:
+        group_links = _UnionFind(list(groups))
+        for constraint in constraints:
+            if constraint.type != "same_workflow":
+                continue
+            source_key = member_to_key.get(constraint.source_id)
+            target_key = member_to_key.get(constraint.target_id)
+            if source_key is None or target_key is None:
+                self._outcomes.append(_Outcome(constraint, False, "", REASON_NOT_IN_CANDIDATE, source_cluster_id))
+                continue
+            if group_links.find(source_key) == group_links.find(target_key):
+                self._outcomes.append(_Outcome(constraint, True, EFFECT_ALREADY_SAME, "", source_cluster_id))
+                continue
+            group_links.union(source_key, target_key)
+            self._outcomes.append(_Outcome(constraint, True, EFFECT_MERGED, "", source_cluster_id))
+
+        merged: dict[str, list[str]] = defaultdict(list)
+        for key, members in groups.items():
+            merged[group_links.find(key)].extend(members)
+        return dict(merged)
+
+    def _apply_separate_workflow(
+        self,
+        constraints: list[WorkflowFeedbackConstraint],
+        groups: dict[str, list[str]],
+        same_links: _UnionFind,
+        source_cluster_id: Any,
+    ) -> dict[str, list[str]]:
+        member_to_key = {member: key for key, members in groups.items() for member in members}
+        separate_seq = 0
+        for constraint in constraints:
+            if constraint.type != "separate_workflow":
+                continue
+            if same_links.find(constraint.source_id) == same_links.find(constraint.target_id):
+                self._outcomes.append(_Outcome(constraint, False, "", REASON_CONFLICT, source_cluster_id))
+                continue
+            source_key = member_to_key.get(constraint.source_id)
+            target_key = member_to_key.get(constraint.target_id)
+            if source_key is None or target_key is None:
+                self._outcomes.append(_Outcome(constraint, False, "", REASON_NOT_IN_CANDIDATE, source_cluster_id))
+                continue
+            if source_key != target_key:
+                self._outcomes.append(_Outcome(constraint, True, EFFECT_ALREADY_SEPARATE, "", source_cluster_id))
+                continue
+            new_key = f"{SEPARATE_GROUP_PREFIX}:{separate_seq}"
+            separate_seq += 1
+            groups[source_key].remove(constraint.target_id)
+            groups[new_key] = [constraint.target_id]
+            member_to_key[constraint.target_id] = new_key
+            self._outcomes.append(_Outcome(constraint, True, EFFECT_SPLIT, "", source_cluster_id))
+        return groups
+
+    def report(self, entrypoints: list[dict[str, Any]]) -> dict[str, Any]:
+        entrypoint_by_member = self._entrypoint_by_member(entrypoints)
+        applied = [outcome for outcome in self._outcomes if outcome.applied]
+        ignored = [outcome for outcome in self._outcomes if not outcome.applied]
+        merge_count = sum(1 for outcome in applied if outcome.effect == EFFECT_MERGED)
+        split_count = sum(1 for outcome in applied if outcome.effect == EFFECT_SPLIT)
+        return {
+            "workflowConstraintCount": self._constraint_count,
+            "appliedWorkflowConstraintCount": len(applied),
+            "ignoredWorkflowConstraintCount": len(ignored),
+            "workflowMergeByFeedbackCount": merge_count,
+            "workflowSplitByFeedbackCount": split_count,
+            "workflowFeedback": {
+                "applied": [self._applied_detail(outcome, entrypoint_by_member) for outcome in applied],
+                "ignored": [self._ignored_detail(outcome) for outcome in ignored],
+            },
+        }
+
+    @staticmethod
+    def _entrypoint_by_member(entrypoints: list[dict[str, Any]]) -> dict[str, Any]:
+        lookup: dict[str, Any] = {}
+        for entrypoint in entrypoints:
+            entry_point_id = entrypoint.get("entryPointId")
+            for member in _string_list(entrypoint.get("memberConversationIds")):
+                lookup[member] = entry_point_id
+        return lookup
+
+    @staticmethod
+    def _applied_detail(outcome: _Outcome, entrypoint_by_member: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "sourceId": outcome.constraint.source_id,
+            "targetId": outcome.constraint.target_id,
+            "type": outcome.constraint.type,
+            "effect": outcome.effect,
+            "sourceClusterId": outcome.source_cluster_id,
+            "sourceEntryPointId": entrypoint_by_member.get(outcome.constraint.source_id),
+            "targetEntryPointId": entrypoint_by_member.get(outcome.constraint.target_id),
+        }
+
+    @staticmethod
+    def _ignored_detail(outcome: _Outcome) -> dict[str, Any]:
+        return {
+            "sourceId": outcome.constraint.source_id,
+            "targetId": outcome.constraint.target_id,
+            "type": outcome.constraint.type,
+            "reason": outcome.reason,
+        }
+
+
+__all__ = ["WorkflowFeedbackReconciler"]

--- a/ml/src/pipeline/stages/intent_discovery/feedback_constraints.py
+++ b/ml/src/pipeline/stages/intent_discovery/feedback_constraints.py
@@ -9,6 +9,14 @@ from typing import Any, Literal, cast
 from pipeline.common.exceptions import PipelineStageError
 
 ConstraintType = Literal["must_link", "cannot_link"]
+WorkflowConstraintType = Literal["same_workflow", "separate_workflow"]
+
+# backend가 emit하는 workflow 결정 값 → 정규화된 workflow constraint type.
+_WORKFLOW_TYPE_ALIASES: dict[str, WorkflowConstraintType] = {
+    "same_workflow": "same_workflow",
+    "separate_workflow": "separate_workflow",
+    "same_intent_separate_workflow": "separate_workflow",
+}
 
 
 @dataclass(frozen=True)
@@ -22,6 +30,17 @@ class FeedbackConstraint:
     decision_id: str | None = None
 
 
+@dataclass(frozen=True)
+class WorkflowFeedbackConstraint:
+    source_id: str
+    target_id: str
+    type: WorkflowConstraintType
+    confidence: float = 1.0
+    scope: str = "workflow"
+    review_task_id: str | None = None
+    decision_id: str | None = None
+
+
 def load_feedback_constraints_from_env() -> list[FeedbackConstraint]:
     path_value = os.getenv("PIPELINE_FEEDBACK_CONSTRAINTS_PATH", "").strip()
     if not path_value:
@@ -30,13 +49,7 @@ def load_feedback_constraints_from_env() -> list[FeedbackConstraint]:
 
 
 def load_feedback_constraints(path: Path) -> list[FeedbackConstraint]:
-    try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise PipelineStageError(f"Failed to read feedback constraints: {path}") from exc
-    rows = payload.get("constraints") if isinstance(payload, dict) else payload
-    if not isinstance(rows, list):
-        raise PipelineStageError("Feedback constraints must be a list or an object with a constraints list.")
+    rows = _read_constraint_rows(path)
     constraints: list[FeedbackConstraint] = []
     for row in rows:
         if not isinstance(row, dict):
@@ -47,27 +60,79 @@ def load_feedback_constraints(path: Path) -> list[FeedbackConstraint]:
     return constraints
 
 
+def _read_constraint_rows(path: Path) -> list[Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise PipelineStageError(f"Failed to read feedback constraints: {path}") from exc
+    rows = payload.get("constraints") if isinstance(payload, dict) else payload
+    if not isinstance(rows, list):
+        raise PipelineStageError("Feedback constraints must be a list or an object with a constraints list.")
+    return rows
+
+
 def _constraint_from_row(row: dict[str, Any]) -> FeedbackConstraint | None:
+    source_id, target_id = _endpoint_ids(row)
+    raw_type = str(row.get("type") or "").strip().lower()
+    scope = str(row.get("scope") or "intent").strip().lower()
+    if not source_id or not target_id or raw_type not in {"must_link", "cannot_link"} or scope != "intent":
+        return None
+    return FeedbackConstraint(
+        source_id=source_id,
+        target_id=target_id,
+        type=cast(ConstraintType, raw_type),
+        confidence=_bounded_float(row.get("confidence", 1.0), default=1.0),
+        scope=scope,
+        review_task_id=_optional_str(row.get("reviewTaskId") or row.get("review_task_id")),
+        decision_id=_optional_str(row.get("decisionId") or row.get("decision_id")),
+    )
+
+
+def load_workflow_feedback_constraints_from_env() -> list[WorkflowFeedbackConstraint]:
+    path_value = os.getenv("PIPELINE_FEEDBACK_CONSTRAINTS_PATH", "").strip()
+    if not path_value:
+        return []
+    return load_workflow_feedback_constraints(Path(path_value))
+
+
+def load_workflow_feedback_constraints(path: Path) -> list[WorkflowFeedbackConstraint]:
+    rows = _read_constraint_rows(path)
+    constraints: list[WorkflowFeedbackConstraint] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        constraint = _workflow_constraint_from_row(cast(dict[str, Any], row))
+        if constraint is not None:
+            constraints.append(constraint)
+    return constraints
+
+
+def _workflow_constraint_from_row(row: dict[str, Any]) -> WorkflowFeedbackConstraint | None:
+    source_id, target_id = _endpoint_ids(row)
+    raw_type = str(row.get("type") or row.get("decisionType") or "").strip().lower()
+    scope = str(row.get("scope") or "").strip().lower()
+    normalized_type = _WORKFLOW_TYPE_ALIASES.get(raw_type)
+    if not source_id or not target_id or normalized_type is None or scope != "workflow":
+        return None
+    return WorkflowFeedbackConstraint(
+        source_id=source_id,
+        target_id=target_id,
+        type=normalized_type,
+        confidence=_bounded_float(row.get("confidence", 1.0), default=1.0),
+        scope=scope,
+        review_task_id=_optional_str(row.get("reviewTaskId") or row.get("review_task_id")),
+        decision_id=_optional_str(row.get("decisionId") or row.get("decision_id")),
+    )
+
+
+def _endpoint_ids(row: dict[str, Any]) -> tuple[str, str]:
     source_id = str(
         row.get("sourceId") or row.get("source_caselet_id") or row.get("sourceCaseletId") or row.get("source_id") or ""
     ).strip()
     target_id = str(
         row.get("targetId") or row.get("target_caselet_id") or row.get("targetCaseletId") or row.get("target_id") or ""
     ).strip()
-    raw_type = str(row.get("type") or "").strip().lower()
-    scope = str(row.get("scope") or "intent").strip().lower()
-    if not source_id or not target_id or raw_type not in {"must_link", "cannot_link"} or scope != "intent":
-        return None
-    confidence = row.get("confidence", 1.0)
-    return FeedbackConstraint(
-        source_id=source_id,
-        target_id=target_id,
-        type=cast(ConstraintType, raw_type),
-        confidence=_bounded_float(confidence, default=1.0),
-        scope=scope,
-        review_task_id=_optional_str(row.get("reviewTaskId") or row.get("review_task_id")),
-        decision_id=_optional_str(row.get("decisionId") or row.get("decision_id")),
-    )
+    return source_id, target_id
 
 
 def _bounded_float(value: object, *, default: float) -> float:
@@ -83,4 +148,11 @@ def _optional_str(value: object) -> str | None:
     return text or None
 
 
-__all__ = ["FeedbackConstraint", "load_feedback_constraints", "load_feedback_constraints_from_env"]
+__all__ = [
+    "FeedbackConstraint",
+    "WorkflowFeedbackConstraint",
+    "load_feedback_constraints",
+    "load_feedback_constraints_from_env",
+    "load_workflow_feedback_constraints",
+    "load_workflow_feedback_constraints_from_env",
+]

--- a/ml/tests/stages/test_feedback_constraints.py
+++ b/ml/tests/stages/test_feedback_constraints.py
@@ -3,7 +3,15 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from pipeline.stages.intent_discovery.feedback_constraints import load_feedback_constraints
+from pipeline.stages.intent_discovery.feedback_constraints import (
+    load_feedback_constraints,
+    load_workflow_feedback_constraints,
+)
+
+
+def _write(path: Path, constraints: list[dict[str, object]]) -> Path:
+    path.write_text(json.dumps({"constraints": constraints}), encoding="utf-8")
+    return path
 
 
 def test_load_feedback_constraints_accepts_review_schema(tmp_path: Path) -> None:
@@ -55,3 +63,49 @@ def test_load_feedback_constraints_ignores_non_intent_scope(tmp_path: Path) -> N
     )
 
     assert load_feedback_constraints(path) == []
+
+
+def test_intent_loader_ignores_workflow_scope(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path / "constraints.json",
+        [{"sourceId": "c1", "targetId": "c2", "type": "same_workflow", "scope": "workflow"}],
+    )
+
+    assert load_feedback_constraints(path) == []
+
+
+def test_workflow_loader_parses_workflow_scope_only(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path / "constraints.json",
+        [
+            {"sourceId": "c1", "targetId": "c2", "type": "same_workflow", "scope": "workflow"},
+            {
+                "sourceId": "c3",
+                "targetId": "c4",
+                "type": "same_intent_separate_workflow",
+                "scope": "workflow",
+                "reviewTaskId": 9,
+                "decisionId": 12,
+            },
+            {"sourceId": "c5", "targetId": "c6", "type": "must_link", "scope": "intent"},
+            {"sourceId": "c7", "targetId": "c8", "type": "different_intent", "scope": "intent"},
+        ],
+    )
+
+    constraints = load_workflow_feedback_constraints(path)
+
+    assert [(c.source_id, c.target_id, c.type) for c in constraints] == [
+        ("c1", "c2", "same_workflow"),
+        ("c3", "c4", "separate_workflow"),
+    ]
+    assert constraints[1].review_task_id == "9"
+    assert constraints[1].decision_id == "12"
+
+
+def test_workflow_loader_ignores_unknown_type(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path / "constraints.json",
+        [{"sourceId": "c1", "targetId": "c2", "type": "cannot_link", "scope": "workflow"}],
+    )
+
+    assert load_workflow_feedback_constraints(path) == []

--- a/ml/tests/stages/test_flow_splitting_stage_run.py
+++ b/ml/tests/stages/test_flow_splitting_stage_run.py
@@ -126,6 +126,138 @@ def test_flow_splitting_creates_entrypoints_and_split_clusters(monkeypatch, tmp_
     assert clusters["clusters"][1]["workflow_signal"]["has_escalation_cases"] is True
 
 
+def _write_signal_split_fixture(artifact_root: Path) -> Path:
+    base_dir = artifact_root / "domain_pack_generation" / "manual__run"
+    intent_dir = base_dir / "intent_discovery"
+    preprocessing_dir = base_dir / "preprocessing"
+    intent_dir.mkdir(parents=True)
+    preprocessing_dir.mkdir(parents=True)
+    (intent_dir / "clusters.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "clusters": [
+                    {
+                        "cluster_id": 7,
+                        "member_indices": [0, 1, 2, 3, 4, 5],
+                        "member_conv_ids": ["c1", "c2", "c3", "c4", "c5", "c6"],
+                        "exemplar_conv_ids": ["c1", "c4"],
+                        "suggested_name": "배송 문의",
+                        "workflow_signal": {"has_escalation_cases": True},
+                        "quality": {
+                            "interpretability_score": 0.8,
+                            "workflow_consistency_score": 0.7,
+                            "branching_explainability_score": 0.6,
+                        },
+                    }
+                ],
+                "stats": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    np.save(
+        intent_dir / "embeddings.npy",
+        np.asarray(
+            [[1.00, 0.00], [0.98, 0.02], [0.96, 0.04], [0.00, 1.00], [0.02, 0.98], [0.04, 0.96]],
+            dtype=np.float32,
+        ),
+    )
+    (preprocessing_dir / "preprocessed_data.json").write_text(
+        json.dumps(
+            {
+                "conversations": [
+                    {"id": "c1", "ended_status": "resolved", "workflow_signal": {"requires_payment_check": True}},
+                    {"id": "c2", "ended_status": "resolved", "workflow_signal": {"requires_payment_check": True}},
+                    {"id": "c3", "ended_status": "resolved", "workflow_signal": {"requires_payment_check": True}},
+                    {"id": "c4", "ended_status": "escalated", "workflow_signal": {"has_escalation_cases": True}},
+                    {"id": "c5", "ended_status": "escalated", "workflow_signal": {"has_escalation_cases": True}},
+                    {"id": "c6", "ended_status": "escalated", "workflow_signal": {"has_escalation_cases": True}},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    upstream_manifest = intent_dir / "manifest.json"
+    upstream_manifest.write_text(
+        json.dumps(
+            {
+                "dag_id": "domain_pack_generation",
+                "run_id": "manual__run",
+                "workspace_id": "3",
+                "dataset_id": "5",
+                "pipeline_job_id": "11",
+                "payload": {"artifact_path": "clusters.json"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return upstream_manifest
+
+
+def test_flow_splitting_merges_entrypoints_on_same_workflow_feedback(monkeypatch, tmp_path: Path) -> None:
+    artifact_root = tmp_path / "artifacts"
+    monkeypatch.setenv("PIPELINE_ARTIFACT_ROOT", str(artifact_root))
+    monkeypatch.setenv("PIPELINE_BACKEND_BASE_URL", "http://backend:8080")
+    monkeypatch.setenv("PIPELINE_FLOW_SPLIT_STRATEGY", "signal")
+    monkeypatch.setenv("PIPELINE_FLOW_MIN_SPLIT_SIZE", "3")
+    upstream_manifest = _write_signal_split_fixture(artifact_root)
+    constraints_path = tmp_path / "feedback_constraints.json"
+    constraints_path.write_text(
+        json.dumps(
+            {"constraints": [{"sourceId": "c1", "targetId": "c4", "type": "same_workflow", "scope": "workflow"}]}
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PIPELINE_FEEDBACK_CONSTRAINTS_PATH", str(constraints_path))
+
+    result = run(str(upstream_manifest))
+
+    output_dir = Path(cast(str, result["artifact_manifest_path"])).parent
+    entrypoints = json.loads((output_dir / "workflow_entrypoints.json").read_text(encoding="utf-8"))
+    report = json.loads((output_dir / "flow_split_report.json").read_text(encoding="utf-8"))
+
+    assert len(entrypoints["workflowEntryPoints"]) == 1
+    assert sorted(entrypoints["workflowEntryPoints"][0]["memberConversationIds"]) == [
+        "c1",
+        "c2",
+        "c3",
+        "c4",
+        "c5",
+        "c6",
+    ]
+    assert report["workflowConstraintCount"] == 1
+    assert report["appliedWorkflowConstraintCount"] == 1
+    assert report["workflowMergeByFeedbackCount"] == 1
+    assert report["workflowSplitByFeedbackCount"] == 0
+    assert report["ignoredWorkflowConstraintCount"] == 0
+    applied = report["workflowFeedback"]["applied"][0]
+    assert applied["effect"] == "merged"
+    assert applied["sourceEntryPointId"] == applied["targetEntryPointId"]
+
+
+def test_flow_splitting_without_feedback_keeps_baseline(monkeypatch, tmp_path: Path) -> None:
+    artifact_root = tmp_path / "artifacts"
+    monkeypatch.setenv("PIPELINE_ARTIFACT_ROOT", str(artifact_root))
+    monkeypatch.setenv("PIPELINE_BACKEND_BASE_URL", "http://backend:8080")
+    monkeypatch.setenv("PIPELINE_FLOW_SPLIT_STRATEGY", "signal")
+    monkeypatch.setenv("PIPELINE_FLOW_MIN_SPLIT_SIZE", "3")
+    monkeypatch.delenv("PIPELINE_FEEDBACK_CONSTRAINTS_PATH", raising=False)
+    upstream_manifest = _write_signal_split_fixture(artifact_root)
+
+    result = run(str(upstream_manifest))
+
+    output_dir = Path(cast(str, result["artifact_manifest_path"])).parent
+    entrypoints = json.loads((output_dir / "workflow_entrypoints.json").read_text(encoding="utf-8"))
+    report = json.loads((output_dir / "flow_split_report.json").read_text(encoding="utf-8"))
+
+    assert len(entrypoints["workflowEntryPoints"]) == 2
+    assert report["workflowConstraintCount"] == 0
+    assert report["appliedWorkflowConstraintCount"] == 0
+    assert report["workflowMergeByFeedbackCount"] == 0
+    assert report["workflowFeedback"]["applied"] == []
+
+
 def test_flow_splitting_rejects_missing_clusters_list(monkeypatch, tmp_path: Path) -> None:
     artifact_root = tmp_path / "artifacts"
     monkeypatch.setenv("PIPELINE_ARTIFACT_ROOT", str(artifact_root))

--- a/ml/tests/stages/test_flow_splitting_workflow_feedback.py
+++ b/ml/tests/stages/test_flow_splitting_workflow_feedback.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pipeline.stages.flow_splitting.workflow_feedback import WorkflowFeedbackReconciler
+from pipeline.stages.intent_discovery.feedback_constraints import WorkflowFeedbackConstraint
+
+
+def _constraint(
+    source: str,
+    target: str,
+    type_: Literal["same_workflow", "separate_workflow"],
+) -> WorkflowFeedbackConstraint:
+    return WorkflowFeedbackConstraint(source_id=source, target_id=target, type=type_)
+
+
+def _cluster(cluster_id: int, members: list[str]) -> dict[str, object]:
+    return {"cluster_id": cluster_id, "member_conv_ids": members}
+
+
+def test_same_workflow_merges_groups() -> None:
+    clusters = [_cluster(1, ["a", "b", "c", "d"])]
+    reconciler = WorkflowFeedbackReconciler([_constraint("a", "c", "same_workflow")], clusters)
+
+    groups = reconciler.reconcile(0, {"g1": ["a", "b"], "g2": ["c", "d"]})
+
+    assert len(groups) == 1
+    merged_members = sorted(next(iter(groups.values())))
+    assert merged_members == ["a", "b", "c", "d"]
+
+    report = reconciler.report([{"entryPointId": "entrypoint-0", "memberConversationIds": merged_members}])
+    assert report["workflowConstraintCount"] == 1
+    assert report["appliedWorkflowConstraintCount"] == 1
+    assert report["workflowMergeByFeedbackCount"] == 1
+    assert report["ignoredWorkflowConstraintCount"] == 0
+    applied = report["workflowFeedback"]["applied"][0]
+    assert applied["effect"] == "merged"
+    assert applied["sourceEntryPointId"] == "entrypoint-0"
+    assert applied["targetEntryPointId"] == "entrypoint-0"
+
+
+def test_same_workflow_already_same_is_applied_without_merge() -> None:
+    clusters = [_cluster(1, ["a", "b"])]
+    reconciler = WorkflowFeedbackReconciler([_constraint("a", "b", "same_workflow")], clusters)
+
+    groups = reconciler.reconcile(0, {"g1": ["a", "b"]})
+
+    assert groups == {"g1": ["a", "b"]}
+    report = reconciler.report([{"entryPointId": "entrypoint-0", "memberConversationIds": ["a", "b"]}])
+    assert report["appliedWorkflowConstraintCount"] == 1
+    assert report["workflowMergeByFeedbackCount"] == 0
+    assert report["workflowFeedback"]["applied"][0]["effect"] == "already_same"
+
+
+def test_separate_workflow_splits_single_group() -> None:
+    clusters = [_cluster(1, ["a", "b", "c"])]
+    reconciler = WorkflowFeedbackReconciler([_constraint("a", "b", "separate_workflow")], clusters)
+
+    groups = reconciler.reconcile(0, {"g1": ["a", "b", "c"]})
+
+    assert len(groups) == 2
+    assert ["b"] in groups.values()
+    report = reconciler.report(
+        [
+            {"entryPointId": "entrypoint-0", "memberConversationIds": ["a", "c"]},
+            {"entryPointId": "entrypoint-1", "memberConversationIds": ["b"]},
+        ]
+    )
+    assert report["workflowSplitByFeedbackCount"] == 1
+    applied = report["workflowFeedback"]["applied"][0]
+    assert applied["effect"] == "split"
+    assert applied["sourceEntryPointId"] == "entrypoint-0"
+    assert applied["targetEntryPointId"] == "entrypoint-1"
+
+
+def test_separate_workflow_already_separate_is_applied_without_split() -> None:
+    clusters = [_cluster(1, ["a", "b"])]
+    reconciler = WorkflowFeedbackReconciler([_constraint("a", "b", "separate_workflow")], clusters)
+
+    groups = reconciler.reconcile(0, {"g1": ["a"], "g2": ["b"]})
+
+    assert groups == {"g1": ["a"], "g2": ["b"]}
+    report = reconciler.report([])
+    assert report["workflowSplitByFeedbackCount"] == 0
+    assert report["workflowFeedback"]["applied"][0]["effect"] == "already_separate"
+
+
+def test_conflicting_separate_after_same_is_ignored() -> None:
+    clusters = [_cluster(1, ["a", "b", "c"])]
+    constraints = [
+        _constraint("a", "b", "same_workflow"),
+        _constraint("a", "b", "separate_workflow"),
+    ]
+    reconciler = WorkflowFeedbackReconciler(constraints, clusters)
+
+    reconciler.reconcile(0, {"g1": ["a"], "g2": ["b"], "g3": ["c"]})
+
+    report = reconciler.report([])
+    assert report["workflowMergeByFeedbackCount"] == 1
+    assert report["ignoredWorkflowConstraintCount"] == 1
+    ignored = report["workflowFeedback"]["ignored"][0]
+    assert ignored["type"] == "separate_workflow"
+    assert ignored["reason"] == "conflicts_with_same_workflow"
+
+
+def test_endpoints_in_different_clusters_are_ignored() -> None:
+    clusters = [_cluster(1, ["a", "b"]), _cluster(2, ["x", "y"])]
+    reconciler = WorkflowFeedbackReconciler([_constraint("a", "x", "same_workflow")], clusters)
+
+    reconciler.reconcile(0, {"g1": ["a", "b"]})
+    reconciler.reconcile(1, {"g1": ["x", "y"]})
+
+    report = reconciler.report([])
+    assert report["appliedWorkflowConstraintCount"] == 0
+    assert report["workflowFeedback"]["ignored"][0]["reason"] == "endpoints_in_different_clusters"
+
+
+def test_endpoint_not_in_any_candidate_is_ignored() -> None:
+    clusters = [_cluster(1, ["a", "b"])]
+    reconciler = WorkflowFeedbackReconciler([_constraint("a", "missing", "same_workflow")], clusters)
+
+    reconciler.reconcile(0, {"g1": ["a", "b"]})
+
+    report = reconciler.report([])
+    assert report["workflowFeedback"]["ignored"][0]["reason"] == "endpoint_not_in_candidate"
+
+
+def test_no_constraints_is_noop() -> None:
+    reconciler = WorkflowFeedbackReconciler([], [_cluster(1, ["a", "b"])])
+
+    groups = reconciler.reconcile(0, {"g1": ["a", "b"]})
+
+    assert groups == {"g1": ["a", "b"]}
+    report = reconciler.report([])
+    assert report["workflowConstraintCount"] == 0
+    assert report["workflowFeedback"]["applied"] == []
+    assert report["workflowFeedback"]["ignored"] == []


### PR DESCRIPTION
Closes #886

## 배경

intent-scope 피드백(`must_link`/`cannot_link`)은 `intent_discovery`의 same-intent graph에 반영되지만, 운영자가 review checkpoint에서 "같은 workflow로 합치기"/"같은 intent지만 workflow 분리"를 선택해도 다음 draft의 workflow entrypoint 구조가 바뀌지 않았다. 두 지점에서 끊겨 있었다.

1. **Backend**: workflow-scope 결정을 `feedback_constraints.json`에 전혀 기록하지 않음(`constraintType`을 빈 문자열로 강제해 emission skip).
2. **ML**: `flow_splitting`이 `PIPELINE_FEEDBACK_CONSTRAINTS_PATH`를 받지도, workflow constraint를 적용하지도 않음.

## 변경

### ML (deliverable)
- `flow_splitting` DAG task에 `PIPELINE_FEEDBACK_CONSTRAINTS_PATH` 전달.
- workflow constraint loader 추가(`load_workflow_feedback_constraints`, intent loader와 row 파서 공용화). `same_intent_separate_workflow` → `separate_workflow` 별칭 수용, `scope:"workflow"`만 파싱.
- `WorkflowFeedbackReconciler`: source cluster 내 flow group을 constraint에 맞게 조정.
  - `same_workflow`: 두 endpoint가 같은 entrypoint에 속하도록 group merge(이미 같으면 `already_same`).
  - `separate_workflow`: 다른 entrypoint로 분리(이미 다르면 `already_separate`).
  - `different_intent`는 intent `cannot_link`로 처리되므로 flow splitting에서 중복 적용하지 않음(loader가 받지 않음).
  - 적용 불가는 reason과 함께 기록: `endpoints_in_different_clusters`, `endpoint_not_in_candidate`, `conflicts_with_same_workflow`.
- artifact metrics에 `workflowConstraintCount` / `appliedWorkflowConstraintCount` / `ignoredWorkflowConstraintCount` / `workflowMergeByFeedbackCount` / `workflowSplitByFeedbackCount`와 적용·무시 상세(`workflowFeedback`) 추가. 적용 항목마다 source/target과 결과 entrypoint id 추적 가능.

### Backend (최소 연동)
- `PipelineReviewCheckpointUseCase`가 workflow 결정을 `scope:"workflow"` + `type:"same_workflow"|"separate_workflow"` constraint로 emit하여 replay 루프가 실제로 동작.

## 품질 근거

- 검토한 패턴: `intent_discovery`의 constraint loader/same-intent graph 반영, `flow_splitting`의 `_flow_groups`/entrypoint 생성, backend feedback constraint emission.
- 3라운드 자체 리뷰(이슈 충실도 / 아키텍처·통합 / CI·테스트) 완료. no-constraint 경로는 reconciler no-op으로 기존 결과 동일.
- 실행한 검증:
  - `cd ml && uv run pytest tests/stages/test_feedback_constraints.py tests/stages/test_flow_splitting_workflow_feedback.py tests/stages/test_flow_splitting_stage_run.py` → 20 passed
  - `cd ml && uv run ruff check . && uv run mypy .` → clean (153 files)
  - flow_splitting/intent/feedback 회귀 198 passed, `tests/test_pipeline.py` 1 passed
  - backend `PipelineReviewCheckpointUseCaseTest` (`--rerun-tasks`) → BUILD SUCCESSFUL, spotless 적용

## 잔여 리스크 / deferral

- `separate_workflow`가 같은 group의 두 endpoint를 분리할 때 target만 파생 group으로 이동하므로 소형(1-member) entrypoint가 생길 수 있다. 운영자의 명시적 hard 결정으로 간주하며 label은 기존 single-member 규칙대로 `needs_review`로 강등된다.

스펙: `.agent/specs/886.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 워크플로우 스코프 피드백 제약(같은 워크플로우/별도 워크플로우)을 처리하여 파이프라인 분할 결과에 반영하는 기능 추가
  * 피드백 제약 로딩 및 적용 결과를 리포트에 기록

* **Tests**
  * 워크플로우 피드백 제약 처리 동작 검증 테스트 추가
  * flow splitting 통합 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->