### PR TITLE
fix(ml): #842 LLM ALB timeout 안정화

### DIFF
--- a/.agent/specs/842.md
+++ b/.agent/specs/842.md
@@ -8,6 +8,8 @@ Airflow domain candidate generation should complete against the GPU-backed local
 
 `pipeline_job_46` reached the internal GPU LLM service after the model task became healthy on ECS. The Qwen request then failed in `domain_candidate_generation` with `httpx.ReadTimeout` after the stage client canceled the request at 20 seconds while the llama.cpp inference server was still producing Qwen tokens. The retry investigation also showed that replay cleanup can stop the LLM ECS service during an initial run when the cleanup task is cleared or scheduled together with initial-run tasks.
 
+After the client request stopped sending a small hardcoded `max_tokens` cap, `pipeline_job_51` exposed the next runtime boundary: the internal LLM ALB returned `504 Gateway Time-out` at its default 60 second idle timeout while llama.cpp was still decoding. ECS events also showed the LLM service target deregistering before Airflow's LLM cleanup task, which means Terraform/CD can race with Airflow's on-demand desired-count changes and scale the service back to zero during a run.
+
 ## Scope
 
 | Area | Change |
@@ -16,7 +18,7 @@ Airflow domain candidate generation should complete against the GPU-backed local
 | Prompt contract | Request JSON-only output with no reasoning or markdown wrapper. |
 | ECS stage task | Forward domain-candidate LLM runtime knobs to one-shot stage task containers. |
 | Airflow DAG | Prevent replay LLM cleanup from stopping the initial-run LLM service. |
-| Infrastructure | Persist Airflow ECS security-group access to the internal LLM ALB on port 8000. |
+| Infrastructure | Persist Airflow ECS security-group access to the internal LLM ALB on port 8000, keep the internal LLM ALB idle timeout above the client read timeout, and prevent Terraform from resetting Airflow-owned runtime desired count. |
 | Tests | Cover timeout defaults, payload caps, ECS env forwarding, and initial-run cleanup guard behavior. |
 
 ## Non-goals
@@ -34,6 +36,8 @@ Airflow domain candidate generation should complete against the GPU-backed local
 - ECS one-shot stage tasks receive `PIPELINE_DOMAIN_CANDIDATE_LLM_TIMEOUT_SECONDS` and related domain-candidate runtime settings.
 - `stop_llm_service` skips replay cleanup during an initial pipeline run.
 - Terraform defines the Airflow ECS to LLM ALB port 8000 security-group path.
+- Terraform configures the internal LLM ALB idle timeout above the domain candidate LLM client timeout.
+- Terraform does not reset the LLM ECS service `desired_count` while Airflow owns on-demand start/stop for a pipeline run.
 
 ## Verification
 
@@ -41,5 +45,6 @@ Airflow domain candidate generation should complete against the GPU-backed local
 |---------|---------|
 | `cd ml && uv run pytest tests/stages/test_domain_candidate_generation_main.py tests/test_ecs_stage_task.py tests/test_domain_pack_generation_dag.py tests/test_llm_service_lifecycle.py` | Verify stage, ECS override, and DAG lifecycle behavior. |
 | `cd ml && uv run ruff check src/pipeline/stages/domain_candidate_generation/main.py src/pipeline/ecs_stage_task.py src/dags/domain_pack_generation.py tests/stages/test_domain_candidate_generation_main.py tests/test_ecs_stage_task.py tests/test_domain_pack_generation_dag.py` | Verify changed ML Python files. |
-| `terraform fmt -check infra/terraform/ecs-airflow.tf infra/terraform/security-groups.tf` | Verify changed Terraform files. |
+| `terraform fmt -check infra/terraform/ecs-airflow.tf infra/terraform/security-groups.tf infra/terraform/ecs-llm.tf infra/terraform/variables.tf` | Verify changed Terraform files. |
+| `cd infra/terraform && terraform validate` | Verify Terraform configuration shape. |
 | `git diff --check` | Verify whitespace safety. |

--- a/infra/terraform/ecs-llm.tf
+++ b/infra/terraform/ecs-llm.tf
@@ -4,6 +4,7 @@ resource "aws_lb" "ml_llm_internal" {
   load_balancer_type = "application"
   security_groups    = [aws_security_group.ml_llm_alb.id]
   subnets            = values(aws_subnet.private)[*].id
+  idle_timeout       = var.llm_service_alb_idle_timeout_seconds
 
   enable_deletion_protection = false
 
@@ -160,6 +161,10 @@ resource "aws_ecs_service" "ml_llm" {
 
   deployment_minimum_healthy_percent = 0
   deployment_maximum_percent         = 100
+
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
 
   depends_on = [aws_lb_listener.ml_llm]
 }

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -462,6 +462,17 @@ variable "llm_service_container_port" {
   default     = 8000
 }
 
+variable "llm_service_alb_idle_timeout_seconds" {
+  description = "Idle timeout for the internal LLM ALB. Keep it above the longest LLM client read timeout."
+  type        = number
+  default     = 300
+
+  validation {
+    condition     = var.llm_service_alb_idle_timeout_seconds >= 1 && var.llm_service_alb_idle_timeout_seconds <= 4000
+    error_message = "llm_service_alb_idle_timeout_seconds must be between 1 and 4000."
+  }
+}
+
 variable "llm_runtime_api_key" {
   description = "Optional API key shared between the ML pipeline and the internal LLM service."
   type        = string


### PR DESCRIPTION
## Summary
- Raise the internal GPU LLM ALB idle timeout from the AWS default 60 seconds to 300 seconds so long llama.cpp responses can outlive the domain-candidate client read timeout.
- Keep Airflow as the runtime owner of the on-demand LLM ECS desired count by ignoring Terraform drift on `desired_count`, preventing CD/Terraform applies from scaling the service back to zero during a pipeline run.
- Update the #842 spec with the `pipeline_job_51` 504/503 evidence and the new infrastructure acceptance criteria.

## Evidence
- `pipeline_job_51` reached the L4-backed llama.cpp service and decoded past the old 520-token failure point, but the internal ALB returned `504 Gateway Time-out` at 60 seconds while generation was still running.
- The retry then hit `503 Service Temporarily Unavailable`, matching the ECS target deregistration/service scale-down race seen before Airflow's cleanup task completed.

## Verification
- `terraform fmt -check infra/terraform/ecs-llm.tf infra/terraform/variables.tf`
- `terraform -chdir=infra/terraform init -backend=false -input=false`
- `terraform -chdir=infra/terraform validate`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 내부 LLM 서비스의 연결 타임아웃 처리를 개선하여 서비스 안정성을 강화했습니다.
  * 서비스 스케일링 시 설정이 예기치 않게 변경되는 문제를 해결하여 인프라 관리 안정성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->