### PR TITLE
feat(workflow-runtime): #880 시뮬레이션 구조적 개선 패치 LLM 생성

### DIFF
--- a/.agent/specs/880.md
+++ b/.agent/specs/880.md
@@ -1,0 +1,101 @@
+# Backend Spec — #880 LLM 기반 시뮬레이션 구조적 개선 패치 생성
+
+## Goal
+
+시뮬레이션 피드백·세션 전사·런타임 상태·골든 케이스 리플레이 실패·Domain Pack 컨텍스트를 근거(evidence)로 모아, LLM이 #879에서 정의한 구조적 패치 문서(`simulation-structural-patch.v1`)를 생성하도록 한다. LLM은 구조화된 패치 JSON만 만들고, 백엔드가 #879 parser로 검증한 뒤에만 `SimulationImprovementCandidate.draftPatchJson`에 저장한다. LLM은 Domain Pack 테이블을 직접 변경하지 않는다.
+
+## Scope
+
+- 백엔드 코드가 evidence package를 조립한다(프론트엔드 프롬프트 조립 금지).
+- evidence → 프롬프트 → LLM 호출 → 출력 해석/검증 → 생성 결과를 만드는 application service 추가.
+- 생성 성공 시 검증된 구조적 패치 JSON을 `draftPatchJson`에 저장한다.
+- 파싱/검증 실패·모호한 대상은 가짜 패치 대신 명확한 생성 실패 상태(envelope)로 후보에 기록한다.
+- 구조적 생성은 rollout 플래그(`app.simulation.structural-patch.enabled`, 기본 false) 뒤에 둔다. 플래그 off면 기존 description-only 동작을 그대로 유지한다.
+- 단위 테스트: evidence 조립, 프롬프트 구성, 유효 LLM 출력, 잘못된 JSON, 미지원 operation, 모호한 대상 처리.
+
+## Non-goals (이슈 명시)
+
+- 구조적 operation을 실제 DB에 적용하지 않는다(별도 이슈).
+- 시각적 diff UI를 만들지 않는다.
+- LLM 생성 패치를 자동 승인하지 않는다.
+- 기존 `simulation-candidate-draft-patch.v1`(UPDATE_DESCRIPTION) 흐름은 플래그 off 시 그대로 둔다.
+
+## Affected Modules
+
+`backend` / `workflow-runtime` bounded context.
+
+검증한 기존 경로:
+- `backend/.../workflowruntime/application/SimulationImprovementCandidateService.java` — `createNewCandidate(...)`에서 `buildDraftPatchJson(...)` 호출(통합 지점).
+- `backend/.../workflowruntime/application/StructuralDomainPackPatchParser.java` — #879 파서/검증(재사용, 신규 validator 만들지 않음).
+- `backend/.../workflowruntime/domain/StructuralDomainPackPatch.java`, `StructuralPatchOperation.java`, `StructuralPatchOperationType.java` — #879 VO(재사용).
+- `backend/.../workflowruntime/application/LlmAssistantService.java`, `config/AiConfig.java` — 기존 `ChatClient` 사용/주입 패턴.
+- `backend/.../workflowruntime/domain/ChatMessageRepository.java` (`findByChatSessionIdOrderBySeqNoAsc`), `WorkflowExecutionRepository.java` (`findTopByChatSessionIdOrderByStartedAtDescIdDesc`), `SimulationGoldenCaseRepository.java`, `SimulationGoldenCaseReplayResultRepository.java` (`findLatestByGoldenCaseId`).
+- `backend/.../domainpack/domain/repository/{Intent,Slot,Workflow,Policy,Risk}DefinitionRepository.java` — 버전별 Domain Pack 요소 조회.
+- `backend/.../workflowruntime/domain/SimulationImprovementCandidate.java` — `draftPatchJson` 보관, `defineDraftPatch(...)`.
+
+## Evidence Package
+
+`SimulationImprovementEvidence`(application record)로 표현하고 `SimulationImprovementEvidenceAssembler`(`@Component`)가 백엔드에서 조립한다. 구성:
+
+- Feedback: `feedbackId`, `feedbackType`, `description`, `expectedBehavior`, `severity`, `chatMessageId`.
+- SessionMeta: `sessionId`, `executionStatus`, `currentState`, `selectedIntentCode`(session meta), `matchedWorkflowCode`(실행의 workflowDefinitionId → workflowCode), `slotValues`(JSON), 최근 대화 turn 목록(role/content, 최근 N개로 제한).
+- GoldenReplay(있을 때만): `goldenCaseId`, `replayResultId`, `status`, `expectedJson`, `actualJson`, `failureSummary`. feedback의 `chatSessionId`를 source로 하는 골든 케이스를 찾아 최신 리플레이 결과를 사용한다.
+- DomainPackContext: 대상 버전의 intents/slots/workflows/policies/risks를 code·name·description(및 slot validation, policy condition, risk trigger, workflow graph) 중심으로 압축. 긴 JSON 필드는 상한 길이로 절단한다.
+
+골든 케이스 조회를 위해 `SimulationGoldenCaseRepository.findBySourceChatSessionId(Long)`(adapter는 `findFirstBySourceChatSessionIdOrderByCreatedAtDesc`로 위임)를 추가한다.
+
+## LLM Output Contract & Prompt
+
+`SimulationStructuralPatchPromptFactory`(`@Component`)가 생성한다.
+
+- system 프롬프트: "Domain Pack repair planner. JSON만 출력." 역할 고정(기존 CS assistant system 프롬프트 대신 호출 시 override).
+- user 프롬프트: 수리 규칙(최소 변경, 기존 workflow 우선, 누락 슬롯이면 슬롯 필수화 우선, 기존 id/code 보존, 외부 사실 금지, JSON only) + #879 허용 operation 13종 목록 + 출력 예시 + 모호 시 탈출구 + 직렬화된 evidence JSON.
+- 모호 대상 탈출구: 모델이 안전하게 대상을 특정할 수 없으면 `{"status":"NEEDS_HUMAN_TARGET","summary":"..."}`를 반환하도록 지시한다.
+
+## Generation Flow
+
+`SimulationStructuralPatchGenerationService`(`@Service`):
+1. `assemble(feedback, session)`로 evidence 조립.
+2. `promptFactory`로 system/user 프롬프트 구성, `ChatClient` 호출.
+3. `interpret(raw)`(package-private, 직접 단위 테스트):
+   - 빈 응답/JSON object 아님 → `INVALID_OUTPUT`.
+   - `status == NEEDS_HUMAN_TARGET` → `NEEDS_HUMAN_TARGET`(summary 보존).
+   - 그 외 → 코드펜스 제거 후 `StructuralDomainPackPatchParser.parse(...)`. 성공 → `SUCCESS`(검증된 JSON 보관). `InvalidStructuralPatchException` → `INVALID_OUTPUT`(사유 메시지).
+4. `ChatClient`가 `NonTransientAiException`/`TransientAiException`을 던지면 잡아 `GENERATION_ERROR` 결과로 변환(후보 생성은 계속).
+
+`SimulationStructuralPatchGenerationResult`(record) + `SimulationStructuralPatchGenerationStatus`(enum: `SUCCESS`, `NEEDS_HUMAN_TARGET`, `INVALID_OUTPUT`, `GENERATION_ERROR`).
+
+## Integration & Status Surface
+
+`SimulationImprovementCandidateService.createNewCandidate(...)`:
+- 플래그 off → `buildDraftPatchJson(candidate)`(기존 description-only) 그대로.
+- 플래그 on → `generationService.generate(feedback, session)`:
+  - `SUCCESS` → 검증된 구조적 패치 JSON을 `draftPatchJson`에 저장.
+  - 그 외 → `simulation-structural-patch-generation.v1` envelope를 저장: `status`, `summary`(FE 렌더용), `message`(상세), 그리고 명시적 비-침묵 fallback으로 기존 description-only 패치를 `descriptionPatch`에 포함.
+
+`draftPatchJson`은 jsonb이며 응답 DTO(`SimulationImprovementCandidateResponse.draftPatchJson`)로 그대로 노출되므로 별도 컬럼/마이그레이션 없이 생성 상태가 후보 응답에 보인다. 프론트엔드는 `summary`만 읽어 raw 요약을 렌더할 수 있다.
+
+## Safety Rules (이슈 매핑)
+
+- 파싱/검증 불가 → 가짜 패치 대신 생성 실패 envelope(상태/메시지) 기록.
+- 허용 operation set(#879)만 사용. parser가 미지원 op를 fail-closed로 거절.
+- 저장 전 백엔드 검증(#879 parser) 통과 필수.
+- 모호 피드백 → `NEEDS_HUMAN_TARGET` envelope(추측 금지).
+- description-only로의 침묵 fallback 금지: 플래그 on에서 실패 시 envelope의 `status`로 "구조적 패치 생성 실패"를 명시하고 description 패치를 그 안에 담는다.
+
+## Tests
+
+- `SimulationImprovementEvidenceAssemblerTest`: feedback/세션/골든 리플레이/Domain Pack 컨텍스트가 evidence로 모인다. 골든 케이스 없음 케이스. 긴 JSON 절단.
+- `SimulationStructuralPatchPromptFactoryTest`: 프롬프트에 허용 operation·출력 계약·evidence 핵심 필드가 포함된다.
+- `SimulationStructuralPatchGenerationServiceTest`(`interpret` 중심): 유효 구조적 출력 → SUCCESS+검증 JSON. 코드펜스 감싼 유효 출력 파싱. 잘못된 JSON → INVALID_OUTPUT. 미지원 op → INVALID_OUTPUT. `NEEDS_HUMAN_TARGET`. 빈 응답 → INVALID_OUTPUT. (가능하면 mock `ChatClient`로 happy-path `generate` 1건.)
+- `SimulationImprovementCandidateServiceTest`(추가): 플래그 off → 기존 description 패치 유지(기존 테스트). 플래그 on + SUCCESS → `draftPatchJson`이 구조적 패치. 플래그 on + 실패 → generation envelope(status/summary/descriptionPatch).
+
+## Acceptance Criteria
+
+- 시뮬레이션 개선 후보 생성이 LLM으로 구조적 패치 JSON을 만들 수 있다.
+- 생성된 패치는 스키마 검증 후에만 `draftPatchJson`에 저장된다.
+- LLM 파싱/검증 실패가 후보 응답(생성 envelope의 status/summary/message)에 보인다.
+- 기존 description-only 후보 흐름이 플래그 off에서 그대로 유지된다.
+- 위 단위 테스트가 evidence 조립·프롬프트 구성·유효 출력·잘못된 JSON·미지원 operation·모호 대상을 모두 커버한다.
+- 프론트엔드가 operation을 전부 이해하지 않아도 raw 패치 `summary`를 렌더할 수 있다.
+</invoke>

--- a/backend/src/main/java/com/init/workflowruntime/application/SimulationImprovementCandidateService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/SimulationImprovementCandidateService.java
@@ -29,6 +29,7 @@ import com.init.workflowruntime.domain.SimulationImprovementCandidateType;
 import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
 import com.init.workspace.domain.repository.WorkspaceMemberRepository;
 import java.util.Locale;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -47,7 +48,9 @@ public class SimulationImprovementCandidateService {
   private final WorkspaceMemberRepository workspaceMemberRepository;
   private final SimulationImprovementCandidateReviewTaskService reviewTaskService;
   private final SimulationImprovementCandidateDecisionService decisionService;
+  private final SimulationStructuralPatchGenerationService structuralPatchGenerationService;
   private final ObjectMapper objectMapper;
+  private final boolean structuralPatchEnabled;
 
   public SimulationImprovementCandidateService(
       SimulationFeedbackRepository feedbackRepository,
@@ -56,14 +59,18 @@ public class SimulationImprovementCandidateService {
       WorkspaceMemberRepository workspaceMemberRepository,
       SimulationImprovementCandidateReviewTaskService reviewTaskService,
       SimulationImprovementCandidateDecisionService decisionService,
-      ObjectMapper objectMapper) {
+      SimulationStructuralPatchGenerationService structuralPatchGenerationService,
+      ObjectMapper objectMapper,
+      @Value("${app.simulation.structural-patch.enabled:false}") boolean structuralPatchEnabled) {
     this.feedbackRepository = feedbackRepository;
     this.candidateRepository = candidateRepository;
     this.chatSessionRepository = chatSessionRepository;
     this.workspaceMemberRepository = workspaceMemberRepository;
     this.reviewTaskService = reviewTaskService;
     this.decisionService = decisionService;
+    this.structuralPatchGenerationService = structuralPatchGenerationService;
     this.objectMapper = objectMapper;
+    this.structuralPatchEnabled = structuralPatchEnabled;
   }
 
   @Transactional
@@ -159,14 +166,31 @@ public class SimulationImprovementCandidateService {
             feedback.getChatMessageId(),
             draftFrom(command, feedback),
             command.userId());
-    candidate.defineDraftPatch(buildDraftPatchJson(candidate));
+    candidate.defineDraftPatch(buildDraftPatch(candidate, feedback, session));
     SimulationImprovementCandidate saved = candidateRepository.save(candidate);
     feedback.markCandidateCreated();
     feedbackRepository.save(feedback);
     return SimulationImprovementCandidateResponse.from(saved);
   }
 
-  private String buildDraftPatchJson(SimulationImprovementCandidate candidate) {
+  private String buildDraftPatch(
+      SimulationImprovementCandidate candidate, SimulationFeedback feedback, ChatSession session) {
+    if (!structuralPatchEnabled) {
+      return buildDescriptionPatchJson(candidate);
+    }
+    SimulationStructuralPatchGenerationResult result =
+        structuralPatchGenerationService.generate(feedback, session);
+    if (result.isSuccess()) {
+      return result.patchJson();
+    }
+    return buildGenerationFailureEnvelope(candidate, result);
+  }
+
+  private String buildDescriptionPatchJson(SimulationImprovementCandidate candidate) {
+    return toJson(buildDescriptionPatchNode(candidate));
+  }
+
+  private ObjectNode buildDescriptionPatchNode(SimulationImprovementCandidate candidate) {
     ObjectNode root = objectMapper.createObjectNode();
     root.put("schemaVersion", "simulation-candidate-draft-patch.v1");
     root.put("operation", "UPDATE_DESCRIPTION");
@@ -180,6 +204,19 @@ public class SimulationImprovementCandidateService {
     root.put("beforeSummary", candidate.getBeforeSummary());
     root.put("afterSummary", candidate.getAfterSummary());
     root.put("evidenceSummary", candidate.getEvidenceSummary());
+    return root;
+  }
+
+  private String buildGenerationFailureEnvelope(
+      SimulationImprovementCandidate candidate, SimulationStructuralPatchGenerationResult result) {
+    ObjectNode root = objectMapper.createObjectNode();
+    root.put("schemaVersion", "simulation-structural-patch-generation.v1");
+    root.put("status", result.status().name());
+    root.put("summary", result.summary());
+    if (result.message() != null) {
+      root.put("message", result.message());
+    }
+    root.set("descriptionPatch", buildDescriptionPatchNode(candidate));
     return toJson(root);
   }
 

--- a/backend/src/main/java/com/init/workflowruntime/application/SimulationImprovementEvidenceAssembler.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/SimulationImprovementEvidenceAssembler.java
@@ -1,0 +1,241 @@
+package com.init.workflowruntime.application;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.init.domainpack.domain.repository.IntentDefinitionRepository;
+import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
+import com.init.domainpack.domain.repository.RiskDefinitionRepository;
+import com.init.domainpack.domain.repository.SlotDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
+import com.init.workflowruntime.application.dto.SimulationImprovementEvidence;
+import com.init.workflowruntime.application.dto.SimulationImprovementEvidence.DomainPackContext;
+import com.init.workflowruntime.application.dto.SimulationImprovementEvidence.GoldenReplay;
+import com.init.workflowruntime.application.dto.SimulationImprovementEvidence.IntentView;
+import com.init.workflowruntime.application.dto.SimulationImprovementEvidence.PolicyView;
+import com.init.workflowruntime.application.dto.SimulationImprovementEvidence.RiskView;
+import com.init.workflowruntime.application.dto.SimulationImprovementEvidence.SessionMeta;
+import com.init.workflowruntime.application.dto.SimulationImprovementEvidence.SlotView;
+import com.init.workflowruntime.application.dto.SimulationImprovementEvidence.Turn;
+import com.init.workflowruntime.application.dto.SimulationImprovementEvidence.WorkflowView;
+import com.init.workflowruntime.domain.ChatMessage;
+import com.init.workflowruntime.domain.ChatMessageRepository;
+import com.init.workflowruntime.domain.ChatSession;
+import com.init.workflowruntime.domain.SimulationFeedback;
+import com.init.workflowruntime.domain.SimulationGoldenCase;
+import com.init.workflowruntime.domain.SimulationGoldenCaseReplayResult;
+import com.init.workflowruntime.domain.SimulationGoldenCaseReplayResultRepository;
+import com.init.workflowruntime.domain.SimulationGoldenCaseRepository;
+import com.init.workflowruntime.domain.WorkflowExecution;
+import com.init.workflowruntime.domain.WorkflowExecutionRepository;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+/**
+ * 시뮬레이션 개선 후보를 위한 evidence package를 백엔드에서 조립한다. 프론트엔드 프롬프트 조립을 막기 위해 대화 전사, 런타임 상태, 골든 리플레이 실패, 대상
+ * Domain Pack 컨텍스트를 모두 백엔드 조회로 모은다. 어떤 DB 변경도 하지 않는다.
+ */
+@Component
+public class SimulationImprovementEvidenceAssembler {
+
+  private static final int MAX_RECENT_TURNS = 12;
+  private static final int MAX_JSON_FIELD_LENGTH = 2000;
+
+  private final ChatMessageRepository chatMessageRepository;
+  private final WorkflowExecutionRepository workflowExecutionRepository;
+  private final SimulationGoldenCaseRepository goldenCaseRepository;
+  private final SimulationGoldenCaseReplayResultRepository replayResultRepository;
+  private final IntentDefinitionRepository intentDefinitionRepository;
+  private final SlotDefinitionRepository slotDefinitionRepository;
+  private final WorkflowDefinitionRepository workflowDefinitionRepository;
+  private final PolicyDefinitionRepository policyDefinitionRepository;
+  private final RiskDefinitionRepository riskDefinitionRepository;
+  private final ObjectMapper objectMapper;
+
+  public SimulationImprovementEvidenceAssembler(
+      ChatMessageRepository chatMessageRepository,
+      WorkflowExecutionRepository workflowExecutionRepository,
+      SimulationGoldenCaseRepository goldenCaseRepository,
+      SimulationGoldenCaseReplayResultRepository replayResultRepository,
+      IntentDefinitionRepository intentDefinitionRepository,
+      SlotDefinitionRepository slotDefinitionRepository,
+      WorkflowDefinitionRepository workflowDefinitionRepository,
+      PolicyDefinitionRepository policyDefinitionRepository,
+      RiskDefinitionRepository riskDefinitionRepository,
+      ObjectMapper objectMapper) {
+    this.chatMessageRepository = chatMessageRepository;
+    this.workflowExecutionRepository = workflowExecutionRepository;
+    this.goldenCaseRepository = goldenCaseRepository;
+    this.replayResultRepository = replayResultRepository;
+    this.intentDefinitionRepository = intentDefinitionRepository;
+    this.slotDefinitionRepository = slotDefinitionRepository;
+    this.workflowDefinitionRepository = workflowDefinitionRepository;
+    this.policyDefinitionRepository = policyDefinitionRepository;
+    this.riskDefinitionRepository = riskDefinitionRepository;
+    this.objectMapper = objectMapper;
+  }
+
+  public SimulationImprovementEvidence assemble(SimulationFeedback feedback, ChatSession session) {
+    Long versionId = session.getDomainPackVersionId();
+    WorkflowExecution execution =
+        workflowExecutionRepository
+            .findTopByChatSessionIdOrderByStartedAtDescIdDesc(session.getId())
+            .orElse(null);
+    return new SimulationImprovementEvidence(
+        feedbackEvidence(feedback),
+        sessionMeta(session, execution, versionId),
+        goldenReplay(session.getId()),
+        domainPackContext(versionId));
+  }
+
+  private SimulationImprovementEvidence.Feedback feedbackEvidence(SimulationFeedback feedback) {
+    return new SimulationImprovementEvidence.Feedback(
+        feedback.getId(),
+        feedback.getFeedbackType() == null ? null : feedback.getFeedbackType().name(),
+        feedback.getDescription(),
+        feedback.getExpectedBehavior(),
+        feedback.getSeverity() == null ? null : feedback.getSeverity().name(),
+        feedback.getChatMessageId());
+  }
+
+  private SessionMeta sessionMeta(
+      ChatSession session, WorkflowExecution execution, Long versionId) {
+    String matchedWorkflowCode = matchedWorkflowCode(execution, versionId);
+    return new SessionMeta(
+        session.getId(),
+        execution == null ? null : execution.getStatus(),
+        execution == null ? null : execution.getCurrentState(),
+        selectedIntentCode(session),
+        matchedWorkflowCode,
+        slotValues(execution),
+        recentTurns(session.getId()));
+  }
+
+  private String matchedWorkflowCode(WorkflowExecution execution, Long versionId) {
+    if (execution == null || execution.getWorkflowDefinitionId() == null) {
+      return null;
+    }
+    return workflowDefinitionRepository
+        .findByIdAndDomainPackVersionId(execution.getWorkflowDefinitionId(), versionId)
+        .map(workflow -> workflow.getWorkflowCode())
+        .orElse(null);
+  }
+
+  private String selectedIntentCode(ChatSession session) {
+    JsonNode meta = readTree(session.getMetaJson());
+    JsonNode value = meta.get("selectedIntentCode");
+    if (value == null || value.isNull() || !value.isTextual()) {
+      return null;
+    }
+    String text = value.asText().strip();
+    return text.isEmpty() ? null : text;
+  }
+
+  private JsonNode slotValues(WorkflowExecution execution) {
+    if (execution == null) {
+      return NullNode.getInstance();
+    }
+    return readTree(execution.getSlotValuesJson());
+  }
+
+  private List<Turn> recentTurns(Long sessionId) {
+    List<ChatMessage> messages =
+        chatMessageRepository.findByChatSessionIdOrderBySeqNoAsc(sessionId);
+    int from = Math.max(0, messages.size() - MAX_RECENT_TURNS);
+    return messages.subList(from, messages.size()).stream()
+        .map(message -> new Turn(message.getSenderRole(), message.getContent()))
+        .toList();
+  }
+
+  private GoldenReplay goldenReplay(Long sessionId) {
+    SimulationGoldenCase goldenCase =
+        goldenCaseRepository.findBySourceChatSessionId(sessionId).orElse(null);
+    if (goldenCase == null) {
+      return null;
+    }
+    SimulationGoldenCaseReplayResult replay =
+        replayResultRepository.findLatestByGoldenCaseId(goldenCase.getId()).orElse(null);
+    if (replay == null) {
+      return new GoldenReplay(goldenCase.getId(), null, null, null, null, null);
+    }
+    return new GoldenReplay(
+        goldenCase.getId(),
+        replay.getId(),
+        replay.getStatus() == null ? null : replay.getStatus().name(),
+        truncate(replay.getExpectedJson()),
+        truncate(replay.getActualJson()),
+        replay.getFailureSummary());
+  }
+
+  private DomainPackContext domainPackContext(Long versionId) {
+    List<IntentView> intents =
+        intentDefinitionRepository.findByDomainPackVersionId(versionId).stream()
+            .map(
+                intent ->
+                    new IntentView(
+                        intent.getIntentCode(), intent.getName(), intent.getDescription()))
+            .toList();
+    List<SlotView> slots =
+        slotDefinitionRepository.findAllByDomainPackVersionIdOrderBySlotCodeAsc(versionId).stream()
+            .map(
+                slot ->
+                    new SlotView(
+                        slot.getSlotCode(),
+                        slot.getName(),
+                        slot.getDescription(),
+                        truncate(slot.getValidationRuleJson())))
+            .toList();
+    List<WorkflowView> workflows =
+        workflowDefinitionRepository.findAllByDomainPackVersionId(versionId).stream()
+            .map(
+                workflow ->
+                    new WorkflowView(
+                        workflow.getWorkflowCode(),
+                        workflow.getName(),
+                        workflow.getDescription(),
+                        truncate(workflow.getGraphJson())))
+            .toList();
+    List<PolicyView> policies =
+        policyDefinitionRepository
+            .findAllByDomainPackVersionIdOrderByPolicyCodeAsc(versionId)
+            .stream()
+            .map(
+                policy ->
+                    new PolicyView(
+                        policy.getPolicyCode(),
+                        policy.getName(),
+                        policy.getDescription(),
+                        truncate(policy.getConditionJson())))
+            .toList();
+    List<RiskView> risks =
+        riskDefinitionRepository.findAllByDomainPackVersionIdOrderByRiskCodeAsc(versionId).stream()
+            .map(
+                risk ->
+                    new RiskView(
+                        risk.getRiskCode(),
+                        risk.getName(),
+                        risk.getDescription(),
+                        truncate(risk.getTriggerConditionJson())))
+            .toList();
+    return new DomainPackContext(versionId, intents, slots, workflows, policies, risks);
+  }
+
+  private JsonNode readTree(String json) {
+    if (json == null || json.isBlank()) {
+      return NullNode.getInstance();
+    }
+    try {
+      return objectMapper.readTree(json);
+    } catch (JsonProcessingException e) {
+      return NullNode.getInstance();
+    }
+  }
+
+  private String truncate(String value) {
+    if (value == null || value.length() <= MAX_JSON_FIELD_LENGTH) {
+      return value;
+    }
+    return value.substring(0, MAX_JSON_FIELD_LENGTH);
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/application/SimulationStructuralPatchGenerationResult.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/SimulationStructuralPatchGenerationResult.java
@@ -1,0 +1,45 @@
+package com.init.workflowruntime.application;
+
+/**
+ * 구조적 패치 생성 결과. {@code SUCCESS}일 때만 {@code patchJson}이 #879 검증을 통과한 구조적 패치 JSON이며, 그 외에는 후보에 기록할 생성
+ * 실패 상태와 사람이 읽을 수 있는 {@code summary}/{@code message}를 담는다.
+ */
+public record SimulationStructuralPatchGenerationResult(
+    SimulationStructuralPatchGenerationStatus status,
+    String patchJson,
+    String summary,
+    String message) {
+
+  public static SimulationStructuralPatchGenerationResult success(String patchJson) {
+    return new SimulationStructuralPatchGenerationResult(
+        SimulationStructuralPatchGenerationStatus.SUCCESS, patchJson, null, null);
+  }
+
+  public static SimulationStructuralPatchGenerationResult needsHumanTarget(String summary) {
+    return new SimulationStructuralPatchGenerationResult(
+        SimulationStructuralPatchGenerationStatus.NEEDS_HUMAN_TARGET,
+        null,
+        summary == null || summary.isBlank() ? "사람이 변경 대상을 직접 지정해야 합니다." : summary.strip(),
+        null);
+  }
+
+  public static SimulationStructuralPatchGenerationResult invalidOutput(String message) {
+    return new SimulationStructuralPatchGenerationResult(
+        SimulationStructuralPatchGenerationStatus.INVALID_OUTPUT,
+        null,
+        "구조적 패치를 자동으로 생성하지 못했습니다.",
+        message);
+  }
+
+  public static SimulationStructuralPatchGenerationResult generationError(String message) {
+    return new SimulationStructuralPatchGenerationResult(
+        SimulationStructuralPatchGenerationStatus.GENERATION_ERROR,
+        null,
+        "구조적 패치 생성 중 오류가 발생했습니다.",
+        message);
+  }
+
+  public boolean isSuccess() {
+    return status == SimulationStructuralPatchGenerationStatus.SUCCESS;
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/application/SimulationStructuralPatchGenerationService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/SimulationStructuralPatchGenerationService.java
@@ -1,0 +1,118 @@
+package com.init.workflowruntime.application;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.workflowruntime.application.dto.SimulationImprovementEvidence;
+import com.init.workflowruntime.domain.ChatSession;
+import com.init.workflowruntime.domain.InvalidStructuralPatchException;
+import com.init.workflowruntime.domain.SimulationFeedback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.retry.NonTransientAiException;
+import org.springframework.ai.retry.TransientAiException;
+import org.springframework.stereotype.Service;
+
+/**
+ * 시뮬레이션 근거로부터 LLM이 {@code simulation-structural-patch.v1} 구조적 패치를 생성하게 하고, #879 parser로 검증한다. 모델은
+ * 구조화된 패치 JSON만 만들고 Domain Pack 테이블을 직접 변경하지 않는다. 파싱/검증 실패와 모호한 대상은 가짜 패치 대신 명확한 실패 상태로 변환한다.
+ */
+@Service
+public class SimulationStructuralPatchGenerationService {
+
+  private static final Logger log =
+      LoggerFactory.getLogger(SimulationStructuralPatchGenerationService.class);
+
+  private final ChatClient chatClient;
+  private final SimulationImprovementEvidenceAssembler evidenceAssembler;
+  private final SimulationStructuralPatchPromptFactory promptFactory;
+  private final StructuralDomainPackPatchParser patchParser;
+  private final ObjectMapper objectMapper;
+
+  public SimulationStructuralPatchGenerationService(
+      ChatClient chatClient,
+      SimulationImprovementEvidenceAssembler evidenceAssembler,
+      SimulationStructuralPatchPromptFactory promptFactory,
+      StructuralDomainPackPatchParser patchParser,
+      ObjectMapper objectMapper) {
+    this.chatClient = chatClient;
+    this.evidenceAssembler = evidenceAssembler;
+    this.promptFactory = promptFactory;
+    this.patchParser = patchParser;
+    this.objectMapper = objectMapper;
+  }
+
+  public SimulationStructuralPatchGenerationResult generate(
+      SimulationFeedback feedback, ChatSession session) {
+    SimulationImprovementEvidence evidence = evidenceAssembler.assemble(feedback, session);
+    String rawContent;
+    try {
+      rawContent =
+          chatClient
+              .prompt()
+              .system(promptFactory.systemPrompt())
+              .user(promptFactory.buildUserPrompt(evidence))
+              .call()
+              .content();
+    } catch (NonTransientAiException | TransientAiException e) {
+      log.warn("structural patch generation LLM call failed: {}", e.toString());
+      log.debug("structural patch generation failure detail", e);
+      return SimulationStructuralPatchGenerationResult.generationError(e.getMessage());
+    }
+    return interpret(rawContent);
+  }
+
+  SimulationStructuralPatchGenerationResult interpret(String rawContent) {
+    if (rawContent == null || rawContent.isBlank()) {
+      return SimulationStructuralPatchGenerationResult.invalidOutput("LLM이 빈 응답을 반환했습니다.");
+    }
+    String jsonText = extractJsonObject(rawContent);
+    if (jsonText == null) {
+      return SimulationStructuralPatchGenerationResult.invalidOutput("응답에서 JSON 객체를 찾을 수 없습니다.");
+    }
+    JsonNode node;
+    try {
+      node = objectMapper.readTree(jsonText);
+    } catch (JsonProcessingException e) {
+      return SimulationStructuralPatchGenerationResult.invalidOutput("응답을 JSON으로 파싱할 수 없습니다.");
+    }
+    if (!node.isObject()) {
+      return SimulationStructuralPatchGenerationResult.invalidOutput("응답은 JSON 객체여야 합니다.");
+    }
+    if (isNeedsHumanTarget(node)) {
+      return SimulationStructuralPatchGenerationResult.needsHumanTarget(readText(node, "summary"));
+    }
+    try {
+      patchParser.parse(jsonText);
+      return SimulationStructuralPatchGenerationResult.success(jsonText);
+    } catch (InvalidStructuralPatchException e) {
+      return SimulationStructuralPatchGenerationResult.invalidOutput(e.getMessage());
+    }
+  }
+
+  private boolean isNeedsHumanTarget(JsonNode node) {
+    JsonNode status = node.get("status");
+    return status != null
+        && status.isTextual()
+        && SimulationStructuralPatchPromptFactory.NEEDS_HUMAN_TARGET.equalsIgnoreCase(
+            status.asText().strip());
+  }
+
+  private String readText(JsonNode node, String field) {
+    JsonNode value = node.get(field);
+    if (value == null || value.isNull() || !value.isTextual()) {
+      return null;
+    }
+    return value.asText();
+  }
+
+  private String extractJsonObject(String content) {
+    int start = content.indexOf('{');
+    int end = content.lastIndexOf('}');
+    if (start < 0 || end <= start) {
+      return null;
+    }
+    return content.substring(start, end + 1);
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/application/SimulationStructuralPatchGenerationStatus.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/SimulationStructuralPatchGenerationStatus.java
@@ -1,0 +1,13 @@
+package com.init.workflowruntime.application;
+
+/** LLM 기반 구조적 패치 생성 결과 상태. */
+public enum SimulationStructuralPatchGenerationStatus {
+  /** 검증된 구조적 패치를 생성했다. */
+  SUCCESS,
+  /** 모델이 안전하게 대상을 특정할 수 없어 사람의 판단이 필요하다. */
+  NEEDS_HUMAN_TARGET,
+  /** 출력이 파싱/검증되지 않았다(fail closed). */
+  INVALID_OUTPUT,
+  /** LLM 호출 자체가 실패했다. */
+  GENERATION_ERROR
+}

--- a/backend/src/main/java/com/init/workflowruntime/application/SimulationStructuralPatchPromptFactory.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/SimulationStructuralPatchPromptFactory.java
@@ -1,0 +1,94 @@
+package com.init.workflowruntime.application;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.workflowruntime.application.dto.SimulationImprovementEvidence;
+import com.init.workflowruntime.domain.StructuralDomainPackPatch;
+import org.springframework.stereotype.Component;
+
+/**
+ * 구조적 패치 생성용 system/user 프롬프트를 만든다. evidence는 백엔드가 조립한 사실만 담아 직렬화하고, 모델에는 #879 허용 operation과 출력 계약,
+ * 최소 변경/기존 식별자 보존 규칙을 강제한다.
+ */
+@Component
+public class SimulationStructuralPatchPromptFactory {
+
+  static final String NEEDS_HUMAN_TARGET = "NEEDS_HUMAN_TARGET";
+
+  private static final String SYSTEM_PROMPT =
+      """
+      You are a Domain Pack repair planner for a customer-service workflow system.
+      You convert simulation feedback and golden-replay failures into a structured,
+      reviewable repair patch. You never apply changes; you only emit one JSON document.
+      Return JSON only, with no prose and no code fences.
+      """;
+
+  private static final String INSTRUCTIONS =
+      """
+      You are given an evidence package describing a simulation failure and the current Domain Pack.
+      Produce ONE JSON document that repairs the smallest number of Domain Pack elements needed.
+
+      Rules:
+      - Repair the smallest number of elements that satisfy the evidence.
+      - Prefer changing an existing workflow over creating a new workflow.
+      - When the failure is a missing slot question, prefer adding/marking required slots over adding vague response text.
+      - Preserve existing node ids, slot codes, policy codes, risk codes, and workflow codes whenever possible.
+      - Do not invent external facts. Use only codes/ids present in the evidence.
+      - Every operation must include a "reason".
+
+      Output schema (schemaVersion MUST be "%s"):
+      {
+        "schemaVersion": "%s",
+        "summary": "<one Korean sentence>",
+        "evidence": { "feedbackId": <num>, "simulationSessionId": <num>, "failureSummary": "<text>" },
+        "operations": [ { "op": "...", "reason": "...", ... } ]
+      }
+
+      Allowed operations and their fields:
+      - UPDATE_INTENT_DESCRIPTION: intentCode|targetId, description
+      - ADD_INTENT_EXAMPLE: intentCode|targetId, example
+      - UPDATE_SLOT_DESCRIPTION: slotCode|targetId, description
+      - MARK_SLOT_REQUIRED: slotCode|targetId
+      - UPDATE_SLOT_VALIDATION: slotCode|targetId, validation
+      - UPDATE_POLICY_CONDITION: policyCode|targetId, condition
+      - UPDATE_RISK_TRIGGER: riskCode|targetId, trigger
+      - UPDATE_RESPONSE_COPY: responseCode|targetId, copy
+      - ADD_WORKFLOW_NODE: workflowCode|workflowDefinitionId, nodeId, nodeType, (slotCode, prompt)
+      - UPDATE_WORKFLOW_NODE: workflowCode|workflowDefinitionId, nodeId, nodeType, (slotCode, prompt)
+      - ADD_TRANSITION: workflowCode|workflowDefinitionId, from, to, (condition)
+      - UPDATE_TRANSITION: workflowCode|workflowDefinitionId, from, to, (condition)
+      - REMOVE_TRANSITION: workflowCode|workflowDefinitionId, from, to
+
+      If you cannot safely identify which Domain Pack element to change, do NOT guess.
+      Instead return exactly: {"status":"%s","summary":"<why a human must choose the target>"}
+
+      Evidence package:
+      %s
+      """;
+
+  private final ObjectMapper objectMapper;
+
+  public SimulationStructuralPatchPromptFactory(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  public String systemPrompt() {
+    return SYSTEM_PROMPT;
+  }
+
+  public String buildUserPrompt(SimulationImprovementEvidence evidence) {
+    return INSTRUCTIONS.formatted(
+        StructuralDomainPackPatch.SCHEMA_VERSION,
+        StructuralDomainPackPatch.SCHEMA_VERSION,
+        NEEDS_HUMAN_TARGET,
+        serialize(evidence));
+  }
+
+  private String serialize(SimulationImprovementEvidence evidence) {
+    try {
+      return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(evidence);
+    } catch (JsonProcessingException e) {
+      throw new IllegalStateException("evidence 직렬화에 실패했습니다.", e);
+    }
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/application/dto/SimulationImprovementEvidence.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/dto/SimulationImprovementEvidence.java
@@ -1,0 +1,65 @@
+package com.init.workflowruntime.application.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.List;
+
+/**
+ * 시뮬레이션 개선 후보를 위해 백엔드가 조립한 근거(evidence) package. LLM이 {@code simulation-structural-patch.v1} 구조적
+ * 패치를 생성할 때 입력으로 쓰인다. 어떤 식별자/요소도 LLM이 추측하지 않도록 백엔드가 미리 모은 사실만 담는다.
+ */
+public record SimulationImprovementEvidence(
+    Feedback feedback,
+    SessionMeta session,
+    GoldenReplay goldenReplay,
+    DomainPackContext domainPack) {
+
+  /** 피드백 핵심 필드. */
+  public record Feedback(
+      Long feedbackId,
+      String feedbackType,
+      String description,
+      String expectedBehavior,
+      String severity,
+      Long chatMessageId) {}
+
+  /** 실패한 턴 주변의 대화 한 줄. */
+  public record Turn(String role, String content) {}
+
+  /** 시뮬레이션 세션 런타임 컨텍스트. */
+  public record SessionMeta(
+      Long sessionId,
+      String executionStatus,
+      String currentState,
+      String selectedIntentCode,
+      String matchedWorkflowCode,
+      JsonNode slotValues,
+      List<Turn> recentTurns) {}
+
+  /** 골든 케이스 최신 리플레이 결과(있을 때만). */
+  public record GoldenReplay(
+      Long goldenCaseId,
+      Long replayResultId,
+      String status,
+      String expectedJson,
+      String actualJson,
+      String failureSummary) {}
+
+  /** 대상 Domain Pack 버전의 압축된 요소 컨텍스트. */
+  public record DomainPackContext(
+      Long domainPackVersionId,
+      List<IntentView> intents,
+      List<SlotView> slots,
+      List<WorkflowView> workflows,
+      List<PolicyView> policies,
+      List<RiskView> risks) {}
+
+  public record IntentView(String intentCode, String name, String description) {}
+
+  public record SlotView(String slotCode, String name, String description, String validation) {}
+
+  public record WorkflowView(String workflowCode, String name, String description, String graph) {}
+
+  public record PolicyView(String policyCode, String name, String description, String condition) {}
+
+  public record RiskView(String riskCode, String name, String description, String trigger) {}
+}

--- a/backend/src/main/java/com/init/workflowruntime/domain/SimulationGoldenCaseRepository.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/SimulationGoldenCaseRepository.java
@@ -10,6 +10,8 @@ public interface SimulationGoldenCaseRepository {
 
   Optional<SimulationGoldenCase> findByIdAndWorkspaceId(Long id, Long workspaceId);
 
+  Optional<SimulationGoldenCase> findBySourceChatSessionId(Long sourceChatSessionId);
+
   DomainPage<SimulationGoldenCase> findByWorkspaceId(
       Long workspaceId, DomainPageRequest pageRequest);
 }

--- a/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaSimulationGoldenCaseRepository.java
+++ b/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaSimulationGoldenCaseRepository.java
@@ -13,6 +13,9 @@ public interface JpaSimulationGoldenCaseRepository
 
   Optional<SimulationGoldenCase> findByIdAndWorkspaceId(Long id, Long workspaceId);
 
+  Optional<SimulationGoldenCase> findFirstBySourceChatSessionIdOrderByCreatedAtDesc(
+      Long sourceChatSessionId);
+
   Page<SimulationGoldenCase> findByWorkspaceIdOrderByCreatedAtDesc(
       Long workspaceId, Pageable pageable);
 }

--- a/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/SimulationGoldenCaseRepositoryAdapter.java
+++ b/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/SimulationGoldenCaseRepositoryAdapter.java
@@ -34,6 +34,11 @@ public class SimulationGoldenCaseRepositoryAdapter implements SimulationGoldenCa
   }
 
   @Override
+  public Optional<SimulationGoldenCase> findBySourceChatSessionId(Long sourceChatSessionId) {
+    return jpaRepository.findFirstBySourceChatSessionIdOrderByCreatedAtDesc(sourceChatSessionId);
+  }
+
+  @Override
   public DomainPage<SimulationGoldenCase> findByWorkspaceId(
       Long workspaceId, DomainPageRequest pageRequest) {
     return toDomainPage(

--- a/backend/src/test/java/com/init/workflowruntime/application/SimulationImprovementCandidateServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/SimulationImprovementCandidateServiceTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.init.domainpack.application.DomainPackDraftSourceType;
 import com.init.domainpack.application.DomainPackVersionCloneCommand;
@@ -112,15 +113,17 @@ class SimulationImprovementCandidateServiceTest {
   @Mock private ReviewTaskRepository reviewTaskRepository;
   @Mock private ReviewDecisionRepository reviewDecisionRepository;
   @Mock private WorkflowMatchingProfileBuildRequestService profileBuildRequestService;
+  @Mock private SimulationStructuralPatchGenerationService structuralPatchGenerationService;
 
   private SimulationImprovementCandidateService service;
   private SimulationImprovementDraftPatchService draftPatchService;
   private SimulationImprovementCandidateReviewTaskService reviewTaskService;
   private SimulationImprovementCandidateDecisionService decisionService;
+  private ObjectMapper objectMapper;
 
   @BeforeEach
   void setUp() {
-    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper = new ObjectMapper();
     Clock clock = Clock.systemDefaultZone();
     reviewTaskService =
         new SimulationImprovementCandidateReviewTaskService(
@@ -146,15 +149,20 @@ class SimulationImprovementCandidateServiceTest {
             draftPatchService,
             profileBuildRequestService,
             clock);
-    service =
-        new SimulationImprovementCandidateService(
-            feedbackRepository,
-            candidateRepository,
-            chatSessionRepository,
-            workspaceMemberRepository,
-            reviewTaskService,
-            decisionService,
-            objectMapper);
+    service = candidateService(false);
+  }
+
+  private SimulationImprovementCandidateService candidateService(boolean structuralPatchEnabled) {
+    return new SimulationImprovementCandidateService(
+        feedbackRepository,
+        candidateRepository,
+        chatSessionRepository,
+        workspaceMemberRepository,
+        reviewTaskService,
+        decisionService,
+        structuralPatchGenerationService,
+        objectMapper,
+        structuralPatchEnabled);
   }
 
   @Test
@@ -195,6 +203,71 @@ class SimulationImprovementCandidateServiceTest {
     assertThat(feedback.getStatus()).isEqualTo(SimulationFeedbackStatus.CANDIDATE_CREATED);
     verify(feedbackRepository).save(feedback);
     assertThat(result.id()).isEqualTo(1000L);
+  }
+
+  @Test
+  @DisplayName("createFromFeedback: 구조적 패치 생성이 켜지고 성공하면 검증된 패치를 draftPatchJson에 저장한다")
+  void shouldStoreStructuralPatch_whenGenerationEnabledAndSucceeds() {
+    SimulationImprovementCandidateService enabledService = candidateService(true);
+    givenMembership();
+    SimulationFeedback feedback =
+        withFeedbackId(feedback(SimulationFeedbackType.MISSING_SLOT_QUESTION), FEEDBACK_ID);
+    ChatSession session = withSessionId(simulationSession(), SESSION_ID);
+    String patchJson =
+        "{\"schemaVersion\":\"simulation-structural-patch.v1\",\"summary\":\"슬롯 보강\","
+            + "\"evidence\":{\"failureSummary\":\"missing slot\"},"
+            + "\"operations\":[{\"op\":\"MARK_SLOT_REQUIRED\",\"slotCode\":\"order_number\","
+            + "\"reason\":\"필수\"}]}";
+    given(feedbackRepository.findByIdForUpdate(FEEDBACK_ID)).willReturn(Optional.of(feedback));
+    given(candidateRepository.findByFeedbackId(FEEDBACK_ID)).willReturn(Optional.empty());
+    given(chatSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
+    given(structuralPatchGenerationService.generate(any(), any()))
+        .willReturn(SimulationStructuralPatchGenerationResult.success(patchJson));
+    given(candidateRepository.save(any(SimulationImprovementCandidate.class)))
+        .willAnswer(invocation -> withCandidateId(invocation.getArgument(0), 1000L));
+
+    enabledService.createFromFeedback(
+        new CreateSimulationImprovementCandidateCommand(
+            WORKSPACE_ID, USER_ID, FEEDBACK_ID, null, null, "order_number", null, null));
+
+    ArgumentCaptor<SimulationImprovementCandidate> candidateCaptor =
+        ArgumentCaptor.forClass(SimulationImprovementCandidate.class);
+    verify(candidateRepository).save(candidateCaptor.capture());
+    assertThat(candidateCaptor.getValue().getDraftPatchJson()).isEqualTo(patchJson);
+  }
+
+  @Test
+  @DisplayName("createFromFeedback: 구조적 패치 생성이 실패하면 생성 실패 envelope를 draftPatchJson에 저장한다")
+  void shouldStoreGenerationFailureEnvelope_whenGenerationFails() throws Exception {
+    SimulationImprovementCandidateService enabledService = candidateService(true);
+    givenMembership();
+    SimulationFeedback feedback =
+        withFeedbackId(feedback(SimulationFeedbackType.MISSING_SLOT_QUESTION), FEEDBACK_ID);
+    ChatSession session = withSessionId(simulationSession(), SESSION_ID);
+    given(feedbackRepository.findByIdForUpdate(FEEDBACK_ID)).willReturn(Optional.of(feedback));
+    given(candidateRepository.findByFeedbackId(FEEDBACK_ID)).willReturn(Optional.empty());
+    given(chatSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
+    given(structuralPatchGenerationService.generate(any(), any()))
+        .willReturn(
+            SimulationStructuralPatchGenerationResult.invalidOutput("지원하지 않는 operation입니다: FOO"));
+    given(candidateRepository.save(any(SimulationImprovementCandidate.class)))
+        .willAnswer(invocation -> withCandidateId(invocation.getArgument(0), 1000L));
+
+    enabledService.createFromFeedback(
+        new CreateSimulationImprovementCandidateCommand(
+            WORKSPACE_ID, USER_ID, FEEDBACK_ID, null, null, "order_number", null, null));
+
+    ArgumentCaptor<SimulationImprovementCandidate> candidateCaptor =
+        ArgumentCaptor.forClass(SimulationImprovementCandidate.class);
+    verify(candidateRepository).save(candidateCaptor.capture());
+    JsonNode envelope = objectMapper.readTree(candidateCaptor.getValue().getDraftPatchJson());
+    assertThat(envelope.get("schemaVersion").asText())
+        .isEqualTo("simulation-structural-patch-generation.v1");
+    assertThat(envelope.get("status").asText()).isEqualTo("INVALID_OUTPUT");
+    assertThat(envelope.get("summary").asText()).isNotBlank();
+    assertThat(envelope.get("message").asText()).contains("FOO");
+    assertThat(envelope.get("descriptionPatch").get("schemaVersion").asText())
+        .isEqualTo("simulation-candidate-draft-patch.v1");
   }
 
   @Test

--- a/backend/src/test/java/com/init/workflowruntime/application/SimulationImprovementEvidenceAssemblerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/SimulationImprovementEvidenceAssemblerTest.java
@@ -1,0 +1,272 @@
+package com.init.workflowruntime.application;
+
+import static com.init.workflowruntime.support.WorkflowRuntimeTestObjects.chatMessageWithId;
+import static com.init.workflowruntime.support.WorkflowRuntimeTestObjects.chatSessionWithId;
+import static com.init.workflowruntime.support.WorkflowRuntimeTestObjects.simulationFeedbackWithId;
+import static com.init.workflowruntime.support.WorkflowRuntimeTestObjects.simulationGoldenCaseWithId;
+import static com.init.workflowruntime.support.WorkflowRuntimeTestObjects.simulationReplayResultWithId;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.domainpack.domain.model.IntentDefinition;
+import com.init.domainpack.domain.model.PolicyDefinition;
+import com.init.domainpack.domain.model.RiskDefinition;
+import com.init.domainpack.domain.model.SlotDefinition;
+import com.init.domainpack.domain.model.WorkflowDefinition;
+import com.init.domainpack.domain.repository.IntentDefinitionRepository;
+import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
+import com.init.domainpack.domain.repository.RiskDefinitionRepository;
+import com.init.domainpack.domain.repository.SlotDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
+import com.init.workflowruntime.application.dto.SimulationImprovementEvidence;
+import com.init.workflowruntime.domain.ChatMessage;
+import com.init.workflowruntime.domain.ChatMessageRepository;
+import com.init.workflowruntime.domain.ChatSession;
+import com.init.workflowruntime.domain.ChatSessionStatus;
+import com.init.workflowruntime.domain.SimulationFeedback;
+import com.init.workflowruntime.domain.SimulationFeedbackContent;
+import com.init.workflowruntime.domain.SimulationFeedbackSeverity;
+import com.init.workflowruntime.domain.SimulationFeedbackType;
+import com.init.workflowruntime.domain.SimulationGoldenCase;
+import com.init.workflowruntime.domain.SimulationGoldenCaseReplayResult;
+import com.init.workflowruntime.domain.SimulationGoldenCaseReplayResultRepository;
+import com.init.workflowruntime.domain.SimulationGoldenCaseReplayStatus;
+import com.init.workflowruntime.domain.SimulationGoldenCaseRepository;
+import com.init.workflowruntime.domain.WorkflowExecutionRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SimulationImprovementEvidenceAssembler")
+class SimulationImprovementEvidenceAssemblerTest {
+
+  private static final Long WORKSPACE_ID = 10L;
+  private static final Long USER_ID = 7L;
+  private static final Long VERSION_ID = 101L;
+  private static final Long SESSION_ID = 55L;
+  private static final Long FEEDBACK_ID = 901L;
+  private static final Long GOLDEN_CASE_ID = 789L;
+  private static final Long REPLAY_ID = 790L;
+
+  @Mock private ChatMessageRepository chatMessageRepository;
+  @Mock private WorkflowExecutionRepository workflowExecutionRepository;
+  @Mock private SimulationGoldenCaseRepository goldenCaseRepository;
+  @Mock private SimulationGoldenCaseReplayResultRepository replayResultRepository;
+  @Mock private IntentDefinitionRepository intentDefinitionRepository;
+  @Mock private SlotDefinitionRepository slotDefinitionRepository;
+  @Mock private WorkflowDefinitionRepository workflowDefinitionRepository;
+  @Mock private PolicyDefinitionRepository policyDefinitionRepository;
+  @Mock private RiskDefinitionRepository riskDefinitionRepository;
+
+  private SimulationImprovementEvidenceAssembler assembler() {
+    return new SimulationImprovementEvidenceAssembler(
+        chatMessageRepository,
+        workflowExecutionRepository,
+        goldenCaseRepository,
+        replayResultRepository,
+        intentDefinitionRepository,
+        slotDefinitionRepository,
+        workflowDefinitionRepository,
+        policyDefinitionRepository,
+        riskDefinitionRepository,
+        new ObjectMapper());
+  }
+
+  private SimulationFeedback feedback() {
+    return simulationFeedbackWithId(
+        SimulationFeedback.create(
+            WORKSPACE_ID,
+            SESSION_ID,
+            5L,
+            new SimulationFeedbackContent(
+                SimulationFeedbackType.MISSING_SLOT_QUESTION,
+                "픽업 날짜를 묻지 않았습니다.",
+                "픽업 날짜를 먼저 묻기",
+                SimulationFeedbackSeverity.HIGH),
+            USER_ID),
+        FEEDBACK_ID);
+  }
+
+  private ChatSession session() {
+    return chatSessionWithId(
+        ChatSession.create(
+            WORKSPACE_ID,
+            VERSION_ID,
+            ChatSessionStatus.OPEN,
+            SimulationService.SIMULATION_CHANNEL,
+            "{\"selectedIntentCode\":\"pickup\"}",
+            USER_ID),
+        SESSION_ID);
+  }
+
+  private void givenConversation() {
+    ChatMessage userTurn =
+        chatMessageWithId(ChatMessage.create(SESSION_ID, 1, "USER", "TEXT", "공항 픽업 예약하고 싶어요"), 1L);
+    ChatMessage assistantTurn =
+        chatMessageWithId(
+            ChatMessage.create(SESSION_ID, 2, "ASSISTANT", "TEXT", "어떤 도움이 필요하신가요?"), 2L);
+    given(chatMessageRepository.findByChatSessionIdOrderBySeqNoAsc(SESSION_ID))
+        .willReturn(List.of(userTurn, assistantTurn));
+    given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(SESSION_ID))
+        .willReturn(Optional.empty());
+  }
+
+  private void givenDomainPack() {
+    given(intentDefinitionRepository.findByDomainPackVersionId(VERSION_ID))
+        .willReturn(
+            List.of(
+                IntentDefinition.create(
+                    VERSION_ID, "pickup", "픽업 예약", "공항 픽업 예약 의도", 1, "{}", "{}", "[]", "{}")));
+    given(slotDefinitionRepository.findAllByDomainPackVersionIdOrderBySlotCodeAsc(VERSION_ID))
+        .willReturn(
+            List.of(
+                SlotDefinition.create(
+                    VERSION_ID,
+                    "pickupDate",
+                    "픽업 날짜",
+                    "예약 픽업 날짜",
+                    "DATE",
+                    false,
+                    "{}",
+                    null,
+                    "{}")));
+    given(workflowDefinitionRepository.findAllByDomainPackVersionId(VERSION_ID))
+        .willReturn(
+            List.of(
+                WorkflowDefinition.create(
+                    VERSION_ID,
+                    "airport_pickup_reservation_flow",
+                    "공항 픽업 예약",
+                    "예약 흐름",
+                    "{\"nodes\":[]}",
+                    "start",
+                    "[]",
+                    "[]",
+                    "{}",
+                    1L,
+                    true,
+                    "{}")));
+    given(policyDefinitionRepository.findAllByDomainPackVersionIdOrderByPolicyCodeAsc(VERSION_ID))
+        .willReturn(
+            List.of(
+                PolicyDefinition.create(
+                    VERSION_ID,
+                    "pickup_policy",
+                    "픽업 정책",
+                    "정책 설명",
+                    "HIGH",
+                    "{}",
+                    "{}",
+                    "[]",
+                    "{}")));
+    given(riskDefinitionRepository.findAllByDomainPackVersionIdOrderByRiskCodeAsc(VERSION_ID))
+        .willReturn(
+            List.of(
+                RiskDefinition.create(
+                    VERSION_ID, "pickup_risk", "픽업 위험", "위험 설명", "HIGH", "{}", "{}", "[]", "{}")));
+  }
+
+  @Test
+  @DisplayName("피드백·대화·골든 리플레이·Domain Pack 컨텍스트를 evidence로 모은다")
+  void shouldAssembleFullEvidence() {
+    givenConversation();
+    givenDomainPack();
+    SimulationGoldenCase goldenCase =
+        simulationGoldenCaseWithId(
+            SimulationGoldenCase.create(
+                WORKSPACE_ID, SESSION_ID, VERSION_ID, "case", "[]", "{}", USER_ID),
+            GOLDEN_CASE_ID);
+    SimulationGoldenCaseReplayResult replay =
+        simulationReplayResultWithId(
+            SimulationGoldenCaseReplayResult.record(
+                WORKSPACE_ID,
+                GOLDEN_CASE_ID,
+                VERSION_ID,
+                999L,
+                SimulationGoldenCaseReplayStatus.FAIL,
+                "{}",
+                "{}",
+                "actionType expected ASK_SLOT but was NEED_INTENT",
+                USER_ID),
+            REPLAY_ID);
+    given(goldenCaseRepository.findBySourceChatSessionId(SESSION_ID))
+        .willReturn(Optional.of(goldenCase));
+    given(replayResultRepository.findLatestByGoldenCaseId(GOLDEN_CASE_ID))
+        .willReturn(Optional.of(replay));
+
+    SimulationImprovementEvidence evidence = assembler().assemble(feedback(), session());
+
+    assertThat(evidence.feedback().feedbackId()).isEqualTo(FEEDBACK_ID);
+    assertThat(evidence.feedback().feedbackType()).isEqualTo("MISSING_SLOT_QUESTION");
+    assertThat(evidence.feedback().severity()).isEqualTo("HIGH");
+    assertThat(evidence.feedback().chatMessageId()).isEqualTo(5L);
+    assertThat(evidence.session().selectedIntentCode()).isEqualTo("pickup");
+    assertThat(evidence.session().recentTurns()).hasSize(2);
+    assertThat(evidence.goldenReplay().goldenCaseId()).isEqualTo(GOLDEN_CASE_ID);
+    assertThat(evidence.goldenReplay().replayResultId()).isEqualTo(REPLAY_ID);
+    assertThat(evidence.goldenReplay().status()).isEqualTo("FAIL");
+    assertThat(evidence.goldenReplay().failureSummary()).contains("ASK_SLOT");
+    assertThat(evidence.domainPack().intents()).hasSize(1);
+    assertThat(evidence.domainPack().intents().get(0).intentCode()).isEqualTo("pickup");
+    assertThat(evidence.domainPack().slots()).hasSize(1);
+    assertThat(evidence.domainPack().workflows()).hasSize(1);
+    assertThat(evidence.domainPack().policies()).hasSize(1);
+    assertThat(evidence.domainPack().risks()).hasSize(1);
+  }
+
+  @Test
+  @DisplayName("골든 케이스가 없으면 goldenReplay는 null이다")
+  void shouldOmitGoldenReplay_whenNoGoldenCase() {
+    givenConversation();
+    givenDomainPack();
+    given(goldenCaseRepository.findBySourceChatSessionId(SESSION_ID)).willReturn(Optional.empty());
+
+    SimulationImprovementEvidence evidence = assembler().assemble(feedback(), session());
+
+    assertThat(evidence.goldenReplay()).isNull();
+  }
+
+  @Test
+  @DisplayName("긴 workflow graph JSON은 상한 길이로 절단된다")
+  void shouldTruncateLongJsonFields() {
+    given(chatMessageRepository.findByChatSessionIdOrderBySeqNoAsc(SESSION_ID))
+        .willReturn(List.of());
+    given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(SESSION_ID))
+        .willReturn(Optional.empty());
+    given(goldenCaseRepository.findBySourceChatSessionId(SESSION_ID)).willReturn(Optional.empty());
+    given(intentDefinitionRepository.findByDomainPackVersionId(VERSION_ID)).willReturn(List.of());
+    given(slotDefinitionRepository.findAllByDomainPackVersionIdOrderBySlotCodeAsc(VERSION_ID))
+        .willReturn(List.of());
+    given(policyDefinitionRepository.findAllByDomainPackVersionIdOrderByPolicyCodeAsc(VERSION_ID))
+        .willReturn(List.of());
+    given(riskDefinitionRepository.findAllByDomainPackVersionIdOrderByRiskCodeAsc(VERSION_ID))
+        .willReturn(List.of());
+    String longGraph = "x".repeat(2500);
+    given(workflowDefinitionRepository.findAllByDomainPackVersionId(VERSION_ID))
+        .willReturn(
+            List.of(
+                WorkflowDefinition.create(
+                    VERSION_ID,
+                    "flow",
+                    "흐름",
+                    "설명",
+                    longGraph,
+                    "start",
+                    "[]",
+                    "[]",
+                    "{}",
+                    1L,
+                    true,
+                    "{}")));
+
+    SimulationImprovementEvidence evidence = assembler().assemble(feedback(), session());
+
+    assertThat(evidence.domainPack().workflows().get(0).graph()).hasSize(2000);
+  }
+}

--- a/backend/src/test/java/com/init/workflowruntime/application/SimulationStructuralPatchGenerationServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/SimulationStructuralPatchGenerationServiceTest.java
@@ -1,0 +1,95 @@
+package com.init.workflowruntime.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("SimulationStructuralPatchGenerationService.interpret")
+class SimulationStructuralPatchGenerationServiceTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final SimulationStructuralPatchGenerationService service =
+      new SimulationStructuralPatchGenerationService(
+          null, null, null, new StructuralDomainPackPatchParser(objectMapper), objectMapper);
+
+  private static final String VALID_PATCH =
+      "{\"schemaVersion\":\"simulation-structural-patch.v1\",\"summary\":\"슬롯 보강\","
+          + "\"evidence\":{\"feedbackId\":901,\"failureSummary\":\"missing slot\"},"
+          + "\"operations\":[{\"op\":\"MARK_SLOT_REQUIRED\",\"slotCode\":\"pickupDate\","
+          + "\"reason\":\"예약 전 필수\"}]}";
+
+  @Test
+  @DisplayName("유효한 구조적 패치 출력은 SUCCESS로 검증된 JSON을 보관한다")
+  void shouldReturnSuccess_whenOutputIsValidStructuralPatch() {
+    SimulationStructuralPatchGenerationResult result = service.interpret(VALID_PATCH);
+
+    assertThat(result.status()).isEqualTo(SimulationStructuralPatchGenerationStatus.SUCCESS);
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.patchJson()).isEqualTo(VALID_PATCH);
+  }
+
+  @Test
+  @DisplayName("코드펜스와 산문에 감싸여 와도 JSON 객체를 추출해 검증한다")
+  void shouldExtractJson_whenWrappedInCodeFence() {
+    String wrapped = "다음 패치입니다:\n```json\n" + VALID_PATCH + "\n```\n끝.";
+
+    SimulationStructuralPatchGenerationResult result = service.interpret(wrapped);
+
+    assertThat(result.isSuccess()).isTrue();
+  }
+
+  @Test
+  @DisplayName("JSON 객체가 없는 응답은 INVALID_OUTPUT으로 처리한다")
+  void shouldReturnInvalidOutput_whenNoJsonObject() {
+    SimulationStructuralPatchGenerationResult result = service.interpret("죄송하지만 만들 수 없습니다");
+
+    assertThat(result.status()).isEqualTo(SimulationStructuralPatchGenerationStatus.INVALID_OUTPUT);
+    assertThat(result.patchJson()).isNull();
+    assertThat(result.summary()).isNotBlank();
+  }
+
+  @Test
+  @DisplayName("깨진 JSON은 INVALID_OUTPUT으로 처리한다")
+  void shouldReturnInvalidOutput_whenJsonIsMalformed() {
+    SimulationStructuralPatchGenerationResult result =
+        service.interpret("{\"schemaVersion\": \"simulation-structural-patch.v1\",");
+
+    assertThat(result.status()).isEqualTo(SimulationStructuralPatchGenerationStatus.INVALID_OUTPUT);
+  }
+
+  @Test
+  @DisplayName("미지원 operation은 fail-closed로 INVALID_OUTPUT 처리한다")
+  void shouldReturnInvalidOutput_whenOperationUnsupported() {
+    String unsupported =
+        "{\"schemaVersion\":\"simulation-structural-patch.v1\",\"summary\":\"x\","
+            + "\"evidence\":{\"failureSummary\":\"f\"},"
+            + "\"operations\":[{\"op\":\"DELETE_EVERYTHING\",\"reason\":\"r\"}]}";
+
+    SimulationStructuralPatchGenerationResult result = service.interpret(unsupported);
+
+    assertThat(result.status()).isEqualTo(SimulationStructuralPatchGenerationStatus.INVALID_OUTPUT);
+    assertThat(result.message()).contains("DELETE_EVERYTHING");
+  }
+
+  @Test
+  @DisplayName("모델이 NEEDS_HUMAN_TARGET을 반환하면 모호 대상 상태로 처리한다")
+  void shouldReturnNeedsHumanTarget_whenModelDeclines() {
+    String declined = "{\"status\":\"NEEDS_HUMAN_TARGET\",\"summary\":\"대상이 모호합니다\"}";
+
+    SimulationStructuralPatchGenerationResult result = service.interpret(declined);
+
+    assertThat(result.status())
+        .isEqualTo(SimulationStructuralPatchGenerationStatus.NEEDS_HUMAN_TARGET);
+    assertThat(result.summary()).isEqualTo("대상이 모호합니다");
+    assertThat(result.patchJson()).isNull();
+  }
+
+  @Test
+  @DisplayName("빈 응답은 INVALID_OUTPUT으로 처리한다")
+  void shouldReturnInvalidOutput_whenBlank() {
+    assertThat(service.interpret("  ").status())
+        .isEqualTo(SimulationStructuralPatchGenerationStatus.INVALID_OUTPUT);
+  }
+}

--- a/backend/src/test/java/com/init/workflowruntime/application/SimulationStructuralPatchPromptFactoryTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/SimulationStructuralPatchPromptFactoryTest.java
@@ -1,0 +1,62 @@
+package com.init.workflowruntime.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.init.workflowruntime.application.dto.SimulationImprovementEvidence;
+import com.init.workflowruntime.application.dto.SimulationImprovementEvidence.DomainPackContext;
+import com.init.workflowruntime.application.dto.SimulationImprovementEvidence.Feedback;
+import com.init.workflowruntime.application.dto.SimulationImprovementEvidence.SessionMeta;
+import com.init.workflowruntime.application.dto.SimulationImprovementEvidence.Turn;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("SimulationStructuralPatchPromptFactory")
+class SimulationStructuralPatchPromptFactoryTest {
+
+  private final SimulationStructuralPatchPromptFactory factory =
+      new SimulationStructuralPatchPromptFactory(new ObjectMapper());
+
+  private SimulationImprovementEvidence evidence() {
+    return new SimulationImprovementEvidence(
+        new Feedback(901L, "MISSING_SLOT_QUESTION", "픽업 날짜를 묻지 않았습니다.", "픽업 날짜를 먼저 묻기", "HIGH", 5L),
+        new SessionMeta(
+            42L,
+            "RUNNING",
+            "ask_intent",
+            "pickup",
+            "airport_pickup_reservation_flow",
+            NullNode.getInstance(),
+            List.of(new Turn("USER", "공항 픽업 예약하고 싶어요"))),
+        null,
+        new DomainPackContext(101L, List.of(), List.of(), List.of(), List.of(), List.of()));
+  }
+
+  @Test
+  @DisplayName("user 프롬프트에 출력 계약·허용 operation·모호 탈출구가 포함된다")
+  void shouldIncludeContractAndOperations() {
+    String prompt = factory.buildUserPrompt(evidence());
+
+    assertThat(prompt).contains("simulation-structural-patch.v1");
+    assertThat(prompt).contains("MARK_SLOT_REQUIRED");
+    assertThat(prompt).contains("ADD_WORKFLOW_NODE");
+    assertThat(prompt).contains("NEEDS_HUMAN_TARGET");
+  }
+
+  @Test
+  @DisplayName("user 프롬프트에 백엔드가 조립한 evidence 핵심 필드가 직렬화되어 들어간다")
+  void shouldEmbedSerializedEvidence() {
+    String prompt = factory.buildUserPrompt(evidence());
+
+    assertThat(prompt).contains("픽업 날짜를 묻지 않았습니다.");
+    assertThat(prompt).contains("airport_pickup_reservation_flow");
+  }
+
+  @Test
+  @DisplayName("system 프롬프트는 JSON only 생성 역할을 고정한다")
+  void shouldFixSystemRole() {
+    assertThat(factory.systemPrompt()).contains("JSON only");
+  }
+}


### PR DESCRIPTION
## 배경

#879에서 정의한 `simulation-structural-patch.v1` 구조적 패치 계약 위에, 시뮬레이션 실패·골든 리플레이 근거로부터 LLM이 실제 패치 문서를 생성하도록 한다. 기존에는 후보가 description-only `simulation-candidate-draft-patch.v1`만 만들어 워크플로우 구조·슬롯 요구사항·정책 조건·그래프 전이를 수리하지 못했다.

closes #880

## 변경 내용

- `SimulationImprovementEvidenceAssembler`: 피드백·최근 대화·런타임 상태(선택 intent/매칭 workflow/슬롯 값)·골든 케이스 최신 리플레이 실패·대상 Domain Pack 요소(intent/slot/workflow/policy/risk)를 백엔드에서 compact evidence로 조립. 긴 JSON 필드는 상한 길이로 절단.
- `SimulationStructuralPatchPromptFactory`: 최소 변경·기존 식별자 보존·JSON only 규칙과 #879 허용 operation 13종, 출력 계약, 모호 시 `NEEDS_HUMAN_TARGET` 탈출구를 담은 system/user 프롬프트 구성.
- `SimulationStructuralPatchGenerationService`: `ChatClient` 호출 후 출력을 해석. 코드펜스/산문에서 JSON 객체를 추출하고 #879 `StructuralDomainPackPatchParser`로 검증. 결과는 `SUCCESS` / `NEEDS_HUMAN_TARGET` / `INVALID_OUTPUT` / `GENERATION_ERROR`. LLM 전송 예외는 잡아 후보 생성을 계속한다.
- `SimulationImprovementCandidateService` 통합: rollout 플래그 `app.simulation.structural-patch.enabled`(기본 off) 뒤에서만 동작. on+성공 → 검증된 구조적 패치를 `draftPatchJson`에 저장. on+실패 → `simulation-structural-patch-generation.v1` envelope(status/summary/message + description 패치 nested)를 저장해 실패가 후보 응답에 명시적으로 보이게 함. off → 기존 description-only 흐름 그대로.
- `SimulationGoldenCaseRepository.findBySourceChatSessionId(...)` 추가(adapter/JPA derived query 포함)로 피드백 세션 기준 골든 케이스 조회.

LLM은 구조화된 패치 JSON만 만들며, 검증 통과 전에는 어떤 것도 저장하지 않고 Domain Pack 테이블을 직접 변경하지 않는다. 구조적 operation의 실제 DB 반영·diff UI·자동 승인은 이슈 명시대로 non-goal.

## 검증

`SimulationStructuralPatchGenerationServiceTest`(7), `SimulationStructuralPatchPromptFactoryTest`(3), `SimulationImprovementEvidenceAssemblerTest`(3), `SimulationImprovementCandidateServiceTest`(45) — 총 58건 통과.

```
./gradlew test --tests "*SimulationStructuralPatch*" \
  --tests "*SimulationImprovementEvidenceAssemblerTest" \
  --tests "*SimulationImprovementCandidateServiceTest" \
  --tests "*SimulationGoldenCase*" \
  --tests "*SimulationImprovementCandidateControllerTest"   # BUILD SUCCESSFUL
./gradlew spotlessCheck   # 통과
```

커버: evidence 조립(골든 유무·긴 JSON 절단), 프롬프트 구성(operation·출력 계약·evidence 직렬화), 유효 LLM 출력→SUCCESS, 코드펜스 추출, 깨진 JSON·미지원 operation→INVALID_OUTPUT, NEEDS_HUMAN_TARGET, 플래그 on 성공/실패 envelope, 플래그 off 하위호환(기존 테스트 유지).

## 자체 리뷰

3라운드(이슈 충실도 / 아키텍처·통합 / 리뷰어·CI 관점) 수행. 점검 표면: #879 parser 재사용으로 검증 중복 회피, 신규 repo 메서드의 interface/adapter/JPA 일관성, 레이어 경계, `draftPatchJson` jsonb 저장·응답 노출 경로, fail-closed 처리.

### 잔여 리스크 / 메모

- `generate()`가 `createNewCandidate`의 트랜잭션 내에서 LLM을 호출한다(후보+피드백 원자적 저장 필요). 기존 LLM 호출 패턴과 동일한 요청 스코프 동작이며, 필요 시 후속 비동기화 가능.
- 생성 상태는 별도 컬럼 없이 `draftPatchJson` 내용(schemaVersion/status/summary)으로 노출 — 스키마 마이그레이션 없음.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * LLM 기반 시뮬레이션 구조적 개선 패치 자동 생성 기능 추가. 사용자 피드백과 대화 데이터를 분석하여 워크플로우 개선 제안 생성 가능.
  * 골든 케이스 리플레이 결과 통합으로 검증된 테스트 케이스 기반 개선 분석 강화.

* **테스트**
  * 구조적 패치 생성 서비스 및 증거 조립 로직 단위 테스트 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->