### PR TITLE
feat(workflow-runtime): #881 구조적 패치를 Domain Pack draft 버전에 검증·적용

### DIFF
--- a/.agent/specs/881.md
+++ b/.agent/specs/881.md
@@ -1,0 +1,157 @@
+# Backend Spec — #881 구조적 패치를 Domain Pack draft 버전에 검증·적용
+
+## Goal
+
+승인된 `simulation-structural-patch.v1` 구조적 패치를 백엔드가 결정론적·방어적으로 검증한 뒤 Domain Pack **draft 버전**에만 안전하게 반영한다. LLM은 패치 문서만 생성하고(#880), 백엔드가 검증·적용의 안전 경계가 된다. 적용은 전부-성공 또는 전부-롤백(원자적)이다.
+
+## Scope
+
+- `SimulationImprovementDraftPatchService.applyDraftPatch(...)`가 `draftPatchJson`의 `schemaVersion`을 감지한다.
+  - `simulation-structural-patch.v1` → 신규 구조적 적용 경로.
+  - 그 외(legacy `{}` description-only, `simulation-structural-patch-generation.v1` envelope 등) → 기존 description patch 동작 그대로.
+- draft 버전 resolve/clone는 기존 로직 재사용.
+- 구조적 operation을 draft 버전 요소에 적용하는 application service 추가.
+- workflow graph mutation 후 기존 `WorkflowGraphValidator`(domainpack)로 재검증, `initialState`/`terminalStatesJson` 재도출.
+- 단위 테스트(graph applier/validator 연동, element 적용, 거절 케이스) + 통합 테스트(clone/reuse draft, 롤백, profile rebuild enqueue 유지).
+
+## Non-goals (이슈 명시)
+
+- LLM 패치 생성은 다루지 않는다(#880).
+- 프론트엔드 diff UI 없음.
+- draft 버전을 자동 배포/활성화하지 않는다.
+- legacy `simulation-candidate-draft-patch.v1` description 동작은 변경하지 않는다.
+
+## Affected Modules
+
+`backend` / `workflow-runtime` + `domain-pack` bounded context.
+
+검증한 기존 경로:
+- `backend/src/main/java/com/init/workflowruntime/application/SimulationImprovementDraftPatchService.java` — 적용 orchestration(확장 대상). 현재 `applyDraftPatch`가 source 버전 resolve → draft resolve/clone → `applyDescriptionPatch`.
+- `backend/src/main/java/com/init/workflowruntime/application/SimulationImprovementCandidateDecisionService.java:50` — `approve(...)`가 `applyDraftPatch` 호출 후 profile rebuild enqueue, `recordApproval`, `markApplied(draftVersion.getId(), ...)` 순으로 진행. 적용이 예외를 던지면 `@Transactional` 롤백되어 `markApplied`에 도달하지 않는다.
+- `backend/src/main/java/com/init/workflowruntime/application/StructuralDomainPackPatchParser.java` — #879 파서(재사용). JSON → `StructuralDomainPackPatch` VO.
+- `backend/src/main/java/com/init/workflowruntime/domain/StructuralDomainPackPatch.java`, `StructuralPatchOperation.java`(`ElementAttribute`/`WorkflowNode`/`WorkflowTransition`), `StructuralPatchOperationType.java`, `StructuralPatchTargetCategory.java`, `InvalidStructuralPatchException.java`(extends `BadRequestException`, code `INVALID_STRUCTURAL_PATCH`) — #879 VO(재사용).
+- `backend/src/main/java/com/init/domainpack/application/WorkflowGraphValidator.java` — 기존 graph 검증기(V1–V8) + `extractInitialState`/`extractTerminalStatesJson`. **신규 validator를 만들지 않고 이것을 재사용**(현재 package-private → 재사용 위해 가시성 확대).
+- `backend/src/main/java/com/init/workflowruntime/application/WorkflowRuntimeGraph.java` — 런타임 graph 파서. graph JSON 형태 근거: `{nodes:[{id,type,policyRef,label,description}], edges:[{id,from,to,condition}]}`.
+- `backend/src/main/java/com/init/domainpack/domain/model/{WorkflowDefinition,SlotDefinition,IntentDefinition,PolicyDefinition,RiskDefinition,IntentSlotBinding}.java` — 적용 대상 엔티티/도메인 메서드.
+- `backend/src/main/java/com/init/domainpack/domain/repository/{Intent,Slot,Policy,Risk,WorkflowDefinition,IntentSlotBinding}Repository.java` — 버전별 code/id 조회.
+- `backend/src/main/java/com/init/workflowruntime/application/LlmToolService.java` — `IntentSlotBinding.isRequired`를 런타임에서 소비(필수 슬롯 표현의 근거).
+
+## Workflow Graph JSON 형태 (검증된 근거)
+
+```json
+{
+  "direction": "LR",
+  "nodes": [
+    {"id": "start", "type": "START"},
+    {"id": "n1", "type": "ACTION", "policyRef": "cancel_policy"},
+    {"id": "end", "type": "TERMINAL"}
+  ],
+  "edges": [
+    {"id": "e1", "from": "start", "to": "n1", "condition": {"type": "always"}},
+    {"id": "e2", "from": "n1", "to": "end", "condition": {"type": "default"}}
+  ]
+}
+```
+
+- node: `id`(필수), `type`(필수: START/TERMINAL/ACTION/DECISION/ANSWER/HANDOFF), optional `policyRef`/`label`/`description`. patch는 optional `slotCode`/`prompt`를 추가 보존.
+- edge: `id`(런타임 필수), `from`/`to`(필수), optional `condition`(JSON object), optional `label`.
+- `initialState` = 유일한 START node id, `terminalStatesJson` = TERMINAL node id 배열 — patch 적용 후 `WorkflowGraphValidator`에서 재도출.
+
+## Class Design
+
+### Orchestration: `SimulationImprovementDraftPatchService` (확장)
+
+```text
+applyDraftPatch(workspaceId, userId, candidate):
+  sourceVersion = findByIdForUpdate(candidate.domainPackVersionId)
+  draftVersion  = resolveDraftVersion(...)            // 기존 로직 그대로
+  if isStructuralPatch(candidate.draftPatchJson):
+      patch = structuralPatchParser.parse(candidate.draftPatchJson)
+      structuralPatchApplyService.apply(draftVersion.getId(), patch)
+  else:
+      applyDescriptionPatch(candidate, draftVersion.getId())   // 기존 그대로
+  return draftVersion
+```
+
+- `isStructuralPatch(json)`: `ObjectMapper`로 `schemaVersion` 텍스트만 peek → `StructuralDomainPackPatch.SCHEMA_VERSION`과 비교. malformed/누락이면 false(legacy 경로).
+- 적용 실패 시 던지는 `InvalidStructuralPatchException`/`Workflow*Exception`(모두 `BadRequestException` 하위)은 `approve`의 RW 트랜잭션을 롤백시켜 candidate가 `APPLIED`로 표시되지 않는다.
+- `appliedDomainPackVersionId`는 기존대로 `candidate.markApplied(draftVersion.getId(), ...)`에서 저장됨(추가 변경 불필요, 통합 테스트로 검증).
+
+### `SimulationStructuralPatchApplyService` (workflowruntime.application, `@Service`)
+
+`apply(Long draftVersionId, StructuralDomainPackPatch patch)` — 호출자 RW 트랜잭션에 합류.
+
+1. operation을 element(`ElementAttribute`)와 workflow(`WorkflowNode`/`WorkflowTransition`)로 분리.
+2. element op를 **patch 순서대로** 적용. category+(`targetCode`|`targetId`)로 draft 버전 내 대상 resolve. 대상 없으면 `InvalidStructuralPatchException`.
+3. workflow op를 대상 workflow별로 그룹핑(순서 보존). workflow별로 `WorkflowGraphPatchApplier`로 한 번에 적용 → `WorkflowGraphValidator.parseAndValidate(newGraphJson, workflowCode)` → `extractInitialState`/`extractTerminalStatesJson` → `workflow.updateGraph(...)` 저장.
+
+element op 적용 규칙:
+- `UPDATE_INTENT_DESCRIPTION`: `reviseDefinition`로 description 교체(나머지 필드 보존).
+- `ADD_INTENT_EXAMPLE`: `metaJson`을 object로 파싱 → `examples` 배열에 append(없으면 생성) → `reviseDefinition`로 metaJson 갱신. 기존 데이터 보존.
+- `UPDATE_SLOT_DESCRIPTION`: `updateFields`로 description 교체.
+- `UPDATE_SLOT_VALIDATION`: 기존 `validationRuleJson` object에 새 validation object를 merge(unrelated 필드 보존). value가 JSON object가 아니면 거절.
+- `MARK_SLOT_REQUIRED`: draft 버전에서 slot resolve → `IntentSlotBinding.isRequired=true`로 표시(런타임 소비 표현, `LlmToolService` 사용). 해당 slot을 참조하는 binding이 없으면 `InvalidStructuralPatchException`(대상 결정 불가).
+- `UPDATE_POLICY_CONDITION`: value가 유효 JSON인지 검증 후 `conditionJson` 교체(나머지 보존).
+- `UPDATE_RISK_TRIGGER`: value가 유효 JSON인지 검증 후 `triggerConditionJson` 교체.
+- `UPDATE_RESPONSE_COPY`: draft 버전 workflow들에서 `responseCode`와 동일한 node id를 탐색. 정확히 1개 매칭 → 해당 node의 `copy` 설정 후 graph 재검증·저장. 0개 또는 2개 이상 → `InvalidStructuralPatchException`.
+
+### `WorkflowGraphPatchApplier` (workflowruntime.application, `@Component`)
+
+`apply(String graphJson, List<StructuralPatchOperation> workflowOps, Predicate<String> slotExists) -> String newGraphJson`
+
+- `ObjectMapper`로 root object 파싱, `nodes`/`edges` ArrayNode 확보(없으면 생성). 알 수 없는 필드/노드 속성은 그대로 보존.
+- `ADD_WORKFLOW_NODE`: node id 중복이면 거절. `{id,type}` 생성, optional `slotCode`/`prompt` 추가. `slotCode` 제공 시 `slotExists` false면 거절. user-facing type(ANSWER/HANDOFF)인데 `prompt`가 명시되었으나 blank면 거절.
+- `UPDATE_WORKFLOW_NODE`: 대상 node 없으면 거절. `type` 갱신, optional `slotCode`/`prompt` 갱신.
+- `ADD_TRANSITION`: deterministic edge id `e_{from}_{to}` 생성. 동일 id 또는 동일 (from,to) edge 존재 시 거절(중복 방지). optional `condition`은 유효 JSON object여야 하며 그대로 저장.
+- `UPDATE_TRANSITION`: (from,to) 매칭 edge 없으면 거절. `condition` 갱신(유효 JSON object).
+- `REMOVE_TRANSITION`: (from,to) 매칭 edge 없으면 거절. 제거.
+- 적용 후 node id 중복 명시 검증(이슈 요구사항: "No duplicate node ids").
+- 반환된 graphJson은 호출 측에서 `WorkflowGraphValidator`로 최종 검증.
+
+`WorkflowGraphValidator` 재검증이 보장하는 것: 유효 JSON, START 정확히 1개(=초기 상태), TERMINAL ≥ 1, dangling edge 없음, START에서 전 노드 도달, 비순환(DAG), DECISION 분기 edge label 필수, edge id 존재·유일, ACTION node policyRef 유효. 이는 손으로 작성한 draft workflow와 동일한 불변식이다.
+
+## Validation Requirements (이슈 매핑)
+
+| 요구사항 | 구현 위치 |
+|---|---|
+| operation 대상 존재 또는 결정론적 생성 | apply service의 resolve + `InvalidStructuralPatchException` |
+| graph JSON 유효성 | `WorkflowGraphValidator` 파싱 |
+| 유효 초기 상태 1개 | `WorkflowGraphValidator` V1(START 1개) |
+| 참조 node id 존재(적용 후) | `WorkflowGraphValidator` V3(dangling) |
+| slot/policy/risk code 존재 | apply service resolve + node `slotCode` `slotExists` 검사 |
+| node id 중복 없음 | `WorkflowGraphPatchApplier` 명시 검증 |
+| transition id 중복 없음 | `WorkflowGraphValidator` V7b + applier 중복 거절 |
+| dangling transition 없음 | `WorkflowGraphValidator` V3 |
+| user-facing node 빈 prompt/response 금지 | applier blank prompt 거절 |
+| 1개 실패 시 전체 롤백 | 호출자 `@Transactional` + 즉시 예외 |
+
+## Failure Behavior
+
+- 잘못된 구조적 패치는 명확한 `BadRequestException` 하위 예외로 실패 → `GlobalExceptionHandler`가 400 매핑.
+- 적용 실패 시 트랜잭션 롤백으로 candidate는 `APPLIED`가 되지 않고, review task 승인도 기록되지 않는다(예외가 `recordApproval`/`markApplied` 이전에 발생).
+- 부분 적용 없음(원자적).
+
+## Design Decisions (검토 필요 표시)
+
+1. **`MARK_SLOT_REQUIRED` 표현**: slot의 모든 draft `IntentSlotBinding.isRequired=true`로 표시. 근거: 런타임(`LlmToolService`)이 실제로 소비하는 필수 슬롯 표현이며 operation이 `slotCode`만 carry하므로 결정론적으로 도달 가능. binding이 없으면 결정 불가로 거절.
+2. **`UPDATE_RESPONSE_COPY` 대상**: 별도 `ResponseDefinition` 엔티티가 없어, `responseCode`를 draft workflow의 node id로 보고 유일 매칭 node의 `copy`에 저장. 비유일/부재 시 거절. 런타임 렌더 연동은 후속 과제.
+3. **DECISION 분기 transition**: `WorkflowGraphValidator` V6는 DECISION node 출발 edge에 label을 요구하나 v1 `WorkflowTransition` 계약에 label 필드가 없다. 따라서 DECISION 출발 ADD_TRANSITION 패치는 검증에서 fail-closed로 거절된다(MVP 한계, 문서화).
+4. **ACTION node 추가**: V8가 ACTION node에 `policyRef`를 요구하나 v1 `WorkflowNode` 계약에 `policyRef`가 없어, ACTION node 추가 패치는 거절된다(MVP 한계). non-ACTION node 추가는 지원.
+
+## Tests
+
+- `WorkflowGraphPatchApplierTest`(단위): ADD/UPDATE node, ADD/UPDATE/REMOVE transition 정상; node id 중복 거절; 미존재 node/transition 거절; 잘못된 condition JSON 거절; slotCode 미존재 거절; 알 수 없는 필드 보존.
+- `SimulationStructuralPatchApplyServiceTest`(단위, Mockito): element op 각 동작; workflow op → 검증·저장; 대상 미존재 거절; `UPDATE_SLOT_VALIDATION` merge 보존; `UPDATE_POLICY_CONDITION`/`UPDATE_RISK_TRIGGER` 잘못된 JSON 거절; `MARK_SLOT_REQUIRED` binding 갱신.
+- `SimulationImprovementDraftPatchServiceTest` 또는 통합: schema 감지 분기(structural vs legacy). legacy 경로 회귀(기존 description 동작 유지).
+- 통합 테스트(Testcontainers, 기존 `AbstractDomainPackJpaTest`/decision service 패턴): 승인 시 (a) 비-draft source면 clone, draft 존재 시 reuse; (b) 구조적 패치로 node+transition 추가가 draft graph에 반영; (c) 잘못된 graph op는 거절되고 draft가 변경되지 않음(롤백); (d) profile rebuild enqueue 유지; (e) `appliedDomainPackVersionId`가 draft id로 저장.
+- 기존 description patch 테스트는 그대로 통과.
+
+## Acceptance Criteria
+
+- 승인된 구조적 패치가 draft workflow graph에 node와 transition을 추가할 수 있다.
+- 승인된 구조적 패치가 slot을 필수로 표시(런타임 소비 표현)할 수 있다.
+- 승인된 구조적 패치가 검증과 함께 policy/risk condition JSON을 갱신할 수 있다.
+- 잘못된 graph operation은 거절되고 draft를 변경하지 않는다.
+- legacy description patch 테스트가 그대로 통과한다.
+- clone/reuse draft 동작과 실패 시 롤백을 통합 테스트로 검증한다.
+- 성공 적용 후 matching profile rebuild가 계속 enqueue된다.

--- a/backend/src/main/java/com/init/domainpack/application/WorkflowGraphValidator.java
+++ b/backend/src/main/java/com/init/domainpack/application/WorkflowGraphValidator.java
@@ -25,13 +25,26 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-final class WorkflowGraphValidator {
+public final class WorkflowGraphValidator {
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private WorkflowGraphValidator() {}
 
   private static final Pattern POLICY_REF_PATTERN = Pattern.compile("[A-Za-z0-9_-]+");
+
+  /** 검증을 통과한 graph에서 재도출한 초기 상태와 terminal 상태 목록(JSON 배열). */
+  public record WorkflowGraphValidation(String initialState, String terminalStatesJson) {}
+
+  /**
+   * graphJson을 V1-V8 규칙으로 검증하고, 검증을 통과하면 재도출한 초기/terminal 상태를 반환한다. 위반 시 해당 {@code
+   * BadRequestException} 하위 예외를 던진다.
+   */
+  public static WorkflowGraphValidation validate(String graphJson, String workflowCode) {
+    ParsedGraph graph = parseAndValidate(graphJson, workflowCode);
+    return new WorkflowGraphValidation(
+        extractInitialState(graph), extractTerminalStatesJson(graph));
+  }
 
   record ParsedGraph(List<GraphNode> nodes, List<GraphEdge> edges) {}
 

--- a/backend/src/main/java/com/init/domainpack/domain/model/IntentSlotBinding.java
+++ b/backend/src/main/java/com/init/domainpack/domain/model/IntentSlotBinding.java
@@ -59,6 +59,11 @@ public class IntentSlotBinding {
     return entity;
   }
 
+  /** 이 binding이 가리키는 slot을 해당 intent에서 필수로 표시한다(idempotent). */
+  public void markRequired() {
+    this.isRequired = true;
+  }
+
   public Long getId() {
     return id;
   }

--- a/backend/src/main/java/com/init/domainpack/domain/repository/IntentSlotBindingRepository.java
+++ b/backend/src/main/java/com/init/domainpack/domain/repository/IntentSlotBindingRepository.java
@@ -10,4 +10,6 @@ public interface IntentSlotBindingRepository {
   <S extends IntentSlotBinding> List<S> saveAllAndFlush(Iterable<S> entities);
 
   List<IntentSlotBinding> findAllByIntentDefinitionIdIn(List<Long> intentDefinitionIds);
+
+  List<IntentSlotBinding> findAllBySlotDefinitionId(Long slotDefinitionId);
 }

--- a/backend/src/main/java/com/init/workflowruntime/application/SimulationImprovementDraftPatchService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/SimulationImprovementDraftPatchService.java
@@ -1,5 +1,8 @@
 package com.init.workflowruntime.application;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.init.domainpack.application.DomainPackDraftSourceType;
 import com.init.domainpack.application.DomainPackVersionCloneCommand;
 import com.init.domainpack.application.DomainPackVersionCloneResult;
@@ -19,6 +22,7 @@ import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
 import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.NotFoundException;
 import com.init.workflowruntime.domain.SimulationImprovementCandidate;
+import com.init.workflowruntime.domain.StructuralDomainPackPatch;
 import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,6 +38,9 @@ public class SimulationImprovementDraftPatchService {
   private final PolicyDefinitionRepository policyDefinitionRepository;
   private final RiskDefinitionRepository riskDefinitionRepository;
   private final WorkflowDefinitionRepository workflowDefinitionRepository;
+  private final StructuralDomainPackPatchParser structuralPatchParser;
+  private final SimulationStructuralPatchApplyService structuralPatchApplyService;
+  private final ObjectMapper objectMapper;
 
   public SimulationImprovementDraftPatchService(
       DomainPackVersionRepository domainPackVersionRepository,
@@ -42,7 +49,10 @@ public class SimulationImprovementDraftPatchService {
       SlotDefinitionRepository slotDefinitionRepository,
       PolicyDefinitionRepository policyDefinitionRepository,
       RiskDefinitionRepository riskDefinitionRepository,
-      WorkflowDefinitionRepository workflowDefinitionRepository) {
+      WorkflowDefinitionRepository workflowDefinitionRepository,
+      StructuralDomainPackPatchParser structuralPatchParser,
+      SimulationStructuralPatchApplyService structuralPatchApplyService,
+      ObjectMapper objectMapper) {
     this.domainPackVersionRepository = domainPackVersionRepository;
     this.domainPackVersionCloneService = domainPackVersionCloneService;
     this.intentDefinitionRepository = intentDefinitionRepository;
@@ -50,6 +60,9 @@ public class SimulationImprovementDraftPatchService {
     this.policyDefinitionRepository = policyDefinitionRepository;
     this.riskDefinitionRepository = riskDefinitionRepository;
     this.workflowDefinitionRepository = workflowDefinitionRepository;
+    this.structuralPatchParser = structuralPatchParser;
+    this.structuralPatchApplyService = structuralPatchApplyService;
+    this.objectMapper = objectMapper;
   }
 
   @Transactional
@@ -65,8 +78,27 @@ public class SimulationImprovementDraftPatchService {
                         "Domain pack version not found: " + candidate.getDomainPackVersionId()));
     DomainPackVersion draftVersion =
         resolveDraftVersion(workspaceId, userId, sourceVersion, candidate);
-    applyDescriptionPatch(candidate, draftVersion.getId());
+    if (isStructuralPatch(candidate.getDraftPatchJson())) {
+      StructuralDomainPackPatch patch = structuralPatchParser.parse(candidate.getDraftPatchJson());
+      structuralPatchApplyService.apply(draftVersion.getId(), patch);
+    } else {
+      applyDescriptionPatch(candidate, draftVersion.getId());
+    }
     return draftVersion;
+  }
+
+  private boolean isStructuralPatch(String draftPatchJson) {
+    if (draftPatchJson == null || draftPatchJson.isBlank()) {
+      return false;
+    }
+    try {
+      JsonNode root = objectMapper.readTree(draftPatchJson);
+      return root.isObject()
+          && StructuralDomainPackPatch.SCHEMA_VERSION.equals(
+              root.path("schemaVersion").asText(null));
+    } catch (JsonProcessingException e) {
+      return false;
+    }
   }
 
   private DomainPackVersion resolveDraftVersion(

--- a/backend/src/main/java/com/init/workflowruntime/application/SimulationStructuralPatchApplyService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/SimulationStructuralPatchApplyService.java
@@ -1,0 +1,396 @@
+package com.init.workflowruntime.application;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.init.domainpack.application.WorkflowGraphValidator;
+import com.init.domainpack.application.WorkflowGraphValidator.WorkflowGraphValidation;
+import com.init.domainpack.domain.model.IntentDefinition;
+import com.init.domainpack.domain.model.IntentSlotBinding;
+import com.init.domainpack.domain.model.PolicyDefinition;
+import com.init.domainpack.domain.model.RiskDefinition;
+import com.init.domainpack.domain.model.SlotDefinition;
+import com.init.domainpack.domain.model.WorkflowDefinition;
+import com.init.domainpack.domain.repository.IntentDefinitionRepository;
+import com.init.domainpack.domain.repository.IntentSlotBindingRepository;
+import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
+import com.init.domainpack.domain.repository.RiskDefinitionRepository;
+import com.init.domainpack.domain.repository.SlotDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
+import com.init.workflowruntime.domain.InvalidStructuralPatchException;
+import com.init.workflowruntime.domain.StructuralDomainPackPatch;
+import com.init.workflowruntime.domain.StructuralPatchOperation;
+import com.init.workflowruntime.domain.StructuralPatchOperation.ElementAttribute;
+import com.init.workflowruntime.domain.StructuralPatchOperation.WorkflowNode;
+import com.init.workflowruntime.domain.StructuralPatchOperation.WorkflowTransition;
+import com.init.workflowruntime.domain.StructuralPatchOperationType;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 검증을 통과한 {@code simulation-structural-patch.v1} operation들을 draft Domain Pack 버전에만 적용한다. 한
+ * operation이라도 실패하면 호출자의 트랜잭션이 롤백되어 부분 적용이 남지 않는다.
+ */
+@Service
+public class SimulationStructuralPatchApplyService {
+
+  private final IntentDefinitionRepository intentRepository;
+  private final SlotDefinitionRepository slotRepository;
+  private final PolicyDefinitionRepository policyRepository;
+  private final RiskDefinitionRepository riskRepository;
+  private final WorkflowDefinitionRepository workflowRepository;
+  private final IntentSlotBindingRepository intentSlotBindingRepository;
+  private final WorkflowGraphPatchApplier workflowGraphPatchApplier;
+  private final ObjectMapper objectMapper;
+
+  public SimulationStructuralPatchApplyService(
+      IntentDefinitionRepository intentRepository,
+      SlotDefinitionRepository slotRepository,
+      PolicyDefinitionRepository policyRepository,
+      RiskDefinitionRepository riskRepository,
+      WorkflowDefinitionRepository workflowRepository,
+      IntentSlotBindingRepository intentSlotBindingRepository,
+      WorkflowGraphPatchApplier workflowGraphPatchApplier,
+      ObjectMapper objectMapper) {
+    this.intentRepository = intentRepository;
+    this.slotRepository = slotRepository;
+    this.policyRepository = policyRepository;
+    this.riskRepository = riskRepository;
+    this.workflowRepository = workflowRepository;
+    this.intentSlotBindingRepository = intentSlotBindingRepository;
+    this.workflowGraphPatchApplier = workflowGraphPatchApplier;
+    this.objectMapper = objectMapper;
+  }
+
+  @Transactional
+  public void apply(Long draftVersionId, StructuralDomainPackPatch patch) {
+    List<StructuralPatchOperation> workflowOps = new ArrayList<>();
+    for (StructuralPatchOperation operation : patch.operations()) {
+      if (operation instanceof ElementAttribute elementOp) {
+        applyElement(draftVersionId, elementOp);
+      } else {
+        workflowOps.add(operation);
+      }
+    }
+    applyWorkflowOperations(draftVersionId, workflowOps);
+  }
+
+  private void applyElement(Long draftVersionId, ElementAttribute op) {
+    switch (op.category()) {
+      case INTENT -> applyIntent(draftVersionId, op);
+      case SLOT -> applySlot(draftVersionId, op);
+      case POLICY -> applyPolicy(draftVersionId, op);
+      case RISK -> applyRisk(draftVersionId, op);
+      case RESPONSE -> applyResponseCopy(draftVersionId, op);
+      case WORKFLOW ->
+          throw new InvalidStructuralPatchException(
+              "workflow operation은 node/transition 형태여야 합니다.");
+    }
+  }
+
+  private void applyIntent(Long draftVersionId, ElementAttribute op) {
+    IntentDefinition intent = resolveIntent(draftVersionId, op);
+    switch (op.type()) {
+      case UPDATE_INTENT_DESCRIPTION ->
+          intent.reviseDefinition(
+              intent.getName(),
+              op.value(),
+              intent.getTaxonomyLevel(),
+              intent.getEntryConditionJson(),
+              intent.getMetaJson());
+      case ADD_INTENT_EXAMPLE ->
+          intent.reviseDefinition(
+              intent.getName(),
+              intent.getDescription(),
+              intent.getTaxonomyLevel(),
+              intent.getEntryConditionJson(),
+              appendExample(intent.getMetaJson(), op.value()));
+      default -> throw unsupported(op);
+    }
+    intentRepository.save(intent);
+  }
+
+  private void applySlot(Long draftVersionId, ElementAttribute op) {
+    SlotDefinition slot = resolveSlot(draftVersionId, op);
+    switch (op.type()) {
+      case UPDATE_SLOT_DESCRIPTION ->
+          slot.updateFields(
+              slot.getName(),
+              op.value(),
+              slot.getIsSensitive(),
+              slot.getValidationRuleJson(),
+              slot.getDefaultValueJson(),
+              slot.getMetaJson());
+      case UPDATE_SLOT_VALIDATION ->
+          slot.updateFields(
+              slot.getName(),
+              slot.getDescription(),
+              slot.getIsSensitive(),
+              mergeJsonObject(slot.getValidationRuleJson(), op.value()),
+              slot.getDefaultValueJson(),
+              slot.getMetaJson());
+      case MARK_SLOT_REQUIRED -> {
+        markSlotRequired(slot);
+        return;
+      }
+      default -> throw unsupported(op);
+    }
+    slotRepository.save(slot);
+  }
+
+  private void applyPolicy(Long draftVersionId, ElementAttribute op) {
+    if (op.type() != StructuralPatchOperationType.UPDATE_POLICY_CONDITION) {
+      throw unsupported(op);
+    }
+    PolicyDefinition policy = resolvePolicy(draftVersionId, op);
+    policy.updateFields(
+        policy.getName(),
+        policy.getDescription(),
+        policy.getSeverity(),
+        requireValidJson(op.value()),
+        policy.getActionJson(),
+        policy.getEvidenceJson(),
+        policy.getMetaJson());
+    policyRepository.save(policy);
+  }
+
+  private void applyRisk(Long draftVersionId, ElementAttribute op) {
+    if (op.type() != StructuralPatchOperationType.UPDATE_RISK_TRIGGER) {
+      throw unsupported(op);
+    }
+    RiskDefinition risk = resolveRisk(draftVersionId, op);
+    risk.updateFields(
+        risk.getName(),
+        risk.getDescription(),
+        risk.getRiskLevel(),
+        requireValidJson(op.value()),
+        risk.getHandlingActionJson(),
+        risk.getEvidenceJson(),
+        risk.getMetaJson());
+    riskRepository.save(risk);
+  }
+
+  private void applyResponseCopy(Long draftVersionId, ElementAttribute op) {
+    String responseCode = op.targetCode();
+    if (responseCode == null) {
+      throw new InvalidStructuralPatchException("UPDATE_RESPONSE_COPY는 responseCode가 필요합니다.");
+    }
+    List<WorkflowDefinition> workflows =
+        workflowRepository.findAllByDomainPackVersionId(draftVersionId);
+    WorkflowDefinition matchedWorkflow = null;
+    String matchedGraph = null;
+    for (WorkflowDefinition workflow : workflows) {
+      Optional<String> patched =
+          workflowGraphPatchApplier.applyResponseCopy(
+              workflow.getGraphJson(), responseCode, op.value());
+      if (patched.isPresent()) {
+        if (matchedWorkflow != null) {
+          throw new InvalidStructuralPatchException(
+              "responseCode가 여러 workflow node와 일치하여 대상을 특정할 수 없습니다: " + responseCode);
+        }
+        matchedWorkflow = workflow;
+        matchedGraph = patched.get();
+      }
+    }
+    if (matchedWorkflow == null) {
+      throw new InvalidStructuralPatchException("일치하는 response node를 찾을 수 없습니다: " + responseCode);
+    }
+    saveValidatedGraph(matchedWorkflow, matchedGraph);
+  }
+
+  private void applyWorkflowOperations(
+      Long draftVersionId, List<StructuralPatchOperation> workflowOps) {
+    Map<Long, WorkflowOperationGroup> groups = new LinkedHashMap<>();
+    for (StructuralPatchOperation op : workflowOps) {
+      WorkflowDefinition workflow = resolveWorkflow(draftVersionId, op);
+      groups
+          .computeIfAbsent(workflow.getId(), ignored -> new WorkflowOperationGroup(workflow))
+          .operations()
+          .add(op);
+    }
+    for (WorkflowOperationGroup group : groups.values()) {
+      String newGraphJson =
+          workflowGraphPatchApplier.apply(
+              group.workflow().getGraphJson(),
+              group.operations(),
+              code -> slotExists(draftVersionId, code));
+      saveValidatedGraph(group.workflow(), newGraphJson);
+    }
+  }
+
+  private void saveValidatedGraph(WorkflowDefinition workflow, String newGraphJson) {
+    WorkflowGraphValidation validation =
+        WorkflowGraphValidator.validate(newGraphJson, workflow.getWorkflowCode());
+    workflow.updateGraph(
+        workflow.getName(),
+        workflow.getDescription(),
+        newGraphJson,
+        validation.initialState(),
+        validation.terminalStatesJson());
+    workflowRepository.save(workflow);
+  }
+
+  private void markSlotRequired(SlotDefinition slot) {
+    List<IntentSlotBinding> bindings =
+        intentSlotBindingRepository.findAllBySlotDefinitionId(slot.getId());
+    if (bindings.isEmpty()) {
+      throw new InvalidStructuralPatchException(
+          "필수로 표시할 slot의 intent binding이 없습니다: " + slot.getSlotCode());
+    }
+    bindings.forEach(IntentSlotBinding::markRequired);
+    intentSlotBindingRepository.saveAll(bindings);
+  }
+
+  private boolean slotExists(Long draftVersionId, String slotCode) {
+    return slotRepository
+        .findByDomainPackVersionIdAndSlotCode(draftVersionId, slotCode)
+        .isPresent();
+  }
+
+  private IntentDefinition resolveIntent(Long draftVersionId, ElementAttribute op) {
+    if (op.targetCode() != null) {
+      return intentRepository
+          .findByDomainPackVersionIdAndIntentCode(draftVersionId, op.targetCode())
+          .orElseThrow(() -> targetNotFound(op));
+    }
+    return intentRepository
+        .findByIdAndDomainPackVersionId(op.targetId(), draftVersionId)
+        .orElseThrow(() -> targetNotFound(op));
+  }
+
+  private SlotDefinition resolveSlot(Long draftVersionId, ElementAttribute op) {
+    if (op.targetCode() != null) {
+      return slotRepository
+          .findByDomainPackVersionIdAndSlotCode(draftVersionId, op.targetCode())
+          .orElseThrow(() -> targetNotFound(op));
+    }
+    return slotRepository
+        .findByIdAndDomainPackVersionId(op.targetId(), draftVersionId)
+        .orElseThrow(() -> targetNotFound(op));
+  }
+
+  private PolicyDefinition resolvePolicy(Long draftVersionId, ElementAttribute op) {
+    if (op.targetCode() != null) {
+      return policyRepository
+          .findByDomainPackVersionIdAndPolicyCode(draftVersionId, op.targetCode())
+          .orElseThrow(() -> targetNotFound(op));
+    }
+    return policyRepository
+        .findByIdAndDomainPackVersionId(op.targetId(), draftVersionId)
+        .orElseThrow(() -> targetNotFound(op));
+  }
+
+  private RiskDefinition resolveRisk(Long draftVersionId, ElementAttribute op) {
+    if (op.targetCode() != null) {
+      return riskRepository
+          .findByDomainPackVersionIdAndRiskCode(draftVersionId, op.targetCode())
+          .orElseThrow(() -> targetNotFound(op));
+    }
+    return riskRepository
+        .findByIdAndDomainPackVersionId(op.targetId(), draftVersionId)
+        .orElseThrow(() -> targetNotFound(op));
+  }
+
+  private WorkflowDefinition resolveWorkflow(Long draftVersionId, StructuralPatchOperation op) {
+    String workflowCode;
+    Long workflowDefinitionId;
+    switch (op) {
+      case WorkflowNode node -> {
+        workflowCode = node.workflowCode();
+        workflowDefinitionId = node.workflowDefinitionId();
+      }
+      case WorkflowTransition transition -> {
+        workflowCode = transition.workflowCode();
+        workflowDefinitionId = transition.workflowDefinitionId();
+      }
+      default ->
+          throw new InvalidStructuralPatchException("workflow operation이 아닙니다: " + op.type());
+    }
+    if (workflowCode != null) {
+      return workflowRepository
+          .findByDomainPackVersionIdAndWorkflowCode(draftVersionId, workflowCode)
+          .orElseThrow(
+              () -> new InvalidStructuralPatchException("대상 workflow를 찾을 수 없습니다: " + workflowCode));
+    }
+    return workflowRepository
+        .findByIdAndDomainPackVersionId(workflowDefinitionId, draftVersionId)
+        .orElseThrow(
+            () ->
+                new InvalidStructuralPatchException(
+                    "대상 workflow를 찾을 수 없습니다: " + workflowDefinitionId));
+  }
+
+  private String appendExample(String metaJson, String example) {
+    ObjectNode meta = readObjectOrEmpty(metaJson);
+    JsonNode examplesNode = meta.get("examples");
+    ArrayNode examples =
+        examplesNode != null && examplesNode.isArray()
+            ? (ArrayNode) examplesNode
+            : meta.putArray("examples");
+    examples.add(example);
+    return write(meta);
+  }
+
+  private String mergeJsonObject(String existingJson, String patchJson) {
+    ObjectNode existing = readObjectOrEmpty(existingJson);
+    JsonNode patch = readTree(patchJson);
+    if (!patch.isObject()) {
+      throw new InvalidStructuralPatchException("validation 값은 JSON object여야 합니다.");
+    }
+    existing.setAll((ObjectNode) patch);
+    return write(existing);
+  }
+
+  private String requireValidJson(String value) {
+    readTree(value);
+    return value;
+  }
+
+  private JsonNode readTree(String json) {
+    try {
+      return objectMapper.readTree(json);
+    } catch (JsonProcessingException e) {
+      throw new InvalidStructuralPatchException("값이 유효한 JSON이 아닙니다.");
+    }
+  }
+
+  private ObjectNode readObjectOrEmpty(String json) {
+    if (json == null || json.isBlank()) {
+      return objectMapper.createObjectNode();
+    }
+    JsonNode node = readTree(json);
+    return node.isObject() ? (ObjectNode) node : objectMapper.createObjectNode();
+  }
+
+  private String write(JsonNode node) {
+    try {
+      return objectMapper.writeValueAsString(node);
+    } catch (JsonProcessingException e) {
+      throw new InvalidStructuralPatchException("JSON 직렬화에 실패했습니다.");
+    }
+  }
+
+  private InvalidStructuralPatchException targetNotFound(ElementAttribute op) {
+    String target = op.targetCode() != null ? op.targetCode() : String.valueOf(op.targetId());
+    return new InvalidStructuralPatchException(op.type() + " 대상을 draft 버전에서 찾을 수 없습니다: " + target);
+  }
+
+  private InvalidStructuralPatchException unsupported(ElementAttribute op) {
+    return new InvalidStructuralPatchException(
+        op.category() + " 카테고리에서 지원하지 않는 operation입니다: " + op.type());
+  }
+
+  private record WorkflowOperationGroup(
+      WorkflowDefinition workflow, List<StructuralPatchOperation> operations) {
+    WorkflowOperationGroup(WorkflowDefinition workflow) {
+      this(workflow, new ArrayList<>());
+    }
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/application/WorkflowGraphPatchApplier.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/WorkflowGraphPatchApplier.java
@@ -1,0 +1,246 @@
+package com.init.workflowruntime.application;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.init.workflowruntime.domain.InvalidStructuralPatchException;
+import com.init.workflowruntime.domain.StructuralPatchOperation;
+import com.init.workflowruntime.domain.StructuralPatchOperation.WorkflowNode;
+import com.init.workflowruntime.domain.StructuralPatchOperation.WorkflowTransition;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+import org.springframework.stereotype.Component;
+
+/**
+ * 단일 workflow의 graphJson에 구조적 node/transition operation을 적용해 새 graphJson을 만든다. 알 수 없는 필드/노드 속성은 그대로
+ * 보존하며, 도달 가능성/순환/초기 상태 등 그래프 전역 불변식은 호출 측이 {@code WorkflowGraphValidator}로 최종 검증한다.
+ */
+@Component
+public class WorkflowGraphPatchApplier {
+
+  private static final Set<String> USER_FACING_NODE_TYPES = Set.of("ANSWER", "HANDOFF");
+
+  private final ObjectMapper objectMapper;
+
+  public WorkflowGraphPatchApplier(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  /** 주어진 workflow operation들을 순서대로 적용한 새 graphJson을 반환한다. */
+  public String apply(
+      String graphJson, List<StructuralPatchOperation> operations, Predicate<String> slotExists) {
+    ObjectNode root = readObject(graphJson);
+    ArrayNode nodes = arrayChild(root, "nodes");
+    ArrayNode edges = arrayChild(root, "edges");
+
+    for (StructuralPatchOperation operation : operations) {
+      switch (operation) {
+        case WorkflowNode node -> applyNode(nodes, node, slotExists);
+        case WorkflowTransition transition -> applyTransition(edges, transition);
+        default ->
+            throw new InvalidStructuralPatchException(
+                "workflow graph에 적용할 수 없는 operation입니다: " + operation.type());
+      }
+    }
+
+    verifyNoDuplicateNodeIds(nodes);
+    return write(root);
+  }
+
+  /** responseCode와 동일한 node가 있으면 그 node의 copy를 설정한 새 graphJson을 반환한다. 없으면 비어있는 결과. */
+  public Optional<String> applyResponseCopy(String graphJson, String nodeId, String copy) {
+    ObjectNode root = readObject(graphJson);
+    ObjectNode node = findNode(arrayChild(root, "nodes"), nodeId);
+    if (node == null) {
+      return Optional.empty();
+    }
+    node.put("copy", copy);
+    return Optional.of(write(root));
+  }
+
+  private void applyNode(ArrayNode nodes, WorkflowNode op, Predicate<String> slotExists) {
+    requireSlotExists(op.slotCode(), slotExists);
+    ObjectNode existing = findNode(nodes, op.nodeId());
+    switch (op.type()) {
+      case ADD_WORKFLOW_NODE -> {
+        if (existing != null) {
+          throw new InvalidStructuralPatchException("이미 존재하는 node id입니다: " + op.nodeId());
+        }
+        ObjectNode node = nodes.addObject();
+        node.put("id", op.nodeId());
+        writeNodeFields(node, op);
+        requireUserFacingPrompt(node, op.nodeType());
+      }
+      case UPDATE_WORKFLOW_NODE -> {
+        if (existing == null) {
+          throw new InvalidStructuralPatchException("수정할 node를 찾을 수 없습니다: " + op.nodeId());
+        }
+        writeNodeFields(existing, op);
+        requireUserFacingPrompt(existing, op.nodeType());
+      }
+      default ->
+          throw new InvalidStructuralPatchException("지원하지 않는 node operation입니다: " + op.type());
+    }
+  }
+
+  private void writeNodeFields(ObjectNode node, WorkflowNode op) {
+    node.put("type", op.nodeType());
+    if (op.slotCode() != null) {
+      node.put("slotCode", op.slotCode());
+    }
+    if (op.prompt() != null) {
+      node.put("prompt", op.prompt());
+    }
+  }
+
+  private void requireUserFacingPrompt(ObjectNode node, String nodeType) {
+    if (!USER_FACING_NODE_TYPES.contains(nodeType)) {
+      return;
+    }
+    JsonNode prompt = node.get("prompt");
+    if (prompt == null || prompt.asText("").isBlank()) {
+      throw new InvalidStructuralPatchException(
+          nodeType + " node는 비어있지 않은 prompt가 필요합니다: " + node.path("id").asText());
+    }
+  }
+
+  private void requireSlotExists(String slotCode, Predicate<String> slotExists) {
+    if (slotCode != null && !slotExists.test(slotCode)) {
+      throw new InvalidStructuralPatchException("존재하지 않는 slotCode를 참조합니다: " + slotCode);
+    }
+  }
+
+  private void applyTransition(ArrayNode edges, WorkflowTransition op) {
+    switch (op.type()) {
+      case ADD_TRANSITION -> {
+        String edgeId = "e_" + op.from() + "_" + op.to();
+        if (findEdgeIndexById(edges, edgeId) >= 0
+            || findEdgeIndex(edges, op.from(), op.to()) >= 0) {
+          throw new InvalidStructuralPatchException(
+              "이미 존재하는 transition입니다: " + op.from() + " -> " + op.to());
+        }
+        ObjectNode edge = edges.addObject();
+        edge.put("id", edgeId);
+        edge.put("from", op.from());
+        edge.put("to", op.to());
+        if (op.condition() != null) {
+          edge.set("condition", readCondition(op.condition()));
+        }
+      }
+      case UPDATE_TRANSITION -> {
+        ObjectNode edge = requireEdge(edges, op);
+        if (op.condition() != null) {
+          edge.set("condition", readCondition(op.condition()));
+        }
+      }
+      case REMOVE_TRANSITION -> {
+        int index = findEdgeIndex(edges, op.from(), op.to());
+        if (index < 0) {
+          throw transitionNotFound(op);
+        }
+        edges.remove(index);
+      }
+      default ->
+          throw new InvalidStructuralPatchException(
+              "지원하지 않는 transition operation입니다: " + op.type());
+    }
+  }
+
+  private ObjectNode requireEdge(ArrayNode edges, WorkflowTransition op) {
+    int index = findEdgeIndex(edges, op.from(), op.to());
+    if (index < 0) {
+      throw transitionNotFound(op);
+    }
+    return (ObjectNode) edges.get(index);
+  }
+
+  private InvalidStructuralPatchException transitionNotFound(WorkflowTransition op) {
+    return new InvalidStructuralPatchException(
+        "수정/삭제할 transition을 찾을 수 없습니다: " + op.from() + " -> " + op.to());
+  }
+
+  private JsonNode readCondition(String condition) {
+    JsonNode parsed;
+    try {
+      parsed = objectMapper.readTree(condition);
+    } catch (JsonProcessingException e) {
+      throw new InvalidStructuralPatchException("transition condition이 유효한 JSON이 아닙니다.");
+    }
+    if (!parsed.isObject()) {
+      throw new InvalidStructuralPatchException("transition condition은 JSON object여야 합니다.");
+    }
+    return parsed;
+  }
+
+  private ObjectNode readObject(String graphJson) {
+    JsonNode root;
+    try {
+      root = objectMapper.readTree(graphJson);
+    } catch (JsonProcessingException e) {
+      throw new InvalidStructuralPatchException("workflow graphJson을 파싱할 수 없습니다.");
+    }
+    if (root == null || !root.isObject()) {
+      throw new InvalidStructuralPatchException("workflow graphJson은 JSON object여야 합니다.");
+    }
+    return (ObjectNode) root;
+  }
+
+  private ArrayNode arrayChild(ObjectNode root, String field) {
+    JsonNode child = root.get(field);
+    if (child != null && child.isArray()) {
+      return (ArrayNode) child;
+    }
+    return root.putArray(field);
+  }
+
+  private ObjectNode findNode(ArrayNode nodes, String nodeId) {
+    for (JsonNode node : nodes) {
+      if (node.isObject() && nodeId.equals(node.path("id").asText(null))) {
+        return (ObjectNode) node;
+      }
+    }
+    return null;
+  }
+
+  private int findEdgeIndex(ArrayNode edges, String from, String to) {
+    for (int i = 0; i < edges.size(); i++) {
+      JsonNode edge = edges.get(i);
+      if (from.equals(edge.path("from").asText(null)) && to.equals(edge.path("to").asText(null))) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  private int findEdgeIndexById(ArrayNode edges, String edgeId) {
+    for (int i = 0; i < edges.size(); i++) {
+      if (edgeId.equals(edges.get(i).path("id").asText(null))) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  private void verifyNoDuplicateNodeIds(ArrayNode nodes) {
+    Set<String> seen = new HashSet<>();
+    for (JsonNode node : nodes) {
+      String id = node.path("id").asText(null);
+      if (id != null && !seen.add(id)) {
+        throw new InvalidStructuralPatchException("중복된 node id가 존재합니다: " + id);
+      }
+    }
+  }
+
+  private String write(ObjectNode root) {
+    try {
+      return objectMapper.writeValueAsString(root);
+    } catch (JsonProcessingException e) {
+      throw new InvalidStructuralPatchException("workflow graphJson 직렬화에 실패했습니다.");
+    }
+  }
+}

--- a/backend/src/test/java/com/init/workflowruntime/application/SimulationImprovementCandidateServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/SimulationImprovementCandidateServiceTest.java
@@ -140,7 +140,10 @@ class SimulationImprovementCandidateServiceTest {
             slotDefinitionRepository,
             policyDefinitionRepository,
             riskDefinitionRepository,
-            workflowDefinitionRepository);
+            workflowDefinitionRepository,
+            new StructuralDomainPackPatchParser(objectMapper),
+            org.mockito.Mockito.mock(SimulationStructuralPatchApplyService.class),
+            objectMapper);
     decisionService =
         new SimulationImprovementCandidateDecisionService(
             candidateRepository,

--- a/backend/src/test/java/com/init/workflowruntime/application/SimulationImprovementDraftPatchServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/SimulationImprovementDraftPatchServiceTest.java
@@ -1,0 +1,216 @@
+package com.init.workflowruntime.application;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.domainpack.application.DomainPackDraftSourceType;
+import com.init.domainpack.application.DomainPackVersionCloneResult;
+import com.init.domainpack.application.DomainPackVersionCloneService;
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.model.IntentDefinition;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.IntentDefinitionRepository;
+import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
+import com.init.domainpack.domain.repository.RiskDefinitionRepository;
+import com.init.domainpack.domain.repository.SlotDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
+import com.init.workflowruntime.domain.InvalidStructuralPatchException;
+import com.init.workflowruntime.domain.SimulationImprovementCandidate;
+import com.init.workflowruntime.domain.SimulationImprovementCandidateDraft;
+import com.init.workflowruntime.domain.SimulationImprovementCandidateTargetType;
+import com.init.workflowruntime.domain.SimulationImprovementCandidateType;
+import com.init.workflowruntime.domain.StructuralDomainPackPatch;
+import com.init.workflowruntime.domain.StructuralPatchEvidence;
+import com.init.workflowruntime.domain.StructuralPatchOperation;
+import com.init.workflowruntime.domain.StructuralPatchOperationType;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SimulationImprovementDraftPatchService")
+class SimulationImprovementDraftPatchServiceTest {
+
+  private static final Long WORKSPACE_ID = 1L;
+  private static final Long USER_ID = 2L;
+  private static final Long VERSION_ID = 100L;
+  private static final Long PACK_ID = 200L;
+  private static final Long DRAFT_ID = 300L;
+  private static final Long FEEDBACK_ID = 400L;
+  private static final Long SESSION_ID = 500L;
+
+  private static final String STRUCTURAL_JSON =
+      "{\"schemaVersion\":\"simulation-structural-patch.v1\",\"summary\":\"s\","
+          + "\"evidence\":{\"failureSummary\":\"f\"},"
+          + "\"operations\":[{\"op\":\"UPDATE_INTENT_DESCRIPTION\",\"intentCode\":\"greet\","
+          + "\"description\":\"d\",\"reason\":\"r\"}]}";
+
+  @Mock private DomainPackVersionRepository domainPackVersionRepository;
+  @Mock private DomainPackVersionCloneService cloneService;
+  @Mock private IntentDefinitionRepository intentRepository;
+  @Mock private SlotDefinitionRepository slotRepository;
+  @Mock private PolicyDefinitionRepository policyRepository;
+  @Mock private RiskDefinitionRepository riskRepository;
+  @Mock private WorkflowDefinitionRepository workflowRepository;
+  @Mock private StructuralDomainPackPatchParser structuralPatchParser;
+  @Mock private SimulationStructuralPatchApplyService structuralPatchApplyService;
+
+  private SimulationImprovementDraftPatchService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new SimulationImprovementDraftPatchService(
+            domainPackVersionRepository,
+            cloneService,
+            intentRepository,
+            slotRepository,
+            policyRepository,
+            riskRepository,
+            workflowRepository,
+            structuralPatchParser,
+            structuralPatchApplyService,
+            new ObjectMapper());
+  }
+
+  @Test
+  @DisplayName("구조적 패치 schema면 structural apply로 위임하고 description 경로를 건드리지 않는다")
+  void should_routeToStructuralApply_when_schemaMatches() {
+    givenDraftSource();
+    StructuralDomainPackPatch patch = structuralPatch();
+    given(structuralPatchParser.parse(STRUCTURAL_JSON)).willReturn(patch);
+
+    service.applyDraftPatch(
+        WORKSPACE_ID,
+        USER_ID,
+        candidate(STRUCTURAL_JSON, SimulationImprovementCandidateTargetType.INTENT, "greet"));
+
+    verify(structuralPatchParser).parse(STRUCTURAL_JSON);
+    verify(structuralPatchApplyService).apply(VERSION_ID, patch);
+    verify(cloneService, never()).cloneVersion(any());
+    verifyNoInteractions(
+        intentRepository, slotRepository, policyRepository, riskRepository, workflowRepository);
+  }
+
+  @Test
+  @DisplayName("구조적 schema가 아니면 기존 description 패치 경로를 사용한다")
+  void should_routeToLegacyDescription_when_notStructural() {
+    givenDraftSource();
+    IntentDefinition intent =
+        IntentDefinition.create(VERSION_ID, "greet", "인사", "기존", 1, "{}", "{}", "[]", "{}");
+    given(intentRepository.findByDomainPackVersionIdAndIntentCode(VERSION_ID, "greet"))
+        .willReturn(Optional.of(intent));
+
+    service.applyDraftPatch(
+        WORKSPACE_ID,
+        USER_ID,
+        candidate("{}", SimulationImprovementCandidateTargetType.INTENT, "greet"));
+
+    verify(intentRepository).save(intent);
+    verifyNoInteractions(structuralPatchParser, structuralPatchApplyService);
+  }
+
+  @Test
+  @DisplayName("source가 DRAFT가 아니면 draft를 clone한 뒤 적용한다")
+  void should_cloneDraft_when_sourceNotDraft() {
+    DomainPackVersion source = DomainPackVersion.ofForTest(VERSION_ID, PACK_ID, "PUBLISHED");
+    DomainPackVersion draft = DomainPackVersion.ofForTest(DRAFT_ID, PACK_ID, "DRAFT");
+    given(domainPackVersionRepository.findByIdForUpdate(VERSION_ID))
+        .willReturn(Optional.of(source));
+    given(
+            domainPackVersionRepository
+                .findFirstByDomainPackIdAndLifecycleStatusOrderByVersionNoDesc(PACK_ID, "DRAFT"))
+        .willReturn(Optional.empty());
+    given(cloneService.cloneVersion(any()))
+        .willReturn(
+            new DomainPackVersionCloneResult(
+                DRAFT_ID,
+                2,
+                "DRAFT",
+                DomainPackDraftSourceType.SIMULATION_REVIEW,
+                VERSION_ID,
+                1,
+                "r"));
+    given(domainPackVersionRepository.findByIdForUpdate(DRAFT_ID)).willReturn(Optional.of(draft));
+    StructuralDomainPackPatch patch = structuralPatch();
+    given(structuralPatchParser.parse(STRUCTURAL_JSON)).willReturn(patch);
+
+    service.applyDraftPatch(
+        WORKSPACE_ID,
+        USER_ID,
+        candidate(STRUCTURAL_JSON, SimulationImprovementCandidateTargetType.INTENT, "greet"));
+
+    verify(cloneService).cloneVersion(any());
+    verify(structuralPatchApplyService).apply(DRAFT_ID, patch);
+  }
+
+  @Test
+  @DisplayName("적용 실패는 호출자로 전파되어 트랜잭션이 롤백되도록 한다")
+  void should_propagateException_when_applyFails() {
+    givenDraftSource();
+    given(structuralPatchParser.parse(STRUCTURAL_JSON)).willReturn(structuralPatch());
+    willThrow(new InvalidStructuralPatchException("invalid"))
+        .given(structuralPatchApplyService)
+        .apply(eq(VERSION_ID), any());
+
+    assertThatThrownBy(
+            () ->
+                service.applyDraftPatch(
+                    WORKSPACE_ID,
+                    USER_ID,
+                    candidate(
+                        STRUCTURAL_JSON, SimulationImprovementCandidateTargetType.INTENT, "greet")))
+        .isInstanceOf(InvalidStructuralPatchException.class);
+  }
+
+  private void givenDraftSource() {
+    DomainPackVersion source = DomainPackVersion.ofForTest(VERSION_ID, PACK_ID, "DRAFT");
+    given(domainPackVersionRepository.findByIdForUpdate(VERSION_ID))
+        .willReturn(Optional.of(source));
+  }
+
+  private StructuralDomainPackPatch structuralPatch() {
+    return new StructuralDomainPackPatch(
+        StructuralDomainPackPatch.SCHEMA_VERSION,
+        "summary",
+        new StructuralPatchEvidence(1L, 2L, null, null, "failure"),
+        List.of(
+            new StructuralPatchOperation.ElementAttribute(
+                StructuralPatchOperationType.UPDATE_INTENT_DESCRIPTION,
+                StructuralPatchOperationType.UPDATE_INTENT_DESCRIPTION.getCategory(),
+                "greet",
+                null,
+                "d",
+                "reason")));
+  }
+
+  private SimulationImprovementCandidate candidate(
+      String draftPatchJson, SimulationImprovementCandidateTargetType targetType, String key) {
+    SimulationImprovementCandidateDraft draft =
+        new SimulationImprovementCandidateDraft(
+            SimulationImprovementCandidateType.OTHER,
+            targetType,
+            null,
+            key,
+            "before",
+            "새 설명",
+            "evidence");
+    SimulationImprovementCandidate candidate =
+        SimulationImprovementCandidate.create(
+            WORKSPACE_ID, VERSION_ID, FEEDBACK_ID, SESSION_ID, null, draft, USER_ID);
+    candidate.defineDraftPatch(draftPatchJson);
+    return candidate;
+  }
+}

--- a/backend/src/test/java/com/init/workflowruntime/application/SimulationStructuralPatchApplyIntegrationTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/SimulationStructuralPatchApplyIntegrationTest.java
@@ -1,0 +1,115 @@
+package com.init.workflowruntime.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.domainpack.domain.model.IntentDefinition;
+import com.init.domainpack.domain.model.IntentSlotBinding;
+import com.init.domainpack.domain.model.SlotDefinition;
+import com.init.domainpack.infrastructure.persistence.JpaIntentDefinitionRepository;
+import com.init.domainpack.infrastructure.persistence.JpaIntentSlotBindingRepository;
+import com.init.domainpack.infrastructure.persistence.JpaPolicyDefinitionRepository;
+import com.init.domainpack.infrastructure.persistence.JpaRiskDefinitionRepository;
+import com.init.domainpack.infrastructure.persistence.JpaSlotDefinitionRepository;
+import com.init.domainpack.infrastructure.persistence.JpaWorkflowDefinitionRepository;
+import com.init.workflowruntime.domain.StructuralDomainPackPatch;
+import com.init.workflowruntime.domain.StructuralPatchEvidence;
+import com.init.workflowruntime.domain.StructuralPatchOperation;
+import com.init.workflowruntime.domain.StructuralPatchOperationType;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * 구조적 패치 적용이 실제 영속 상태에 반영되는지 검증한다. graphJson(jsonb) 내용 round-trip은 운영 PostgreSQL 매핑(기존 description
+ * patch 경로에서 검증됨)과 {@code SimulationStructuralPatchApplyServiceTest}(실제 validator 사용)가 다루고, 여기서는
+ * H2가 안정적으로 round-trip하는 컬럼(IntentSlotBinding.is_required)과 신규 조회 쿼리를 다룬다.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@TestPropertySource(
+    properties = {
+      "spring.datasource.url=jdbc:h2:mem:testdb-structural-patch;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE",
+      "spring.datasource.driver-class-name=org.h2.Driver",
+      "spring.datasource.username=sa",
+      "spring.datasource.password=",
+      "spring.jpa.hibernate.ddl-auto=create-drop",
+      "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect",
+      "spring.jpa.properties.hibernate.hbm2ddl.create_namespaces=true",
+      "spring.liquibase.enabled=false"
+    })
+@DisplayName("SimulationStructuralPatchApply 영속 통합")
+class SimulationStructuralPatchApplyIntegrationTest {
+
+  private static final Long DRAFT_VERSION_ID = 9001L;
+
+  @Autowired private TestEntityManager em;
+  @Autowired private JpaIntentDefinitionRepository intentRepository;
+  @Autowired private JpaSlotDefinitionRepository slotRepository;
+  @Autowired private JpaPolicyDefinitionRepository policyRepository;
+  @Autowired private JpaRiskDefinitionRepository riskRepository;
+  @Autowired private JpaWorkflowDefinitionRepository workflowRepository;
+  @Autowired private JpaIntentSlotBindingRepository intentSlotBindingRepository;
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private SimulationStructuralPatchApplyService service;
+  private Long slotId;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new SimulationStructuralPatchApplyService(
+            intentRepository,
+            slotRepository,
+            policyRepository,
+            riskRepository,
+            workflowRepository,
+            intentSlotBindingRepository,
+            new WorkflowGraphPatchApplier(objectMapper),
+            objectMapper);
+
+    IntentDefinition intent =
+        em.persistAndFlush(
+            IntentDefinition.create(
+                DRAFT_VERSION_ID, "cancel", "취소", "취소 의도", 1, "{}", "{}", "[]", "{}"));
+    SlotDefinition slot =
+        em.persistAndFlush(
+            SlotDefinition.create(
+                DRAFT_VERSION_ID, "pickupDate", "픽업 일자", "설명", "STRING", false, "{}", null, "{}"));
+    slotId = slot.getId();
+    em.persistAndFlush(IntentSlotBinding.create(intent.getId(), slotId, false, 1, null, "{}"));
+    em.clear();
+  }
+
+  @Test
+  @DisplayName("MARK_SLOT_REQUIRED은 draft slot의 binding is_required를 영구히 true로 만든다")
+  void should_persistSlotRequired() {
+    service.apply(
+        DRAFT_VERSION_ID,
+        new StructuralDomainPackPatch(
+            StructuralDomainPackPatch.SCHEMA_VERSION,
+            "summary",
+            new StructuralPatchEvidence(1L, 2L, null, null, "failure"),
+            List.of(
+                new StructuralPatchOperation.ElementAttribute(
+                    StructuralPatchOperationType.MARK_SLOT_REQUIRED,
+                    StructuralPatchOperationType.MARK_SLOT_REQUIRED.getCategory(),
+                    "pickupDate",
+                    null,
+                    null,
+                    "reason"))));
+    em.flush();
+    em.clear();
+
+    List<IntentSlotBinding> bindings =
+        intentSlotBindingRepository.findAllBySlotDefinitionId(slotId);
+    assertThat(bindings).isNotEmpty();
+    assertThat(bindings).allMatch(IntentSlotBinding::getIsRequired);
+  }
+}

--- a/backend/src/test/java/com/init/workflowruntime/application/SimulationStructuralPatchApplyServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/SimulationStructuralPatchApplyServiceTest.java
@@ -319,6 +319,104 @@ class SimulationStructuralPatchApplyServiceTest {
         .hasMessageContaining("찾을 수 없습니다");
   }
 
+  @Test
+  @DisplayName("UPDATE_SLOT_VALIDATION은 JSON object가 아닌 값을 거절한다")
+  void should_rejectNonObjectSlotValidation() {
+    SlotDefinition slot = slot("{}");
+    given(slotRepository.findByDomainPackVersionIdAndSlotCode(DRAFT_VERSION_ID, "pickup"))
+        .willReturn(Optional.of(slot));
+
+    assertThatThrownBy(
+            () ->
+                service.apply(
+                    DRAFT_VERSION_ID,
+                    patch(
+                        element(
+                            StructuralPatchOperationType.UPDATE_SLOT_VALIDATION, "pickup", "[]"))))
+        .isInstanceOf(InvalidStructuralPatchException.class);
+    verify(slotRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("ADD_INTENT_EXAMPLE은 기존 examples 배열 뒤에 덧붙인다")
+  void should_appendExampleToExistingArray() throws Exception {
+    IntentDefinition intent = intent("{\"examples\":[\"기존\"]}", "설명");
+    given(intentRepository.findByDomainPackVersionIdAndIntentCode(DRAFT_VERSION_ID, "greet"))
+        .willReturn(Optional.of(intent));
+
+    service.apply(
+        DRAFT_VERSION_ID,
+        patch(element(StructuralPatchOperationType.ADD_INTENT_EXAMPLE, "greet", "새 예시")));
+
+    JsonNode examples = objectMapper.readTree(intent.getMetaJson()).path("examples");
+    assertThat(examples).hasSize(2);
+    assertThat(examples.get(0).asText()).isEqualTo("기존");
+    assertThat(examples.get(1).asText()).isEqualTo("새 예시");
+  }
+
+  @Test
+  @DisplayName("element operation은 targetCode 없이 targetId로 대상을 resolve한다")
+  void should_resolveElementByTargetId() {
+    IntentDefinition intent = intent("{}", "기존");
+    given(intentRepository.findByIdAndDomainPackVersionId(7L, DRAFT_VERSION_ID))
+        .willReturn(Optional.of(intent));
+    SlotDefinition slot = slot("{}");
+    given(slotRepository.findByIdAndDomainPackVersionId(8L, DRAFT_VERSION_ID))
+        .willReturn(Optional.of(slot));
+    PolicyDefinition policy = policy();
+    given(policyRepository.findByIdAndDomainPackVersionId(9L, DRAFT_VERSION_ID))
+        .willReturn(Optional.of(policy));
+    RiskDefinition risk = risk();
+    given(riskRepository.findByIdAndDomainPackVersionId(11L, DRAFT_VERSION_ID))
+        .willReturn(Optional.of(risk));
+
+    service.apply(
+        DRAFT_VERSION_ID,
+        patch(
+            elementById(StructuralPatchOperationType.UPDATE_INTENT_DESCRIPTION, 7L, "새 설명"),
+            elementById(StructuralPatchOperationType.UPDATE_SLOT_DESCRIPTION, 8L, "슬롯 설명"),
+            elementById(StructuralPatchOperationType.UPDATE_POLICY_CONDITION, 9L, "{\"k\":1}"),
+            elementById(StructuralPatchOperationType.UPDATE_RISK_TRIGGER, 11L, "{\"k\":2}")));
+
+    assertThat(intent.getDescription()).isEqualTo("새 설명");
+    assertThat(slot.getDescription()).isEqualTo("슬롯 설명");
+    assertThat(policy.getConditionJson()).contains("\"k\"");
+    assertThat(risk.getTriggerConditionJson()).contains("\"k\"");
+  }
+
+  @Test
+  @DisplayName("workflow operation은 workflowDefinitionId로 대상을 resolve한다")
+  void should_resolveWorkflowByDefinitionId() throws Exception {
+    WorkflowDefinition workflow = workflow(BASE_GRAPH);
+    given(workflowRepository.findByIdAndDomainPackVersionId(12L, DRAFT_VERSION_ID))
+        .willReturn(Optional.of(workflow));
+
+    service.apply(
+        DRAFT_VERSION_ID,
+        patch(
+            new StructuralPatchOperation.WorkflowNode(
+                StructuralPatchOperationType.ADD_WORKFLOW_NODE,
+                null,
+                12L,
+                "answer_x",
+                "ANSWER",
+                null,
+                "안내드립니다",
+                "reason"),
+            new StructuralPatchOperation.WorkflowTransition(
+                StructuralPatchOperationType.ADD_TRANSITION,
+                null,
+                12L,
+                "start",
+                "answer_x",
+                null,
+                "reason")));
+
+    JsonNode graph = objectMapper.readTree(workflow.getGraphJson());
+    assertThat(nodeExists(graph, "answer_x")).isTrue();
+    verify(workflowRepository).save(workflow);
+  }
+
   // --- helpers ---
 
   private StructuralDomainPackPatch patch(StructuralPatchOperation... ops) {
@@ -333,6 +431,12 @@ class SimulationStructuralPatchApplyServiceTest {
       StructuralPatchOperationType type, String targetCode, String value) {
     return new StructuralPatchOperation.ElementAttribute(
         type, type.getCategory(), targetCode, null, value, "reason");
+  }
+
+  private StructuralPatchOperation elementById(
+      StructuralPatchOperationType type, Long targetId, String value) {
+    return new StructuralPatchOperation.ElementAttribute(
+        type, type.getCategory(), null, targetId, value, "reason");
   }
 
   private IntentDefinition intent(String metaJson, String description) {

--- a/backend/src/test/java/com/init/workflowruntime/application/SimulationStructuralPatchApplyServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/SimulationStructuralPatchApplyServiceTest.java
@@ -1,0 +1,391 @@
+package com.init.workflowruntime.application;
+
+import static com.init.workflowruntime.support.WorkflowRuntimeTestObjects.slotDefinitionWithId;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.domainpack.domain.model.IntentDefinition;
+import com.init.domainpack.domain.model.IntentSlotBinding;
+import com.init.domainpack.domain.model.PolicyDefinition;
+import com.init.domainpack.domain.model.RiskDefinition;
+import com.init.domainpack.domain.model.SlotDefinition;
+import com.init.domainpack.domain.model.WorkflowDefinition;
+import com.init.domainpack.domain.repository.IntentDefinitionRepository;
+import com.init.domainpack.domain.repository.IntentSlotBindingRepository;
+import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
+import com.init.domainpack.domain.repository.RiskDefinitionRepository;
+import com.init.domainpack.domain.repository.SlotDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.workflowruntime.domain.InvalidStructuralPatchException;
+import com.init.workflowruntime.domain.StructuralDomainPackPatch;
+import com.init.workflowruntime.domain.StructuralPatchEvidence;
+import com.init.workflowruntime.domain.StructuralPatchOperation;
+import com.init.workflowruntime.domain.StructuralPatchOperationType;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SimulationStructuralPatchApplyService")
+class SimulationStructuralPatchApplyServiceTest {
+
+  private static final Long DRAFT_VERSION_ID = 10L;
+  private static final String BASE_GRAPH =
+      "{\"nodes\":[{\"id\":\"start\",\"type\":\"START\"},{\"id\":\"end\",\"type\":\"TERMINAL\"}],"
+          + "\"edges\":[{\"id\":\"e1\",\"from\":\"start\",\"to\":\"end\"}]}";
+
+  @Mock private IntentDefinitionRepository intentRepository;
+  @Mock private SlotDefinitionRepository slotRepository;
+  @Mock private PolicyDefinitionRepository policyRepository;
+  @Mock private RiskDefinitionRepository riskRepository;
+  @Mock private WorkflowDefinitionRepository workflowRepository;
+  @Mock private IntentSlotBindingRepository intentSlotBindingRepository;
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private SimulationStructuralPatchApplyService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new SimulationStructuralPatchApplyService(
+            intentRepository,
+            slotRepository,
+            policyRepository,
+            riskRepository,
+            workflowRepository,
+            intentSlotBindingRepository,
+            new WorkflowGraphPatchApplier(objectMapper),
+            objectMapper);
+  }
+
+  @Test
+  @DisplayName("UPDATE_INTENT_DESCRIPTION은 description을 교체하고 저장한다")
+  void should_updateIntentDescription() {
+    IntentDefinition intent = intent("{}", "기존 설명");
+    given(intentRepository.findByDomainPackVersionIdAndIntentCode(DRAFT_VERSION_ID, "greet"))
+        .willReturn(Optional.of(intent));
+
+    service.apply(
+        DRAFT_VERSION_ID,
+        patch(element(StructuralPatchOperationType.UPDATE_INTENT_DESCRIPTION, "greet", "새 설명")));
+
+    assertThat(intent.getDescription()).isEqualTo("새 설명");
+    verify(intentRepository).save(intent);
+  }
+
+  @Test
+  @DisplayName("ADD_INTENT_EXAMPLE은 metaJson examples 배열에 추가하고 기존 데이터를 보존한다")
+  void should_addIntentExample() throws Exception {
+    IntentDefinition intent = intent("{\"note\":\"keep\"}", "설명");
+    given(intentRepository.findByDomainPackVersionIdAndIntentCode(DRAFT_VERSION_ID, "greet"))
+        .willReturn(Optional.of(intent));
+
+    service.apply(
+        DRAFT_VERSION_ID,
+        patch(element(StructuralPatchOperationType.ADD_INTENT_EXAMPLE, "greet", "환불해 주세요")));
+
+    JsonNode meta = objectMapper.readTree(intent.getMetaJson());
+    assertThat(meta.path("note").asText()).isEqualTo("keep");
+    assertThat(meta.path("examples").get(0).asText()).isEqualTo("환불해 주세요");
+  }
+
+  @Test
+  @DisplayName("UPDATE_SLOT_VALIDATION은 기존 validation을 보존하며 merge한다")
+  void should_mergeSlotValidation() throws Exception {
+    SlotDefinition slot = slot("{\"maxLength\":10}");
+    given(slotRepository.findByDomainPackVersionIdAndSlotCode(DRAFT_VERSION_ID, "pickup"))
+        .willReturn(Optional.of(slot));
+
+    service.apply(
+        DRAFT_VERSION_ID,
+        patch(
+            element(
+                StructuralPatchOperationType.UPDATE_SLOT_VALIDATION,
+                "pickup",
+                "{\"required\":true}")));
+
+    JsonNode validation = objectMapper.readTree(slot.getValidationRuleJson());
+    assertThat(validation.path("maxLength").asInt()).isEqualTo(10);
+    assertThat(validation.path("required").asBoolean()).isTrue();
+    verify(slotRepository).save(slot);
+  }
+
+  @Test
+  @DisplayName("MARK_SLOT_REQUIRED은 slot의 모든 intent binding을 필수로 표시한다")
+  void should_markSlotRequired() {
+    SlotDefinition slot = slotDefinitionWithId(slot("{}"), 55L);
+    given(slotRepository.findByDomainPackVersionIdAndSlotCode(DRAFT_VERSION_ID, "pickup"))
+        .willReturn(Optional.of(slot));
+    IntentSlotBinding binding = IntentSlotBinding.create(7L, 55L, false, 1, null, "{}");
+    given(intentSlotBindingRepository.findAllBySlotDefinitionId(55L)).willReturn(List.of(binding));
+
+    service.apply(
+        DRAFT_VERSION_ID,
+        patch(element(StructuralPatchOperationType.MARK_SLOT_REQUIRED, "pickup", null)));
+
+    assertThat(binding.getIsRequired()).isTrue();
+    verify(intentSlotBindingRepository).saveAll(List.of(binding));
+  }
+
+  @Test
+  @DisplayName("MARK_SLOT_REQUIRED은 binding이 없으면 거절한다")
+  void should_rejectMarkSlotRequiredWithoutBinding() {
+    SlotDefinition slot = slotDefinitionWithId(slot("{}"), 55L);
+    given(slotRepository.findByDomainPackVersionIdAndSlotCode(DRAFT_VERSION_ID, "pickup"))
+        .willReturn(Optional.of(slot));
+    given(intentSlotBindingRepository.findAllBySlotDefinitionId(55L)).willReturn(List.of());
+
+    assertThatThrownBy(
+            () ->
+                service.apply(
+                    DRAFT_VERSION_ID,
+                    patch(
+                        element(StructuralPatchOperationType.MARK_SLOT_REQUIRED, "pickup", null))))
+        .isInstanceOf(InvalidStructuralPatchException.class)
+        .hasMessageContaining("binding");
+  }
+
+  @Test
+  @DisplayName("UPDATE_POLICY_CONDITION은 잘못된 JSON을 거절한다")
+  void should_rejectInvalidPolicyConditionJson() {
+    PolicyDefinition policy = policy();
+    given(policyRepository.findByDomainPackVersionIdAndPolicyCode(DRAFT_VERSION_ID, "p1"))
+        .willReturn(Optional.of(policy));
+
+    assertThatThrownBy(
+            () ->
+                service.apply(
+                    DRAFT_VERSION_ID,
+                    patch(
+                        element(
+                            StructuralPatchOperationType.UPDATE_POLICY_CONDITION,
+                            "p1",
+                            "not-json"))))
+        .isInstanceOf(InvalidStructuralPatchException.class);
+    verify(policyRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("UPDATE_RISK_TRIGGER은 condition JSON을 교체한다")
+  void should_updateRiskTrigger() {
+    RiskDefinition risk = risk();
+    given(riskRepository.findByDomainPackVersionIdAndRiskCode(DRAFT_VERSION_ID, "r1"))
+        .willReturn(Optional.of(risk));
+
+    service.apply(
+        DRAFT_VERSION_ID,
+        patch(
+            element(
+                StructuralPatchOperationType.UPDATE_RISK_TRIGGER,
+                "r1",
+                "{\"type\":\"keyword\",\"value\":\"환불\"}")));
+
+    assertThat(risk.getTriggerConditionJson()).contains("keyword");
+    verify(riskRepository).save(risk);
+  }
+
+  @Test
+  @DisplayName("대상 요소가 draft 버전에 없으면 거절한다")
+  void should_rejectMissingTarget() {
+    given(intentRepository.findByDomainPackVersionIdAndIntentCode(DRAFT_VERSION_ID, "ghost"))
+        .willReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () ->
+                service.apply(
+                    DRAFT_VERSION_ID,
+                    patch(
+                        element(
+                            StructuralPatchOperationType.UPDATE_INTENT_DESCRIPTION, "ghost", "x"))))
+        .isInstanceOf(InvalidStructuralPatchException.class)
+        .hasMessageContaining("찾을 수 없습니다");
+  }
+
+  @Test
+  @DisplayName("workflow node와 transition을 추가하면 검증을 거쳐 graph가 저장된다")
+  void should_applyWorkflowNodeAndTransition() throws Exception {
+    WorkflowDefinition workflow = workflow(BASE_GRAPH);
+    given(workflowRepository.findByDomainPackVersionIdAndWorkflowCode(DRAFT_VERSION_ID, "wf"))
+        .willReturn(Optional.of(workflow));
+
+    service.apply(
+        DRAFT_VERSION_ID,
+        patch(
+            new StructuralPatchOperation.WorkflowNode(
+                StructuralPatchOperationType.ADD_WORKFLOW_NODE,
+                "wf",
+                null,
+                "answer_pickup",
+                "ANSWER",
+                null,
+                "픽업 일자를 알려주세요",
+                "reason"),
+            new StructuralPatchOperation.WorkflowTransition(
+                StructuralPatchOperationType.ADD_TRANSITION,
+                "wf",
+                null,
+                "start",
+                "answer_pickup",
+                null,
+                "reason")));
+
+    JsonNode graph = objectMapper.readTree(workflow.getGraphJson());
+    assertThat(nodeExists(graph, "answer_pickup")).isTrue();
+    assertThat(workflow.getInitialState()).isEqualTo("start");
+    assertThat(workflow.getTerminalStatesJson()).contains("end");
+    verify(workflowRepository).save(workflow);
+  }
+
+  @Test
+  @DisplayName("dangling transition을 만드는 패치는 검증에서 거절되고 graph를 저장하지 않는다")
+  void should_rejectDanglingTransition_and_notSave() {
+    WorkflowDefinition workflow = workflow(BASE_GRAPH);
+    given(workflowRepository.findByDomainPackVersionIdAndWorkflowCode(DRAFT_VERSION_ID, "wf"))
+        .willReturn(Optional.of(workflow));
+
+    assertThatThrownBy(
+            () ->
+                service.apply(
+                    DRAFT_VERSION_ID,
+                    patch(
+                        new StructuralPatchOperation.WorkflowTransition(
+                            StructuralPatchOperationType.ADD_TRANSITION,
+                            "wf",
+                            null,
+                            "ghost",
+                            "end",
+                            null,
+                            "reason"))))
+        .isInstanceOf(BadRequestException.class);
+    verify(workflowRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("UPDATE_RESPONSE_COPY는 일치하는 단일 node의 copy를 설정한다")
+  void should_applyResponseCopyToUniqueNode() throws Exception {
+    WorkflowDefinition workflow = workflow(BASE_GRAPH);
+    given(workflowRepository.findAllByDomainPackVersionId(DRAFT_VERSION_ID))
+        .willReturn(List.of(workflow));
+
+    service.apply(
+        DRAFT_VERSION_ID,
+        patch(element(StructuralPatchOperationType.UPDATE_RESPONSE_COPY, "end", "감사합니다")));
+
+    JsonNode graph = objectMapper.readTree(workflow.getGraphJson());
+    assertThat(nodeCopy(graph, "end")).isEqualTo("감사합니다");
+    verify(workflowRepository).save(workflow);
+  }
+
+  @Test
+  @DisplayName("UPDATE_RESPONSE_COPY는 여러 workflow node와 일치하면 거절한다")
+  void should_rejectAmbiguousResponseCopy() {
+    given(workflowRepository.findAllByDomainPackVersionId(DRAFT_VERSION_ID))
+        .willReturn(List.of(workflow(BASE_GRAPH), workflow(BASE_GRAPH)));
+
+    assertThatThrownBy(
+            () ->
+                service.apply(
+                    DRAFT_VERSION_ID,
+                    patch(element(StructuralPatchOperationType.UPDATE_RESPONSE_COPY, "end", "감사"))))
+        .isInstanceOf(InvalidStructuralPatchException.class)
+        .hasMessageContaining("여러 workflow");
+  }
+
+  @Test
+  @DisplayName("UPDATE_RESPONSE_COPY는 일치하는 node가 없으면 거절한다")
+  void should_rejectResponseCopyWithoutMatch() {
+    given(workflowRepository.findAllByDomainPackVersionId(DRAFT_VERSION_ID))
+        .willReturn(List.of(workflow(BASE_GRAPH)));
+
+    assertThatThrownBy(
+            () ->
+                service.apply(
+                    DRAFT_VERSION_ID,
+                    patch(
+                        element(StructuralPatchOperationType.UPDATE_RESPONSE_COPY, "ghost", "감사"))))
+        .isInstanceOf(InvalidStructuralPatchException.class)
+        .hasMessageContaining("찾을 수 없습니다");
+  }
+
+  // --- helpers ---
+
+  private StructuralDomainPackPatch patch(StructuralPatchOperation... ops) {
+    return new StructuralDomainPackPatch(
+        StructuralDomainPackPatch.SCHEMA_VERSION,
+        "summary",
+        new StructuralPatchEvidence(1L, 2L, null, null, "failure"),
+        List.of(ops));
+  }
+
+  private StructuralPatchOperation element(
+      StructuralPatchOperationType type, String targetCode, String value) {
+    return new StructuralPatchOperation.ElementAttribute(
+        type, type.getCategory(), targetCode, null, value, "reason");
+  }
+
+  private IntentDefinition intent(String metaJson, String description) {
+    return IntentDefinition.create(
+        DRAFT_VERSION_ID, "greet", "인사", description, 1, "{}", "{}", "[]", metaJson);
+  }
+
+  private SlotDefinition slot(String validationRuleJson) {
+    return SlotDefinition.create(
+        DRAFT_VERSION_ID, "pickup", "픽업 일자", "설명", "STRING", false, validationRuleJson, null, "{}");
+  }
+
+  private PolicyDefinition policy() {
+    return PolicyDefinition.create(
+        DRAFT_VERSION_ID, "p1", "정책", "설명", "MEDIUM", "{}", "{}", "[]", "{}");
+  }
+
+  private RiskDefinition risk() {
+    return RiskDefinition.create(
+        DRAFT_VERSION_ID, "r1", "위험", "설명", "MEDIUM", "{}", "{}", "[]", "{}");
+  }
+
+  private WorkflowDefinition workflow(String graphJson) {
+    return WorkflowDefinition.create(
+        DRAFT_VERSION_ID,
+        "wf",
+        "워크플로우",
+        "설명",
+        graphJson,
+        "start",
+        "[\"end\"]",
+        "[]",
+        "{}",
+        1L,
+        true,
+        "{}");
+  }
+
+  private boolean nodeExists(JsonNode graph, String id) {
+    for (JsonNode node : graph.path("nodes")) {
+      if (id.equals(node.path("id").asText(null))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private String nodeCopy(JsonNode graph, String id) {
+    for (JsonNode node : graph.path("nodes")) {
+      if (id.equals(node.path("id").asText(null))) {
+        return node.path("copy").asText(null);
+      }
+    }
+    return null;
+  }
+}

--- a/backend/src/test/java/com/init/workflowruntime/application/WorkflowGraphPatchApplierTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/WorkflowGraphPatchApplierTest.java
@@ -1,0 +1,306 @@
+package com.init.workflowruntime.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.workflowruntime.domain.InvalidStructuralPatchException;
+import com.init.workflowruntime.domain.StructuralPatchOperation;
+import com.init.workflowruntime.domain.StructuralPatchOperationType;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("WorkflowGraphPatchApplier")
+class WorkflowGraphPatchApplierTest {
+
+  private static final String BASE_GRAPH =
+      """
+      {
+        "direction": "LR",
+        "nodes": [
+          {"id": "start", "type": "START", "label": "시작"},
+          {"id": "end", "type": "TERMINAL"}
+        ],
+        "edges": [
+          {"id": "e1", "from": "start", "to": "end", "condition": {"type": "always"}}
+        ]
+      }
+      """;
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final WorkflowGraphPatchApplier applier = new WorkflowGraphPatchApplier(objectMapper);
+  private final Predicate<String> anySlotExists = code -> true;
+
+  @Test
+  @DisplayName("ADD_WORKFLOW_NODE는 node를 추가하고 기존 node 속성을 보존한다")
+  void should_addNodeAndPreserveExistingFields() throws Exception {
+    StructuralPatchOperation op =
+        new StructuralPatchOperation.WorkflowNode(
+            StructuralPatchOperationType.ADD_WORKFLOW_NODE,
+            "wf",
+            null,
+            "answer_pickup",
+            "ANSWER",
+            null,
+            "픽업 일자를 알려주세요",
+            "reason");
+
+    JsonNode result = parse(applier.apply(BASE_GRAPH, List.of(op), anySlotExists));
+
+    assertThat(nodeById(result, "answer_pickup").path("prompt").asText()).isEqualTo("픽업 일자를 알려주세요");
+    assertThat(nodeById(result, "start").path("label").asText()).isEqualTo("시작");
+  }
+
+  @Test
+  @DisplayName("ADD_WORKFLOW_NODE는 이미 존재하는 node id를 거절한다")
+  void should_rejectDuplicateNodeOnAdd() {
+    StructuralPatchOperation op =
+        new StructuralPatchOperation.WorkflowNode(
+            StructuralPatchOperationType.ADD_WORKFLOW_NODE,
+            "wf",
+            null,
+            "start",
+            "ANSWER",
+            null,
+            "text",
+            "reason");
+
+    assertThatThrownBy(() -> applier.apply(BASE_GRAPH, List.of(op), anySlotExists))
+        .isInstanceOf(InvalidStructuralPatchException.class)
+        .hasMessageContaining("이미 존재하는 node id");
+  }
+
+  @Test
+  @DisplayName("user-facing node는 prompt가 비어 있으면 거절한다")
+  void should_rejectUserFacingNodeWithoutPrompt() {
+    StructuralPatchOperation op =
+        new StructuralPatchOperation.WorkflowNode(
+            StructuralPatchOperationType.ADD_WORKFLOW_NODE,
+            "wf",
+            null,
+            "answer_x",
+            "ANSWER",
+            null,
+            null,
+            "reason");
+
+    assertThatThrownBy(() -> applier.apply(BASE_GRAPH, List.of(op), anySlotExists))
+        .isInstanceOf(InvalidStructuralPatchException.class)
+        .hasMessageContaining("prompt");
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 slotCode를 참조하는 node는 거절한다")
+  void should_rejectNodeWithUnknownSlotCode() {
+    StructuralPatchOperation op =
+        new StructuralPatchOperation.WorkflowNode(
+            StructuralPatchOperationType.ADD_WORKFLOW_NODE,
+            "wf",
+            null,
+            "ask_pickup",
+            "ASK_SLOT",
+            "pickupDate",
+            null,
+            "reason");
+
+    assertThatThrownBy(() -> applier.apply(BASE_GRAPH, List.of(op), code -> false))
+        .isInstanceOf(InvalidStructuralPatchException.class)
+        .hasMessageContaining("slotCode");
+  }
+
+  @Test
+  @DisplayName("UPDATE_WORKFLOW_NODE는 존재하는 node를 수정하고, 없으면 거절한다")
+  void should_updateExistingNode_and_rejectMissing() throws Exception {
+    StructuralPatchOperation update =
+        new StructuralPatchOperation.WorkflowNode(
+            StructuralPatchOperationType.UPDATE_WORKFLOW_NODE,
+            "wf",
+            null,
+            "end",
+            "TERMINAL",
+            null,
+            null,
+            "reason");
+    JsonNode result = parse(applier.apply(BASE_GRAPH, List.of(update), anySlotExists));
+    assertThat(nodeById(result, "end").path("type").asText()).isEqualTo("TERMINAL");
+
+    StructuralPatchOperation missing =
+        new StructuralPatchOperation.WorkflowNode(
+            StructuralPatchOperationType.UPDATE_WORKFLOW_NODE,
+            "wf",
+            null,
+            "ghost",
+            "ACTION",
+            null,
+            null,
+            "reason");
+    assertThatThrownBy(() -> applier.apply(BASE_GRAPH, List.of(missing), anySlotExists))
+        .isInstanceOf(InvalidStructuralPatchException.class)
+        .hasMessageContaining("찾을 수 없습니다");
+  }
+
+  @Test
+  @DisplayName("ADD_TRANSITION은 deterministic id로 edge를 추가하고 condition을 보존한다")
+  void should_addTransitionWithCondition() throws Exception {
+    StructuralPatchOperation op =
+        new StructuralPatchOperation.WorkflowTransition(
+            StructuralPatchOperationType.ADD_TRANSITION,
+            "wf",
+            null,
+            "end",
+            "start",
+            "{\"type\":\"default\"}",
+            "reason");
+
+    JsonNode result = parse(applier.apply(BASE_GRAPH, List.of(op), anySlotExists));
+    JsonNode edge = edgeByFromTo(result, "end", "start");
+    assertThat(edge.path("id").asText()).isEqualTo("e_end_start");
+    assertThat(edge.path("condition").path("type").asText()).isEqualTo("default");
+  }
+
+  @Test
+  @DisplayName("ADD_TRANSITION은 동일 from/to edge가 있으면 거절한다")
+  void should_rejectDuplicateTransition() {
+    StructuralPatchOperation op =
+        new StructuralPatchOperation.WorkflowTransition(
+            StructuralPatchOperationType.ADD_TRANSITION,
+            "wf",
+            null,
+            "start",
+            "end",
+            null,
+            "reason");
+
+    assertThatThrownBy(() -> applier.apply(BASE_GRAPH, List.of(op), anySlotExists))
+        .isInstanceOf(InvalidStructuralPatchException.class)
+        .hasMessageContaining("이미 존재하는 transition");
+  }
+
+  @Test
+  @DisplayName("ADD_TRANSITION은 잘못된 condition JSON을 거절한다")
+  void should_rejectInvalidConditionJson() {
+    StructuralPatchOperation op =
+        new StructuralPatchOperation.WorkflowTransition(
+            StructuralPatchOperationType.ADD_TRANSITION,
+            "wf",
+            null,
+            "end",
+            "start",
+            "not-json",
+            "reason");
+
+    assertThatThrownBy(() -> applier.apply(BASE_GRAPH, List.of(op), anySlotExists))
+        .isInstanceOf(InvalidStructuralPatchException.class)
+        .hasMessageContaining("condition");
+  }
+
+  @Test
+  @DisplayName("UPDATE_TRANSITION은 condition을 교체하고, 없으면 거절한다")
+  void should_updateTransition_and_rejectMissing() throws Exception {
+    StructuralPatchOperation update =
+        new StructuralPatchOperation.WorkflowTransition(
+            StructuralPatchOperationType.UPDATE_TRANSITION,
+            "wf",
+            null,
+            "start",
+            "end",
+            "{\"type\":\"slot_present\",\"slotCode\":\"pickupDate\"}",
+            "reason");
+    JsonNode result = parse(applier.apply(BASE_GRAPH, List.of(update), anySlotExists));
+    assertThat(edgeByFromTo(result, "start", "end").path("condition").path("type").asText())
+        .isEqualTo("slot_present");
+
+    StructuralPatchOperation missing =
+        new StructuralPatchOperation.WorkflowTransition(
+            StructuralPatchOperationType.UPDATE_TRANSITION, "wf", null, "x", "y", null, "reason");
+    assertThatThrownBy(() -> applier.apply(BASE_GRAPH, List.of(missing), anySlotExists))
+        .isInstanceOf(InvalidStructuralPatchException.class);
+  }
+
+  @Test
+  @DisplayName("REMOVE_TRANSITION은 edge를 제거하고, 없으면 거절한다")
+  void should_removeTransition_and_rejectMissing() throws Exception {
+    StructuralPatchOperation remove =
+        new StructuralPatchOperation.WorkflowTransition(
+            StructuralPatchOperationType.REMOVE_TRANSITION,
+            "wf",
+            null,
+            "start",
+            "end",
+            null,
+            "reason");
+    JsonNode result = parse(applier.apply(BASE_GRAPH, List.of(remove), anySlotExists));
+    assertThat(result.path("edges")).isEmpty();
+
+    StructuralPatchOperation missing =
+        new StructuralPatchOperation.WorkflowTransition(
+            StructuralPatchOperationType.REMOVE_TRANSITION, "wf", null, "x", "y", null, "reason");
+    assertThatThrownBy(() -> applier.apply(BASE_GRAPH, List.of(missing), anySlotExists))
+        .isInstanceOf(InvalidStructuralPatchException.class);
+  }
+
+  @Test
+  @DisplayName("같은 patch에서 추가한 node를 이어지는 transition이 참조할 수 있다")
+  void should_supportNodeThenTransitionInSamePatch() throws Exception {
+    StructuralPatchOperation addNode =
+        new StructuralPatchOperation.WorkflowNode(
+            StructuralPatchOperationType.ADD_WORKFLOW_NODE,
+            "wf",
+            null,
+            "answer_pickup",
+            "ANSWER",
+            null,
+            "픽업 일자를 알려주세요",
+            "reason");
+    StructuralPatchOperation addEdge =
+        new StructuralPatchOperation.WorkflowTransition(
+            StructuralPatchOperationType.ADD_TRANSITION,
+            "wf",
+            null,
+            "start",
+            "answer_pickup",
+            null,
+            "reason");
+
+    JsonNode result = parse(applier.apply(BASE_GRAPH, List.of(addNode, addEdge), anySlotExists));
+    assertThat(nodeById(result, "answer_pickup").isMissingNode()).isFalse();
+    assertThat(edgeByFromTo(result, "start", "answer_pickup").path("id").asText())
+        .isEqualTo("e_start_answer_pickup");
+  }
+
+  @Test
+  @DisplayName("applyResponseCopy는 일치하는 node가 있으면 copy를 설정하고 없으면 비어있다")
+  void should_setResponseCopyWhenNodeMatches() throws Exception {
+    Optional<String> patched = applier.applyResponseCopy(BASE_GRAPH, "end", "감사합니다");
+    assertThat(patched).isPresent();
+    assertThat(nodeById(parse(patched.get()), "end").path("copy").asText()).isEqualTo("감사합니다");
+
+    assertThat(applier.applyResponseCopy(BASE_GRAPH, "ghost", "x")).isEmpty();
+  }
+
+  private JsonNode parse(String json) throws Exception {
+    return objectMapper.readTree(json);
+  }
+
+  private JsonNode nodeById(JsonNode graph, String id) {
+    for (JsonNode node : graph.path("nodes")) {
+      if (id.equals(node.path("id").asText(null))) {
+        return node;
+      }
+    }
+    return objectMapper.missingNode();
+  }
+
+  private JsonNode edgeByFromTo(JsonNode graph, String from, String to) {
+    for (JsonNode edge : graph.path("edges")) {
+      if (from.equals(edge.path("from").asText(null)) && to.equals(edge.path("to").asText(null))) {
+        return edge;
+      }
+    }
+    return objectMapper.missingNode();
+  }
+}


### PR DESCRIPTION
## 배경

#879(구조적 패치 계약)과 #880(LLM 패치 생성) 위에서, 승인된 `simulation-structural-patch.v1` 패치를 실제로 Domain Pack draft 버전에 안전하게 반영하는 적용 경계를 구현한다. 기존 적용 로직(`SimulationImprovementDraftPatchService`)은 description/summary만 갱신할 수 있어 워크플로우 그래프·슬롯 요구사항·정책 조건·응답 문구를 수리하지 못했다. LLM은 패치를 제안하고, 백엔드가 검증·적용의 안전 경계가 된다.

closes #881

## 변경 내용

- `SimulationImprovementDraftPatchService`가 orchestration 계층이 되어 `draftPatchJson`의 `schemaVersion`을 감지한다. `simulation-structural-patch.v1` → 신규 구조적 적용, 그 외(legacy `{}`·생성 envelope) → 기존 description 패치 동작 그대로.
- `SimulationStructuralPatchApplyService`: 검증된 operation을 draft 버전에만 적용. 대상은 draft 버전 내 code/id로 resolve하며 없으면 명확한 비즈니스 예외로 거절.
  - intent description/example(metaJson examples append), slot description/validation(기존 필드 보존 merge), policy condition, risk trigger — JSON 안전성 검증 후 적용.
  - `MARK_SLOT_REQUIRED`은 런타임이 소비하는 intent-slot binding의 `is_required`를 갱신.
  - `UPDATE_RESPONSE_COPY`는 draft workflow에서 동일 node id를 유일 매칭으로 찾아 copy 설정.
- `WorkflowGraphPatchApplier`: node/transition operation을 graphJson에 적용(알 수 없는 필드 보존, deterministic edge id, 중복/미존재/잘못된 condition 거절). 적용 결과는 기존 `WorkflowGraphValidator`(V1-V8)로 재검증해 초기 상태·도달 가능성·비순환·edge id·dangling 등 그래프 무결성을 보장하고 `initialState`/`terminalStates`를 재도출.
- `WorkflowGraphValidator`에 재사용 가능한 public `validate(graphJson, workflowCode)` 파사드를 추가(검증 + initial/terminal 재도출). 신규 validator를 만들지 않고 기존 검증 규칙을 그대로 재사용.
- `IntentSlotBinding.markRequired()` 도메인 메서드와 `IntentSlotBindingRepository.findAllBySlotDefinitionId(...)` 조회를 추가.

한 operation이라도 실패하면 승인 트랜잭션이 롤백되어 candidate가 `APPLIED`로 표시되지 않으며, 부분 적용이 남지 않는다. matching profile rebuild enqueue와 `appliedDomainPackVersionId` 저장은 기존 승인 흐름 그대로 유지된다.

## 설계 결정 (리뷰 포인트)

- `MARK_SLOT_REQUIRED`은 operation이 `slotCode`만 carry하므로, 런타임이 실제 소비하는 표현인 해당 slot의 모든 draft intent-slot binding `is_required`를 true로 표시한다. binding이 없으면 결정 불가로 거절.
- `UPDATE_RESPONSE_COPY`는 별도 `ResponseDefinition` 엔티티가 없어 `responseCode`를 draft workflow node id로 보고 유일 매칭 node의 `copy`에 저장한다. 비유일/부재 시 거절.
- `WorkflowGraphValidator` V6/V8 제약상 DECISION 출발 transition(label 필요)·ACTION node(policyRef 필요)는 v1 패치 계약에 해당 필드가 없어 fail-closed로 거절된다(MVP 한계, non-ACTION node 추가는 지원).

## 검증

backend Java 21 / Gradle. 워크트리에서 실행:

- `WorkflowGraphPatchApplierTest` (12) — node/transition 추가·수정·삭제, 중복/미존재/잘못된 condition/slot 거절, 필드 보존, 같은 패치 내 node→transition 참조.
- `SimulationStructuralPatchApplyServiceTest` (13) — element op 각 동작, workflow op 검증·저장, 대상 미존재·잘못된 JSON 거절, slot validation merge 보존, `MARK_SLOT_REQUIRED` binding 갱신, dangling 거절 시 미저장, response copy 유일/모호/부재.
- `SimulationImprovementDraftPatchServiceTest` (4) — schema 감지 분기(structural vs legacy), source 비-draft 시 clone, 적용 실패 전파.
- `SimulationStructuralPatchApplyIntegrationTest` (1, H2) — `MARK_SLOT_REQUIRED` binding 영구 반영 및 신규 조회 쿼리.
- 기존 `SimulationImprovementCandidateServiceTest` 등 `*.application` 패키지 회귀 통과, Spotless `spotlessCheck` 통과.

graphJson(jsonb) 내용 round-trip은 H2 테스트 하네스가 JSON String 컬럼을 이중 인코딩하는 한계가 있어, 실제 검증기/applier를 사용하는 apply-service 단위 테스트와 운영 PostgreSQL 매핑(기존 description 패치 경로에서 검증됨)으로 보장한다.

3라운드 self-review(이슈 충실도 / 아키텍처·통합 / 리뷰·CI 적대 검토) 완료, blocking 발견 없음.