### PR TITLE
feat(review): #884 도메인 확정 전 confirmed profile 편집 지원

### DIFF
--- a/.agent/specs/884.md
+++ b/.agent/specs/884.md
@@ -1,0 +1,141 @@
+# 884 · 도메인 확정 전 confirmed profile 편집 지원
+
+> Issue: feat(review) 도메인 확정 전 confirmed profile 편집을 지원한다
+> Area: 백엔드(주) + 프론트엔드 + ML (mixed). 백엔드 DDD 템플릿을 기준으로 작성하고 FE/ML 섹션을 분리한다.
+
+---
+
+## Goal
+
+운영자가 domain candidate를 **선택한 뒤** replay 입력으로 넘어갈 `confirmed-domain-profile.v1`의
+핵심 필드(`confirmedDomain`, `displayName`, `description`, `domainLexicon`, `evidenceTerms`,
+선택적 `exclusionTerms`)를 직접 다듬을 수 있게 한다. 후보 payload를 기본값으로 두고 operator override를
+병합해 `CONFIRMED_DOMAIN_PROFILE` artifact와 replay summary에 남긴다.
+
+낮은 confidence이거나 `혼합 또는 미확정`에 가까운 첫 checkpoint에서 잘못된 domain profile이 확정되면
+이후 `intent_discovery -> flow_splitting -> draft_generation`이 잘못된 전제 위에서 진행되는 문제를 사람이 바로잡는다.
+
+---
+
+## Scope
+
+- 백엔드 `confirmDomain` 요청 DTO에 operator override를 추가하고, 후보 payload와 병합해 artifact를 생성한다.
+- 프론트엔드 Domain confirmation UI에서 후보 선택 후 편집 가능한 profile 폼을 제공한다.
+- ML `intent_discovery/domain_profile.py`가 편집된 `domainLexicon`/`evidenceTerms`를 그대로 쓰고,
+  `description`/`exclusionTerms`를 `root_domain_profile.json`에 보존한다.
+- 생성 클라이언트(orval) 재생성: `pnpm run codegen`.
+
+## Non-goals
+
+- domain candidate 생성 로직(`ml/.../domain_candidate_generation`) 변경. 후보 자체는 그대로 둔다.
+- 자동 domain 구조 개선·추천 알고리즘 추가. 이 작업은 사람이 첫 입력 품질을 바로잡는 UX 기반 변경이다.
+- `exclusionTerms`를 same-intent 스코어링에 반영하는 신규 ML feature. 본 이슈에서는 profile에 보존·전달만 한다.
+- 권한 모델 변경. 기존 OWNER/ADMIN/OPERATOR 검사를 그대로 사용한다.
+
+---
+
+## Affected modules (verified paths)
+
+### Backend (`com.init.review`)
+- `backend/src/main/java/com/init/review/presentation/PipelineReviewController.java` — `ConfirmDomainRequest` 확장.
+- `backend/src/main/java/com/init/review/application/PipelineReviewCheckpointUseCase.java` — `ConfirmDomainCommand`,
+  `confirmDomain` 병합 로직, `CONFIRMED_DOMAIN_PROFILE` artifact 필드 확장.
+- `backend/src/test/java/com/init/review/application/PipelineReviewCheckpointUseCaseTest.java`
+- `backend/src/test/java/com/init/review/presentation/PipelineReviewControllerTest.java`
+
+### Frontend (`features/pipeline-review`)
+- `frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.tsx`
+- `frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.module.css`
+- `frontend/src/features/pipeline-review/api/pipelineReviewApi.ts`
+- `frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.test.tsx`
+- 재생성: `frontend/src/shared/api/generated/**` (orval), `frontend/src/shared/api/generated/.codegen-meta.json`
+
+### ML (`intent_discovery`)
+- `ml/src/pipeline/stages/intent_discovery/domain_profile.py`
+- `ml/tests/stages/test_intent_discovery_domain_profile.py`
+
+---
+
+## Data / API impact
+
+### `confirmed-domain-profile.v1` artifact (현행 → 변경)
+
+현행 `confirmDomain`은 선택 후보를 그대로 transcribe한다. 변경 후 operator override가 있으면 그 값을, 없으면
+후보 값을 사용한다. 신규 필드 `description`, `exclusionTerms`를 추가한다(하위호환: 없으면 후보/빈 배열).
+
+```json
+{
+  "schemaVersion": "confirmed-domain-profile.v1",
+  "candidateId": "card",
+  "confirmedDomain": "카드 상담",        // override 우선, 없으면 후보 displayName
+  "displayName": "카드 상담",            // override 우선, 없으면 후보 displayName
+  "description": "카드 분실·결제·한도 문의", // 신규: override 우선, 없으면 후보 description
+  "confidence": 0.92,                    // 후보값 유지(편집 대상 아님)
+  "evidenceTerms": ["분실", "한도"],      // override 우선, 없으면 후보 evidenceTerms
+  "evidenceConversationIds": ["c1"],     // 후보값 유지
+  "domainLexicon": ["카드", "결제"],      // override 우선, 없으면 후보 suggestedDomainLexicon
+  "exclusionTerms": ["배송"],            // 신규: override만, 없으면 [] (생략 가능)
+  "sourceReviewTaskId": 101,
+  "confirmedBy": 9
+}
+```
+
+### REST 요청 (`POST .../review-checkpoint/domain-confirmation`)
+
+`ConfirmDomainRequest`에 선택적 override 필드를 추가한다. **모두 optional** → 후보 선택만 보내는 기존 요청도
+동일하게 동작한다(하위호환).
+
+```json
+{
+  "reviewTaskId": 101,
+  "reason": "대표 도메인",
+  "confirmedDomain": "카드 상담",
+  "displayName": "카드 상담",
+  "description": "카드 분실·결제·한도 문의",
+  "domainLexicon": ["카드", "결제"],
+  "evidenceTerms": ["분실", "한도"],
+  "exclusionTerms": ["배송"]
+}
+```
+
+병합 규칙(백엔드):
+- 문자열 필드(`confirmedDomain`/`displayName`/`description`): override가 non-blank이면 그 값, 아니면 후보값.
+- 리스트 필드(`domainLexicon`/`evidenceTerms`): override가 non-null이면 그 리스트(빈 리스트 = 의도적 비움 허용),
+  null이면 후보값. trim 후 빈 항목 제거.
+- `exclusionTerms`: override가 non-null이면 그 리스트, 아니면 빈 배열.
+- `confidence`, `evidenceConversationIds`, `candidateId`: 후보값 유지.
+
+### ML `root_domain_profile.json`
+
+`load_confirmed_domain_profile`은 이미 `domainLexicon`/`evidenceTerms`를 읽고 `method=llm_confirmed_domain.v1`,
+`usesOperatorCategoryMetadata=true`를 설정한다. 변경: `domain_evidence`에 `description`과 `exclusionTerms`를 보존해
+산출물에 operator 편집이 남게 한다.
+
+---
+
+## Acceptance criteria
+
+1. 운영자는 후보 선택 후 `confirmedDomain`/`displayName`/`description`/`domainLexicon`/`evidenceTerms`
+   (+선택 `exclusionTerms`)를 폼에서 수정할 수 있다.
+2. 후보를 선택하지 않으면 확정 버튼이 비활성이며 확정 요청을 보낼 수 없다.
+3. 확정 후 `CONFIRMED_DOMAIN_PROFILE` artifact와 replay summary에 operator-edited profile이 남는다.
+4. replay 산출물 `root_domain_profile.json`에서 `method=llm_confirmed_domain.v1`,
+   `usesOperatorCategoryMetadata=true`가 확인되며, 편집된 `domainLexicon`/`evidenceTerms`가 반영된다.
+5. `reviewTaskId`(+`reason`)만 보내는 기존 요청도 동일하게 동작한다(하위호환).
+
+---
+
+## Validation
+
+| 스택 | 명령 | 검증 대상 |
+|---|---|---|
+| Backend | `pnpm run ci:backend` | confirmDomain 병합/하위호환, controller 매핑 |
+| Frontend | `pnpm --dir frontend test`, `pnpm --dir frontend build` | 편집 폼 상호작용, 선택 강제, override payload |
+| ML | `pnpm run ci:ml` (또는 `pytest ml/tests/stages/test_intent_discovery_domain_profile.py`) | description/exclusionTerms 보존 |
+| Codegen | `pnpm run codegen` | OpenAPI drift 없음, 생성 client에 override 필드 반영 |
+
+---
+
+## Open questions
+
+- `exclusionTerms`의 향후 ML 활용(예: same-intent 음의 신호) 범위는 별도 이슈로 둔다. 본 이슈는 보존·전달까지.

--- a/backend/src/main/java/com/init/review/application/PipelineReviewCheckpointUseCase.java
+++ b/backend/src/main/java/com/init/review/application/PipelineReviewCheckpointUseCase.java
@@ -42,6 +42,7 @@ public class PipelineReviewCheckpointUseCase {
   private static final String ARTIFACT_FEEDBACK_CONSTRAINTS = "FEEDBACK_CONSTRAINTS";
   private static final String FIELD_CONFIDENCE = "confidence";
   private static final String FIELD_DISPLAY_NAME = "displayName";
+  private static final String FIELD_DESCRIPTION = "description";
   private static final Set<String> ALLOWED_REVIEW_ROLES = Set.of("OWNER", "ADMIN", "OPERATOR");
 
   private final PipelineJobRepository pipelineJobRepository;
@@ -108,17 +109,7 @@ public class PipelineReviewCheckpointUseCase {
     ReviewTask selectedTask =
         openTaskForSession(session, command.reviewTaskId(), ReviewTask.TARGET_DOMAIN_CANDIDATE);
     JsonNode candidate = jsonSupport.readJson(selectedTask.getTargetRefJson());
-    ObjectNode profile = jsonSupport.objectNode();
-    profile.put("schemaVersion", "confirmed-domain-profile.v1");
-    profile.put("candidateId", jsonSupport.text(candidate, "candidateId"));
-    profile.put("confirmedDomain", jsonSupport.text(candidate, FIELD_DISPLAY_NAME));
-    profile.put(FIELD_DISPLAY_NAME, jsonSupport.text(candidate, FIELD_DISPLAY_NAME));
-    profile.put(FIELD_CONFIDENCE, jsonSupport.number(candidate, FIELD_CONFIDENCE));
-    profile.set("evidenceTerms", candidate.path("evidenceTerms"));
-    profile.set("evidenceConversationIds", candidate.path("evidenceConversationIds"));
-    profile.set("domainLexicon", candidate.path("suggestedDomainLexicon"));
-    profile.put("sourceReviewTaskId", selectedTask.getId());
-    profile.put("confirmedBy", command.userId());
+    ObjectNode profile = buildConfirmedDomainProfile(candidate, selectedTask, command);
 
     OffsetDateTime now = OffsetDateTime.now(clock);
     selectedTask.resolve(command.userId(), now);
@@ -153,6 +144,75 @@ public class PipelineReviewCheckpointUseCase {
                 now));
     replayOrchestrator.triggerDomainConfirmedReplay(job, artifact.getPayloadJson());
     return ReviewCheckpointResult.of(session.getId(), "DOMAIN_CONFIRMED_REPLAY_TRIGGERED");
+  }
+
+  /**
+   * 선택한 candidate payload를 기본값으로 두고 operator override를 병합해 {@code confirmed-domain-profile.v1}을
+   * 만든다. override 필드가 비어 있으면 candidate 값을 유지하므로 candidate 선택만 보내는 기존 요청도 동일하게 동작한다.
+   */
+  private ObjectNode buildConfirmedDomainProfile(
+      JsonNode candidate, ReviewTask selectedTask, ConfirmDomainCommand command) {
+    DomainProfileOverride override =
+        command.profileOverride() == null
+            ? DomainProfileOverride.empty()
+            : command.profileOverride();
+    String candidateDisplayName = jsonSupport.text(candidate, FIELD_DISPLAY_NAME);
+    ObjectNode profile = jsonSupport.objectNode();
+    profile.put("schemaVersion", "confirmed-domain-profile.v1");
+    profile.put("candidateId", jsonSupport.text(candidate, "candidateId"));
+    profile.put(
+        "confirmedDomain", overrideOrFallback(override.confirmedDomain(), candidateDisplayName));
+    profile.put(
+        FIELD_DISPLAY_NAME, overrideOrFallback(override.displayName(), candidateDisplayName));
+    profile.put(
+        FIELD_DESCRIPTION,
+        overrideOrFallback(override.description(), jsonSupport.text(candidate, FIELD_DESCRIPTION)));
+    profile.put(FIELD_CONFIDENCE, jsonSupport.number(candidate, FIELD_CONFIDENCE));
+    profile.set(
+        "evidenceTerms", mergeTermList(override.evidenceTerms(), candidate.path("evidenceTerms")));
+    profile.set("evidenceConversationIds", candidate.path("evidenceConversationIds"));
+    profile.set(
+        "domainLexicon",
+        mergeTermList(override.domainLexicon(), candidate.path("suggestedDomainLexicon")));
+    profile.set("exclusionTerms", sanitizeTerms(override.exclusionTerms()));
+    profile.put("sourceReviewTaskId", selectedTask.getId());
+    profile.put("confirmedBy", command.userId());
+    return profile;
+  }
+
+  private String overrideOrFallback(String overrideValue, String candidateValue) {
+    return overrideValue != null && !overrideValue.isBlank()
+        ? overrideValue.trim()
+        : candidateValue;
+  }
+
+  /** override list가 주어지면(빈 list 포함, 의도적 비움 허용) 그것을, 아니면 candidate array를 사용한다. */
+  private ArrayNode mergeTermList(List<String> override, JsonNode candidateTerms) {
+    if (override != null) {
+      return sanitizeTerms(override);
+    }
+    ArrayNode array = jsonSupport.arrayNode();
+    if (candidateTerms != null && candidateTerms.isArray()) {
+      for (JsonNode term : candidateTerms) {
+        String value = term.asText("").trim();
+        if (!value.isBlank()) {
+          array.add(value);
+        }
+      }
+    }
+    return array;
+  }
+
+  private ArrayNode sanitizeTerms(List<String> terms) {
+    ArrayNode array = jsonSupport.arrayNode();
+    if (terms != null) {
+      for (String term : terms) {
+        if (term != null && !term.isBlank()) {
+          array.add(term.trim());
+        }
+      }
+    }
+    return array;
   }
 
   @Transactional
@@ -456,7 +516,25 @@ public class PipelineReviewCheckpointUseCase {
   public record CheckpointCallbackResult(String status, String externalEventId) {}
 
   public record ConfirmDomainCommand(
-      Long workspaceId, Long pipelineJobId, Long reviewTaskId, Long userId, String reason) {}
+      Long workspaceId,
+      Long pipelineJobId,
+      Long reviewTaskId,
+      Long userId,
+      String reason,
+      DomainProfileOverride profileOverride) {}
+
+  /** 운영자가 candidate를 다듬은 값. 모든 필드 optional이며 null이면 candidate 값을 유지한다(하위호환). */
+  public record DomainProfileOverride(
+      String confirmedDomain,
+      String displayName,
+      String description,
+      List<String> domainLexicon,
+      List<String> evidenceTerms,
+      List<String> exclusionTerms) {
+    public static DomainProfileOverride empty() {
+      return new DomainProfileOverride(null, null, null, null, null, null);
+    }
+  }
 
   public record SubmitFeedbackCommand(
       Long workspaceId, Long pipelineJobId, Long userId, List<FeedbackDecisionInput> decisions) {}

--- a/backend/src/main/java/com/init/review/presentation/PipelineReviewController.java
+++ b/backend/src/main/java/com/init/review/presentation/PipelineReviewController.java
@@ -45,7 +45,18 @@ public class PipelineReviewController {
     return ResponseEntity.ok(
         useCase.confirmDomain(
             new PipelineReviewCheckpointUseCase.ConfirmDomainCommand(
-                workspaceId, pipelineJobId, request.reviewTaskId(), userId, request.reason())));
+                workspaceId,
+                pipelineJobId,
+                request.reviewTaskId(),
+                userId,
+                request.reason(),
+                new PipelineReviewCheckpointUseCase.DomainProfileOverride(
+                    request.confirmedDomain(),
+                    request.displayName(),
+                    request.description(),
+                    request.domainLexicon(),
+                    request.evidenceTerms(),
+                    request.exclusionTerms()))));
   }
 
   @PostMapping("/human-feedback")
@@ -71,7 +82,15 @@ public class PipelineReviewController {
                     .toList())));
   }
 
-  public record ConfirmDomainRequest(@NotNull Long reviewTaskId, String reason) {}
+  public record ConfirmDomainRequest(
+      @NotNull Long reviewTaskId,
+      String reason,
+      String confirmedDomain,
+      String displayName,
+      String description,
+      List<String> domainLexicon,
+      List<String> evidenceTerms,
+      List<String> exclusionTerms) {}
 
   public record SubmitFeedbackRequest(@NotEmpty List<@Valid FeedbackDecisionRequest> decisions) {}
 

--- a/backend/src/test/java/com/init/review/application/PipelineReviewCheckpointUseCaseTest.java
+++ b/backend/src/test/java/com/init/review/application/PipelineReviewCheckpointUseCaseTest.java
@@ -274,7 +274,8 @@ class PipelineReviewCheckpointUseCaseTest {
 
     PipelineReviewCheckpointUseCase.ReviewCheckpointResult result =
         useCase.confirmDomain(
-            new PipelineReviewCheckpointUseCase.ConfirmDomainCommand(1L, 7L, 101L, 9L, "대표 도메인"));
+            new PipelineReviewCheckpointUseCase.ConfirmDomainCommand(
+                1L, 7L, 101L, 9L, "대표 도메인", null));
 
     ArgumentCaptor<DomainPackGenerationTriggerCommand> triggerCaptor =
         ArgumentCaptor.forClass(DomainPackGenerationTriggerCommand.class);
@@ -286,8 +287,90 @@ class PipelineReviewCheckpointUseCaseTest {
     assertThat(other.getStatus()).isEqualTo(ReviewTask.STATUS_RESOLVED);
     assertThat(job.getStatus()).isEqualTo(PipelineJob.STATUS_RUNNING);
     assertThat(triggerCaptor.getValue().runMode()).isEqualTo("DOMAIN_CONFIRMED_REPLAY");
-    assertThat(triggerCaptor.getValue().confirmedDomainProfileJson()).contains("카드 상담");
     assertThat(triggerCaptor.getValue().skipFeedbackCheckpoint()).isFalse();
+
+    JsonNode profile = objectMapper.readTree(triggerCaptor.getValue().confirmedDomainProfileJson());
+    assertThat(profile.path("confirmedDomain").asText()).isEqualTo("카드 상담");
+    assertThat(profile.path("displayName").asText()).isEqualTo("카드 상담");
+    assertThat(termList(profile, "domainLexicon")).containsExactly("카드", "결제");
+    assertThat(termList(profile, "evidenceTerms")).containsExactly("분실", "한도");
+    assertThat(profile.path("exclusionTerms").isArray()).isTrue();
+    assertThat(profile.path("exclusionTerms")).isEmpty();
+  }
+
+  @Test
+  @DisplayName("confirm domain merges operator-edited profile fields over the candidate payload")
+  void confirmDomain_appliesOperatorOverride() throws Exception {
+    PipelineJob job =
+        job(
+            PipelineJob.STATUS_WAITING_DOMAIN_CONFIRMATION,
+            "{\"upstreamManifestPath\":\"/artifacts/initial/manifest.json\"}");
+    ReviewSession session =
+        session(ReviewSession.KIND_DOMAIN_CONFIRMATION, ReviewSession.STATUS_OPEN, 55L);
+    ReviewTask selected =
+        task(
+            101L,
+            ReviewTask.TARGET_DOMAIN_CANDIDATE,
+            """
+            {
+              "candidateId": "card",
+              "displayName": "카드 상담",
+              "confidence": 0.92,
+              "evidenceTerms": ["분실", "한도"],
+              "evidenceConversationIds": ["c1"],
+              "suggestedDomainLexicon": ["카드", "결제"]
+            }
+            """);
+
+    givenReviewAccess(job);
+    given(
+            reviewSessionRepository.findFirstByPipelineJobIdAndReviewKindOrderByOpenedAtDesc(
+                7L, ReviewSession.KIND_DOMAIN_CONFIRMATION))
+        .willReturn(Optional.of(session));
+    given(reviewTaskRepository.findById(101L)).willReturn(Optional.of(selected));
+    given(reviewTaskRepository.findByReviewSessionIdOrderByIdAsc(55L))
+        .willReturn(List.of(selected));
+    given(reviewDecisionRepository.save(any(ReviewDecision.class)))
+        .willAnswer(invocation -> invocation.getArgument(0));
+    given(pipelineArtifactRepository.save(any(PipelineArtifact.class)))
+        .willAnswer(invocation -> invocation.getArgument(0));
+    given(triggerPort.trigger(any(DomainPackGenerationTriggerCommand.class)))
+        .willReturn(new DomainPackGenerationTriggerResult("domain_pack_generation", "run-3"));
+
+    useCase.confirmDomain(
+        new PipelineReviewCheckpointUseCase.ConfirmDomainCommand(
+            1L,
+            7L,
+            101L,
+            9L,
+            "운영자 수정",
+            new PipelineReviewCheckpointUseCase.DomainProfileOverride(
+                "신용카드 분실/도난",
+                "신용카드 분실/도난",
+                "분실·도난 신고와 재발급 중심 상담",
+                List.of("재발급", "도난신고"),
+                List.of("분실", "도난", " "),
+                List.of("배송", ""))));
+
+    ArgumentCaptor<DomainPackGenerationTriggerCommand> triggerCaptor =
+        ArgumentCaptor.forClass(DomainPackGenerationTriggerCommand.class);
+    verify(triggerPort).trigger(triggerCaptor.capture());
+
+    JsonNode profile = objectMapper.readTree(triggerCaptor.getValue().confirmedDomainProfileJson());
+    assertThat(profile.path("confirmedDomain").asText()).isEqualTo("신용카드 분실/도난");
+    assertThat(profile.path("displayName").asText()).isEqualTo("신용카드 분실/도난");
+    assertThat(profile.path("description").asText()).isEqualTo("분실·도난 신고와 재발급 중심 상담");
+    assertThat(termList(profile, "domainLexicon")).containsExactly("재발급", "도난신고");
+    assertThat(termList(profile, "evidenceTerms")).containsExactly("분실", "도난");
+    assertThat(termList(profile, "exclusionTerms")).containsExactly("배송");
+    assertThat(profile.path("candidateId").asText()).isEqualTo("card");
+    assertThat(profile.path("confidence").asDouble()).isEqualTo(0.92);
+  }
+
+  private static List<String> termList(JsonNode profile, String fieldName) {
+    List<String> values = new java.util.ArrayList<>();
+    profile.path(fieldName).forEach(term -> values.add(term.asText()));
+    return values;
   }
 
   @Test
@@ -303,7 +386,7 @@ class PipelineReviewCheckpointUseCaseTest {
             () ->
                 useCase.confirmDomain(
                     new PipelineReviewCheckpointUseCase.ConfirmDomainCommand(
-                        1L, 7L, 101L, 9L, "대표 도메인")))
+                        1L, 7L, 101L, 9L, "대표 도메인", null)))
         .isInstanceOf(QuotaExceededException.class);
 
     verify(triggerPort, never()).trigger(any(DomainPackGenerationTriggerCommand.class));
@@ -349,7 +432,7 @@ class PipelineReviewCheckpointUseCaseTest {
             () ->
                 useCase.confirmDomain(
                     new PipelineReviewCheckpointUseCase.ConfirmDomainCommand(
-                        1L, 7L, 101L, 9L, "대표 도메인")))
+                        1L, 7L, 101L, 9L, "대표 도메인", null)))
         .isInstanceOf(AirflowTriggerFailedException.class);
 
     verify(failurePersistenceService).markFailed(eq(job), eq("airflow offline"), eq(NOW));

--- a/backend/src/test/java/com/init/review/presentation/PipelineReviewControllerTest.java
+++ b/backend/src/test/java/com/init/review/presentation/PipelineReviewControllerTest.java
@@ -45,7 +45,18 @@ class PipelineReviewControllerTest {
         .willReturn(new PipelineReviewCheckpointUseCase.ReviewCheckpointResult(55L, "TRIGGERED"));
 
     controller.confirmDomain(
-        1L, 7L, new PipelineReviewController.ConfirmDomainRequest(101L, "대표 도메인"), auth());
+        1L,
+        7L,
+        new PipelineReviewController.ConfirmDomainRequest(
+            101L,
+            "대표 도메인",
+            "신용카드 분실/도난",
+            "신용카드 분실/도난",
+            "분실·도난 신고 중심 상담",
+            List.of("재발급", "도난신고"),
+            List.of("분실", "도난"),
+            List.of("배송")),
+        auth());
 
     ArgumentCaptor<PipelineReviewCheckpointUseCase.ConfirmDomainCommand> captor =
         ArgumentCaptor.forClass(PipelineReviewCheckpointUseCase.ConfirmDomainCommand.class);
@@ -55,6 +66,13 @@ class PipelineReviewControllerTest {
     assertThat(captor.getValue().reviewTaskId()).isEqualTo(101L);
     assertThat(captor.getValue().userId()).isEqualTo(9L);
     assertThat(captor.getValue().reason()).isEqualTo("대표 도메인");
+    PipelineReviewCheckpointUseCase.DomainProfileOverride override =
+        captor.getValue().profileOverride();
+    assertThat(override.confirmedDomain()).isEqualTo("신용카드 분실/도난");
+    assertThat(override.description()).isEqualTo("분실·도난 신고 중심 상담");
+    assertThat(override.domainLexicon()).containsExactly("재발급", "도난신고");
+    assertThat(override.evidenceTerms()).containsExactly("분실", "도난");
+    assertThat(override.exclusionTerms()).containsExactly("배송");
   }
 
   @Test

--- a/frontend/e2e/support/app-mocks.ts
+++ b/frontend/e2e/support/app-mocks.ts
@@ -1710,7 +1710,16 @@ async function fulfillUploadAndReview(
     method === "POST" &&
     path === "/workspaces/1/pipeline-jobs/900/review-checkpoint/domain-confirmation"
   ) {
-    expect(route.request().postDataJSON()).toEqual({ reviewTaskId: 9101 });
+    // 후보 선택과 함께 운영자가 다듬은 profile override가 전송된다.
+    expect(route.request().postDataJSON()).toEqual({
+      reviewTaskId: 9101,
+      confirmedDomain: "환불 상담",
+      displayName: "환불/결제 도메인",
+      description: "결제 취소, 환불 조건, 주문번호 확인 상담이 포함됩니다.",
+      domainLexicon: [],
+      evidenceTerms: ["환불", "취소", "결제", "주문번호"],
+      exclusionTerms: ["배송"],
+    });
     await fulfillJson(route, { data: { accepted: true }, status: 200 });
     return true;
   }

--- a/frontend/e2e/workspace-core.spec.ts
+++ b/frontend/e2e/workspace-core.spec.ts
@@ -501,7 +501,12 @@ test.describe("Workspace core operator screens", () => {
         await captureScreen(page, testInfo, "pipeline-domain-review");
 
         await page.getByRole("button", { name: /환불\/결제 도메인/ }).click();
-        await expect(page.getByText(/이 선택은 intent clustering 입력으로 반영되며/)).toBeVisible();
+        await expect(page.getByText(/intent clustering 입력으로 반영되며/)).toBeVisible();
+        // 후보 값으로 시드된 편집 폼을 운영자가 다듬을 수 있다.
+        const domainNameField = page.getByLabel("도메인명");
+        await expect(domainNameField).toHaveValue("환불/결제 도메인");
+        await domainNameField.fill("환불 상담");
+        await page.getByLabel("제외 키워드 (선택)").fill("배송");
         expect(seen).not.toContain(
           "POST /workspaces/1/pipeline-jobs/900/review-checkpoint/domain-confirmation",
         );

--- a/frontend/src/features/pipeline-review/api/pipelineReviewApi.test.tsx
+++ b/frontend/src/features/pipeline-review/api/pipelineReviewApi.test.tsx
@@ -126,7 +126,7 @@ describe("pipelineReviewApi", () => {
     expect(mockedGetCheckpoint).not.toHaveBeenCalled();
   });
 
-  it("posts selected domain candidate via generated confirmDomain", async () => {
+  it("posts selected domain candidate and operator-edited profile via generated confirmDomain", async () => {
     mockedConfirmDomain.mockResolvedValueOnce({
       data: { status: "DOMAIN_CONFIRMED_REPLAY_TRIGGERED" },
       status: 200,
@@ -135,10 +135,20 @@ describe("pipelineReviewApi", () => {
     const { result } = renderHook(() => useConfirmPipelineDomain(1, 7), { wrapper });
 
     await act(async () => {
-      await result.current.mutateAsync(11);
+      await result.current.mutateAsync({
+        reviewTaskId: 11,
+        confirmedDomain: "신용카드 분실/도난",
+        domainLexicon: ["재발급"],
+        exclusionTerms: ["배송"],
+      });
     });
 
-    expect(mockedConfirmDomain).toHaveBeenCalledWith(1, 7, { reviewTaskId: 11 });
+    expect(mockedConfirmDomain).toHaveBeenCalledWith(1, 7, {
+      reviewTaskId: 11,
+      confirmedDomain: "신용카드 분실/도난",
+      domainLexicon: ["재발급"],
+      exclusionTerms: ["배송"],
+    });
   });
 
   it("posts feedback decisions via generated submitFeedback", async () => {

--- a/frontend/src/features/pipeline-review/api/pipelineReviewApi.ts
+++ b/frontend/src/features/pipeline-review/api/pipelineReviewApi.ts
@@ -17,6 +17,7 @@ export interface ReviewTaskPayload {
   confidence?: number;
   description?: string;
   evidenceTerms?: string[];
+  suggestedDomainLexicon?: string[];
   sourceId?: string;
   targetId?: string;
   sourceReviewContext?: ReviewCaseContext;
@@ -119,12 +120,24 @@ export function usePipelineReviewCheckpoint(
   });
 }
 
+// 후보 선택(reviewTaskId)에 더해 운영자가 다듬은 profile override를 함께 보낸다.
+// 모든 override 필드는 optional이며 생략하면 백엔드가 후보 값을 유지한다(하위호환).
+export interface ConfirmDomainInput {
+  reviewTaskId: number;
+  confirmedDomain?: string;
+  displayName?: string;
+  description?: string;
+  domainLexicon?: string[];
+  evidenceTerms?: string[];
+  exclusionTerms?: string[];
+}
+
 export function useConfirmPipelineDomain(workspaceId?: number, pipelineJobId?: number) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (reviewTaskId: number) => {
+    mutationFn: (input: ConfirmDomainInput) => {
       const ids = requirePipelineReviewIds(workspaceId, pipelineJobId);
-      return confirmDomain(ids.workspaceId, ids.pipelineJobId, { reviewTaskId });
+      return confirmDomain(ids.workspaceId, ids.pipelineJobId, input);
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({

--- a/frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.module.css
+++ b/frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.module.css
@@ -246,22 +246,6 @@
   letter-spacing: -0.1px;
 }
 
-.domainReviewPanel {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: var(--s-4);
-  align-items: end;
-  padding: var(--s-4);
-  border: 1px solid var(--ink);
-  border-radius: var(--r-2);
-  background: var(--paper);
-}
-
-.domainReviewCopy {
-  display: grid;
-  gap: var(--s-2);
-}
-
 .domainReviewTitle {
   color: var(--ink);
   font-size: 15px;
@@ -280,6 +264,78 @@
 
 .domainReviewImpact {
   color: var(--ink-3);
+}
+
+.domainConfirmPanel {
+  display: grid;
+  gap: var(--s-4);
+  padding: var(--s-4);
+  border: 1px solid var(--ink);
+  border-radius: var(--r-2);
+  background: var(--paper);
+}
+
+.profileForm {
+  display: grid;
+  gap: var(--s-3);
+}
+
+.field {
+  display: grid;
+  gap: var(--s-1);
+}
+
+.fieldLabel {
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+}
+
+.fieldHint {
+  color: var(--ink-3);
+  font-size: 11px;
+  letter-spacing: -0.1px;
+  line-height: 1.4;
+}
+
+.textInput,
+.textArea {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-1);
+  background: var(--paper);
+  color: var(--ink);
+  font: inherit;
+  font-size: 13px;
+  letter-spacing: -0.14px;
+  transition:
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast);
+}
+
+.textArea {
+  min-height: 64px;
+  resize: vertical;
+}
+
+.textInput:focus-visible,
+.textArea:focus-visible {
+  outline: none;
+  border-color: var(--ink);
+  box-shadow: var(--focus-ring);
+}
+
+.textInput[aria-invalid="true"] {
+  border-color: var(--ink-3);
+}
+
+.textInput:disabled,
+.textArea:disabled {
+  cursor: not-allowed;
+  opacity: 0.56;
 }
 
 .feedbackList {
@@ -534,11 +590,7 @@
     width: 100%;
   }
 
-  .domainReviewPanel {
-    grid-template-columns: 1fr;
-  }
-
-  .domainReviewPanel .submitButton {
+  .domainConfirmPanel .submitButton {
     width: 100%;
   }
 }

--- a/frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.test.tsx
+++ b/frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.test.tsx
@@ -138,13 +138,77 @@ describe("PipelineReviewCheckpointCard", () => {
       "true",
     );
     expect(
-      screen.getByText(/이 선택은 intent clustering 입력으로 반영되며/),
+      screen.getByText(/intent clustering 입력으로 반영되며/),
     ).toBeInTheDocument();
     expect(mutate).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole("button", { name: "선택한 도메인 확정" }));
 
-    expect(mutate).toHaveBeenCalledWith(101);
+    // 후보 값으로 시드된 profile이 그대로 전송된다(편집하지 않은 경우).
+    expect(mutate).toHaveBeenCalledWith({
+      reviewTaskId: 101,
+      confirmedDomain: "카드 상담",
+      displayName: "카드 상담",
+      description: "카드 분실, 결제, 한도 문의가 섞인 상담",
+      domainLexicon: [],
+      evidenceTerms: ["분실", "결제", "한도"],
+      exclusionTerms: [],
+    });
+  });
+
+  it("sends operator-edited profile fields when confirming a selected domain", () => {
+    const mutate = vi.fn();
+    mockedUseConfirmDomain.mockReturnValue({
+      isPending: false,
+      mutate,
+    } as never);
+    mockedUseCheckpoint.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        pipelineJobId: 7,
+        pipelineStatus: "WAITING_DOMAIN_CONFIRMATION",
+        reviewKind: "DOMAIN_CONFIRMATION",
+        tasks: [
+          {
+            id: 101,
+            targetType: "DOMAIN_CANDIDATE",
+            status: "OPEN",
+            priority: "HIGH",
+            title: "카드 상담",
+            payload: {
+              displayName: "카드 상담",
+              confidence: 0.92,
+              description: "카드 분실, 결제, 한도 문의가 섞인 상담",
+              evidenceTerms: ["분실", "결제", "한도"],
+              suggestedDomainLexicon: ["카드", "결제"],
+            },
+          },
+        ],
+      },
+    } as never);
+
+    renderCard();
+    fireEvent.click(screen.getByRole("button", { name: /카드 상담/ }));
+
+    fireEvent.change(screen.getByLabelText("도메인명"), {
+      target: { value: "신용카드 분실/도난" },
+    });
+    fireEvent.change(screen.getByLabelText("제외 키워드 (선택)"), {
+      target: { value: "배송, 배송, 환불\n" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "선택한 도메인 확정" }));
+
+    expect(mutate).toHaveBeenCalledWith({
+      reviewTaskId: 101,
+      confirmedDomain: "신용카드 분실/도난",
+      displayName: "카드 상담",
+      description: "카드 분실, 결제, 한도 문의가 섞인 상담",
+      domainLexicon: ["카드", "결제"],
+      evidenceTerms: ["분실", "결제", "한도"],
+      exclusionTerms: ["배송", "환불"],
+    });
   });
 
   it("keeps domain confirmation disabled while confirmation is pending", () => {

--- a/frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.tsx
+++ b/frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.tsx
@@ -4,6 +4,7 @@ import { Link } from "react-router-dom";
 import {
   type FeedbackAnswerOption,
   type ReviewCaseContext,
+  type ReviewTaskView,
   useConfirmPipelineDomain,
   usePipelineReviewCheckpoint,
   useSubmitPipelineFeedback,
@@ -39,6 +40,15 @@ const WORKFLOW_FEEDBACK_ANSWER_OPTIONS = [
 type FeedbackDecision = string;
 type FeedbackDecisions = Record<number, FeedbackDecision>;
 
+interface DomainProfileEdits {
+  confirmedDomain: string;
+  displayName: string;
+  description: string;
+  domainLexicon: string;
+  evidenceTerms: string;
+  exclusionTerms: string;
+}
+
 export function PipelineReviewCheckpointCard({
   workspaceId,
   pipelineJobId,
@@ -64,6 +74,10 @@ export function PipelineReviewCheckpointCard({
     selectionKey: null,
     taskId: null,
   });
+  const [domainEdits, setDomainEdits] = useState<{
+    taskKey: string | null;
+    values: DomainProfileEdits;
+  }>({ taskKey: null, values: emptyDomainEdits() });
 
   const openTasks = useMemo(
     () => query.data?.tasks.filter((task) => task.status === "OPEN") ?? [],
@@ -89,6 +103,30 @@ export function PipelineReviewCheckpointCard({
       openTasks,
     ],
   );
+  const currentDomainEditKey = selectedDomainTask
+    ? `${domainSelectionKey}:${selectedDomainTask.id}`
+    : null;
+  // 후보를 바꾸면 편집값을 그 후보로 다시 시드한다. 운영자가 입력하기 전까지는 후보 기반 시드를 보여 준다.
+  const activeDomainEdits =
+    selectedDomainTask &&
+    domainEdits.taskKey === currentDomainEditKey
+      ? domainEdits.values
+      : seedDomainEdits(selectedDomainTask);
+  const updateDomainEdit = (field: keyof DomainProfileEdits, value: string) => {
+    if (!selectedDomainTask) {
+      return;
+    }
+    setDomainEdits((current) => {
+      const base =
+        current.taskKey === currentDomainEditKey
+          ? current.values
+          : seedDomainEdits(selectedDomainTask);
+      return {
+        taskKey: currentDomainEditKey,
+        values: { ...base, [field]: value },
+      };
+    });
+  };
   const openTaskDecisionValues = useMemo(
     () =>
       new Map(
@@ -358,62 +396,109 @@ export function PipelineReviewCheckpointCard({
             );
           })}
         </div>
-        <div className={styles.domainReviewPanel} aria-live="polite">
-          <div className={styles.domainReviewCopy}>
-            <span className={styles.eyebrow}>Selected domain</span>
-            {selectedDomainTask ? (
-              <>
-                <strong className={styles.domainReviewTitle}>
-                  {selectedDomainTask.payload.displayName ??
-                    selectedDomainTask.title}
-                </strong>
-                <span className={styles.domainReviewDescription}>
-                  {selectedDomainTask.payload.description ??
-                    "도메인 설명이 제공되지 않았습니다."}
-                </span>
-                <span className={styles.domainReviewImpact}>
-                  이 선택은 intent clustering 입력으로 반영되며, 확정 후
-                  pipeline replay를 거쳐 다음 review 단계 또는 Domain Pack 초안
-                  생성으로 이어집니다.
-                </span>
-                <div className={styles.termRow} aria-label="선택 근거 키워드">
-                  {selectedDomainTask.payload.confidence !== undefined && (
-                    <span className={styles.term}>
-                      신뢰도{" "}
-                      {formatDomainConfidence(
-                        selectedDomainTask.payload.confidence,
-                      )}
-                    </span>
-                  )}
-                  {(selectedDomainTask.payload.evidenceTerms ?? [])
-                    .slice(0, 6)
-                    .map((term) => (
-                      <span key={term} className={styles.term}>
-                        {term}
-                      </span>
-                    ))}
+        <div className={styles.domainConfirmPanel} aria-live="polite">
+          <span className={styles.eyebrow}>Confirmed profile</span>
+          {selectedDomainTask ? (
+            <>
+              <p className={styles.domainReviewImpact}>
+                후보 값을 기본으로 채웠습니다. 필요하면 직접 다듬어 확정하세요. 이
+                profile은 intent clustering 입력으로 반영되며, 확정 후 pipeline
+                replay를 거쳐 다음 review 단계 또는 Domain Pack 초안 생성으로
+                이어집니다.
+              </p>
+              <div className={styles.profileForm}>
+                <ProfileTextField
+                  id="domain-edit-confirmed-domain"
+                  label="도메인명"
+                  value={activeDomainEdits.confirmedDomain}
+                  disabled={confirmDomain.isPending}
+                  invalid={activeDomainEdits.confirmedDomain.trim() === ""}
+                  onChange={(value) => updateDomainEdit("confirmedDomain", value)}
+                />
+                <ProfileTextField
+                  id="domain-edit-display-name"
+                  label="표시 이름"
+                  value={activeDomainEdits.displayName}
+                  disabled={confirmDomain.isPending}
+                  onChange={(value) => updateDomainEdit("displayName", value)}
+                />
+                <ProfileMultilineField
+                  id="domain-edit-description"
+                  label="설명"
+                  value={activeDomainEdits.description}
+                  disabled={confirmDomain.isPending}
+                  onChange={(value) => updateDomainEdit("description", value)}
+                />
+                <ProfileMultilineField
+                  id="domain-edit-lexicon"
+                  label="도메인 lexicon"
+                  hint="쉼표 또는 줄바꿈으로 구분합니다."
+                  value={activeDomainEdits.domainLexicon}
+                  disabled={confirmDomain.isPending}
+                  showChips
+                  onChange={(value) => updateDomainEdit("domainLexicon", value)}
+                />
+                <ProfileMultilineField
+                  id="domain-edit-evidence"
+                  label="근거 키워드"
+                  hint="쉼표 또는 줄바꿈으로 구분합니다."
+                  value={activeDomainEdits.evidenceTerms}
+                  disabled={confirmDomain.isPending}
+                  showChips
+                  onChange={(value) => updateDomainEdit("evidenceTerms", value)}
+                />
+                <ProfileMultilineField
+                  id="domain-edit-exclusion"
+                  label="제외 키워드 (선택)"
+                  hint="이 도메인과 무관한 표현을 쉼표 또는 줄바꿈으로 구분합니다."
+                  value={activeDomainEdits.exclusionTerms}
+                  disabled={confirmDomain.isPending}
+                  showChips
+                  onChange={(value) => updateDomainEdit("exclusionTerms", value)}
+                />
+              </div>
+              {selectedDomainTask.payload.confidence !== undefined && (
+                <div className={styles.termRow} aria-label="후보 신뢰도">
+                  <span className={styles.term}>
+                    후보 신뢰도{" "}
+                    {formatDomainConfidence(
+                      selectedDomainTask.payload.confidence,
+                    )}
+                  </span>
                 </div>
-              </>
-            ) : (
-              <>
-                <strong className={styles.domainReviewTitle}>
-                  확정할 도메인을 선택하세요.
-                </strong>
-                <span className={styles.domainReviewDescription}>
-                  후보를 선택하면 근거와 파이프라인 반영 범위를 확인한 뒤 확정할
-                  수 있습니다.
-                </span>
-              </>
-            )}
-          </div>
+              )}
+            </>
+          ) : (
+            <>
+              <strong className={styles.domainReviewTitle}>
+                확정할 도메인을 선택하세요.
+              </strong>
+              <span className={styles.domainReviewDescription}>
+                후보를 선택하면 profile 필드를 다듬어 확정할 수 있습니다.
+              </span>
+            </>
+          )}
           <button
             type="button"
             className={styles.submitButton}
-            disabled={confirmDomain.isPending || !selectedDomainTask}
+            disabled={
+              confirmDomain.isPending ||
+              !selectedDomainTask ||
+              activeDomainEdits.confirmedDomain.trim() === ""
+            }
             onClick={() => {
-              if (selectedDomainTask) {
-                confirmDomain.mutate(selectedDomainTask.id);
+              if (!selectedDomainTask) {
+                return;
               }
+              confirmDomain.mutate({
+                reviewTaskId: selectedDomainTask.id,
+                confirmedDomain: activeDomainEdits.confirmedDomain.trim(),
+                displayName: activeDomainEdits.displayName.trim(),
+                description: activeDomainEdits.description.trim(),
+                domainLexicon: parseTerms(activeDomainEdits.domainLexicon),
+                evidenceTerms: parseTerms(activeDomainEdits.evidenceTerms),
+                exclusionTerms: parseTerms(activeDomainEdits.exclusionTerms),
+              });
             }}
           >
             {confirmDomain.isPending ? "확정 중입니다" : "선택한 도메인 확정"}
@@ -641,6 +726,136 @@ function questionScopeLabel(
 
 function formatDomainConfidence(confidence: number): string {
   return `${Math.round(confidence * 100)}%`;
+}
+
+function emptyDomainEdits(): DomainProfileEdits {
+  return {
+    confirmedDomain: "",
+    displayName: "",
+    description: "",
+    domainLexicon: "",
+    evidenceTerms: "",
+    exclusionTerms: "",
+  };
+}
+
+function seedDomainEdits(task?: ReviewTaskView): DomainProfileEdits {
+  if (!task) {
+    return emptyDomainEdits();
+  }
+  const name = task.payload.displayName ?? task.title;
+  return {
+    confirmedDomain: name,
+    displayName: name,
+    description: task.payload.description ?? "",
+    domainLexicon: (task.payload.suggestedDomainLexicon ?? []).join(", "),
+    evidenceTerms: (task.payload.evidenceTerms ?? []).join(", "),
+    exclusionTerms: "",
+  };
+}
+
+// 쉼표/줄바꿈으로 구분된 입력을 trim·중복제거해 term 배열로 변환한다.
+function parseTerms(value: string): string[] {
+  const seen = new Set<string>();
+  const terms: string[] = [];
+  for (const raw of value.split(/[,\n]/)) {
+    const term = raw.trim();
+    if (term && !seen.has(term)) {
+      seen.add(term);
+      terms.push(term);
+    }
+  }
+  return terms;
+}
+
+function ProfileTextField({
+  id,
+  label,
+  value,
+  disabled,
+  invalid,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  disabled: boolean;
+  invalid?: boolean;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <div className={styles.field}>
+      <label htmlFor={id} className={styles.fieldLabel}>
+        {label}
+      </label>
+      <input
+        id={id}
+        type="text"
+        className={styles.textInput}
+        value={value}
+        disabled={disabled}
+        aria-invalid={invalid}
+        onChange={(event) => onChange(event.target.value)}
+      />
+    </div>
+  );
+}
+
+function ProfileMultilineField({
+  id,
+  label,
+  hint,
+  value,
+  disabled,
+  showChips,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  hint?: string;
+  value: string;
+  disabled: boolean;
+  showChips?: boolean;
+  onChange: (value: string) => void;
+}) {
+  const hintId = `${id}-hint`;
+  return (
+    <div className={styles.field}>
+      <label htmlFor={id} className={styles.fieldLabel}>
+        {label}
+      </label>
+      {hint && (
+        <span id={hintId} className={styles.fieldHint}>
+          {hint}
+        </span>
+      )}
+      <textarea
+        id={id}
+        className={styles.textArea}
+        value={value}
+        disabled={disabled}
+        aria-describedby={hint ? hintId : undefined}
+        onChange={(event) => onChange(event.target.value)}
+      />
+      {showChips && <DomainTermChips value={value} />}
+    </div>
+  );
+}
+
+function DomainTermChips({ value }: { value: string }) {
+  const terms = parseTerms(value);
+  if (terms.length === 0) {
+    return null;
+  }
+  return (
+    <div className={styles.termRow} aria-hidden="true">
+      {terms.map((term) => (
+        <span key={term} className={styles.term}>
+          {term}
+        </span>
+      ))}
+    </div>
+  );
 }
 
 function feedbackAnswerOptions(payload: {

--- a/frontend/src/shared/api/generated/.codegen-meta.json
+++ b/frontend/src/shared/api/generated/.codegen-meta.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "openapiHash": "sha256:e089570679f599982a9aa62cfddf92498ce877ba5a297f4dcd3b2ce465d9a4de",
+  "openapiHash": "sha256:f976d8b758c2dbe2741897be6150db1d8f384ff9fa1273773cd6a029794b4c3a",
   "openapiPathsCount": 106,
   "orvalVersion": "^8.9.0",
   "openapiSourcePath": "backend/build/openapi.json"

--- a/frontend/src/shared/api/generated/zod/confirmDomainBody.zod.ts
+++ b/frontend/src/shared/api/generated/zod/confirmDomainBody.zod.ts
@@ -8,7 +8,13 @@ import { z as zod } from 'zod';
 
 export const ConfirmDomainBody = zod.object({
   "reviewTaskId": zod.number(),
-  "reason": zod.string().optional()
+  "reason": zod.string().optional(),
+  "confirmedDomain": zod.string().optional(),
+  "displayName": zod.string().optional(),
+  "description": zod.string().optional(),
+  "domainLexicon": zod.array(zod.string()).optional(),
+  "evidenceTerms": zod.array(zod.string()).optional(),
+  "exclusionTerms": zod.array(zod.string()).optional()
 })
 
 export type ConfirmDomainBody = zod.input<typeof ConfirmDomainBody>;

--- a/frontend/src/shared/api/generated/zod/confirmDomainRequest.zod.ts
+++ b/frontend/src/shared/api/generated/zod/confirmDomainRequest.zod.ts
@@ -8,7 +8,13 @@ import { z as zod } from 'zod';
 
 export const ConfirmDomainRequest = zod.object({
   "reviewTaskId": zod.number(),
-  "reason": zod.string().optional()
+  "reason": zod.string().optional(),
+  "confirmedDomain": zod.string().optional(),
+  "displayName": zod.string().optional(),
+  "description": zod.string().optional(),
+  "domainLexicon": zod.array(zod.string()).optional(),
+  "evidenceTerms": zod.array(zod.string()).optional(),
+  "exclusionTerms": zod.array(zod.string()).optional()
 })
 
 export type ConfirmDomainRequest = zod.input<typeof ConfirmDomainRequest>;

--- a/ml/src/pipeline/stages/intent_discovery/domain_profile.py
+++ b/ml/src/pipeline/stages/intent_discovery/domain_profile.py
@@ -112,7 +112,9 @@ def load_confirmed_domain_profile(path: Path) -> RootDomainProfile:
         domain_evidence={
             "candidateId": payload.get("candidateId"),
             "displayName": payload.get("displayName"),
+            "description": _clean_text(payload.get("description")),
             "evidenceConversationIds": _string_list(payload.get("evidenceConversationIds")),
+            "exclusionTerms": _string_list(payload.get("exclusionTerms")),
             "sourceReviewTaskId": payload.get("sourceReviewTaskId"),
         },
     )
@@ -186,6 +188,12 @@ def _string_list(value: object) -> list[str]:
     if not isinstance(value, list):
         return []
     return [text for item in value if (text := str(item).strip())]
+
+
+def _clean_text(value: object) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
 
 
 def _bounded_float(value: object, *, default: float) -> float:

--- a/ml/tests/stages/test_intent_discovery_domain_profile.py
+++ b/ml/tests/stages/test_intent_discovery_domain_profile.py
@@ -60,6 +60,35 @@ def test_should_load_confirmed_domain_profile(tmp_path) -> None:
     assert profile.to_dict()["usesOperatorCategoryMetadata"] is True
 
 
+def test_should_preserve_operator_edited_description_and_exclusion_terms(tmp_path) -> None:
+    profile_path = tmp_path / "confirmed.json"
+    profile_path.write_text(
+        """
+        {
+          "candidateId": "card",
+          "displayName": "신용카드 분실/도난",
+          "description": "분실·도난 신고와 재발급 중심 상담",
+          "confidence": 0.9,
+          "domainLexicon": ["재발급", "도난신고"],
+          "evidenceTerms": ["분실", "도난"],
+          "exclusionTerms": ["배송"],
+          "sourceReviewTaskId": 11
+        }
+        """,
+        encoding="utf-8",
+    )
+
+    profile = load_confirmed_domain_profile(profile_path)
+    serialized = profile.to_dict()
+
+    assert profile.domain_lexicon == ("재발급", "도난신고")
+    assert profile.evidence_terms["신용카드 분실/도난"] == ("분실", "도난")
+    assert serialized["domainEvidence"]["description"] == "분실·도난 신고와 재발급 중심 상담"
+    assert serialized["domainEvidence"]["exclusionTerms"] == ["배송"]
+    assert serialized["method"] == CONFIRMED_DOMAIN_METHOD
+    assert serialized["usesOperatorCategoryMetadata"] is True
+
+
 def test_load_confirmed_domain_profile_from_env_returns_none_without_path(monkeypatch) -> None:
     monkeypatch.delenv("PIPELINE_CONFIRMED_DOMAIN_PROFILE_PATH", raising=False)
 


### PR DESCRIPTION
Closes #884

## 배경

Domain confirmation checkpoint는 ML이 생성한 domain candidate 중 하나를 선택하는 흐름뿐이라, 후보가 낮은 confidence이거나 `혼합 또는 미확정`에 가깝더라도 운영자가 도메인명·설명·lexicon·근거 키워드를 다듬어 replay 입력으로 넘길 수 없었다. 첫 checkpoint에서 잘못된 domain profile이 확정되면 이후 `intent_discovery -> flow_splitting -> draft_generation` 전체가 잘못된 전제 위에서 진행된다.

## 변경

### Frontend (deliverable)
- Domain confirmation UI에서 후보를 선택하면 후보 값으로 시드된 편집 폼을 노출한다. 편집 필드: `confirmedDomain`, `displayName`, `description`, `domainLexicon`, `evidenceTerms`와 선택적 제외 키워드(`exclusionTerms`).
- lexicon·근거·제외 키워드는 쉼표/줄바꿈으로 입력하고 파싱된 결과를 chip으로 미리 보여 준다. 후보를 바꾸면 편집값을 새 후보로 다시 시드한다.
- 후보를 선택하지 않으면(또는 도메인명이 비면) 확정 버튼이 비활성이다. 각 입력은 label/`aria-describedby` 연결과 pending 비활성 처리를 갖는다.

### Backend (최소 연동)
- `ConfirmDomainRequest`/`ConfirmDomainCommand`에 operator override 필드(모두 optional)를 추가한다.
- 선택 후보 payload를 기본값으로 두고 override를 병합해 `confirmed-domain-profile.v1`을 만든다. 문자열은 override가 non-blank일 때, 리스트는 override가 주어지면(빈 리스트=의도적 비움 허용) 적용하고 아니면 후보 값을 쓴다. `description`/`exclusionTerms` 필드를 profile에 추가한다.
- 병합된 profile은 `CONFIRMED_DOMAIN_PROFILE` artifact와 replay summary에 그대로 남는다. override 없이 `reviewTaskId`만 보내면 기존과 동일하게 동작한다(하위호환).

### ML (보존)
- `intent_discovery/domain_profile.py`가 편집된 `domainLexicon`/`evidenceTerms`를 그대로 사용하고, `description`과 `exclusionTerms`를 `root_domain_profile.json`의 `domainEvidence`에 보존한다. confirmed 경로의 `method=llm_confirmed_domain.v1`, `usesOperatorCategoryMetadata=true`는 유지된다.

### Generated client
- backend OpenAPI 재생성 후 `pnpm api:gen`으로 orval client(zod) 재생성. drift 없음.

## 품질 근거

- 검토한 패턴: `confirmDomain`의 artifact/replay 흐름, `PipelineReviewTaskFactory`의 candidate 필드, `domain_candidate_generation`의 candidate 스키마, 카드의 기존 선택 state/CSS 토큰, shared 입력 패턴.
- 3라운드 자체 리뷰(이슈 충실도 / 아키텍처·통합 / CI·테스트) 완료. no-override 경로는 후보 값 그대로라 기존 결과와 동일.
- 실행한 검증:
  - backend: `./gradlew test --tests "...PipelineReviewCheckpointUseCaseTest" --tests "...PipelineReviewControllerTest"` → BUILD SUCCESSFUL, `spotlessCheck` clean
  - ml: `uv run pytest tests/stages/test_intent_discovery_domain_profile.py` → 5 passed, `ruff check`/`ruff format --check`/`mypy` clean
  - frontend: `vp test src/features/pipeline-review` → 35 passed, `tsc -b` + `vp build` 성공, 변경 파일 eslint clean
  - codegen: 전용 임시 pgvector로 `generateOpenApiDocs` + `api:gen` 실행, 생성물 drift 확인

## 잔여 리스크 / deferral

- `exclusionTerms`의 same-intent 음의 신호 활용은 본 PR 범위 밖이며 profile 보존·전달까지만 다룬다(별도 이슈).
- 운영자가 `evidenceTerms`를 비우면 ML loader 폴백(`evidenceTerms or domainLexicon`)에 따라 lexicon이 근거로 쓰인다 — 기존 동작 유지.

스펙: `.agent/specs/884.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 도메인 확정 전에 운영자가 프로필 필드(확정 도메인명, 표시명, 설명, 도메인 어휘, 근거 용어, 제외 용어)를 폼에서 직접 편집·제출할 수 있게 되었습니다.  
  * 편집된 내용은 기록되어 재생/후속 처리 및 모델 입력에 반영됩니다.

* **Tests / E2E**
  * 편집 동작과 전송 페이로드를 검증하는 단위·통합·E2E 테스트가 추가/강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->