### PR TITLE
chore(test): waitFor/findBy 비동기 타임아웃 상향으로 flaky 테스트 안정화

### DIFF
--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,5 +1,11 @@
 import { vi } from "vite-plus/test";
 import "@testing-library/jest-dom";
+import { configure } from "@testing-library/react";
+
+// testing-library 의 waitFor/findBy 기본 비동기 타임아웃은 1000ms 라, CI 병렬
+// 부하 하에서 느린 비동기 흐름(예: 시뮬레이션 replay)이 간헐적으로 타임아웃되어
+// flaky 하게 실패했다. vitest testTimeout(10s) 안에서 여유를 두어 안정화한다.
+configure({ asyncUtilTimeout: 5000 });
 
 // WorkspaceMarker hits React Query (useListWorkspaces) which throws without
 // a QueryClientProvider. Tests render OstoneShell with no provider, so stub


### PR DESCRIPTION
## 배경

PR #890 머지 후 `main` CI(`frontend` 잡)가 실패했다. 원인은 내 변경(어드민 로그아웃)과 무관한 **flaky 테스트**다.

- 실패 파일: `src/pages/workspace/ui/WorkspaceSimulationPage.qa-fixes.test.tsx`
- 실행마다 다른 테스트가 실패 (PR CI: "replay가 FAIL이면…" line 106 / main CI: "replay가 PASS면…" line 93)
- 격리 실행 시 **항상 통과**, 전체 병렬 스위트(2262 tests)에서만 간헐 실패
- 실패한 테스트 소요 시간이 **~1250ms** — testing-library `waitFor`/`findBy` 기본 `asyncUtilTimeout`(**1000ms**)을 CI 부하 하에서 초과

`vitest` 의 `testTimeout`(10s)과 testing-library 의 `asyncUtilTimeout`(1000ms)은 별개라, 테스트 타임아웃이 넉넉해도 `waitFor` 가 먼저 1초에 포기하면서 flaky 하게 깨졌다.

## 변경

- `src/test/setup.ts` 전역 설정에 `configure({ asyncUtilTimeout: 5000 })` 추가
- `waitFor`/`findBy` 기본 대기 한도를 1000ms → 5000ms 로 상향 (vitest `testTimeout` 10s 범위 내)
- 개별 테스트 수정 없이 스위트 전체의 부하성 flakiness 제거

## 검증

- [x] `WorkspaceSimulationPage.qa-fixes.test.tsx` 통과 (10/10)
- [x] `eslint src/test/setup.ts` 통과
- [x] 대기 한도 상향은 통과 시점을 늦추지 않음(조건 충족 즉시 반환) — 정상 통과 테스트 속도 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 테스트 환경 설정을 개선하여 테스트 실행의 신뢰성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->