### PR TITLE
fix(workflow-runtime): 운영자 미리보기 채팅 시스템 오류 및 워크플로우 미매칭 수정 (#903, #905)

### DIFF
--- a/backend/src/main/java/com/init/workflowruntime/application/IntentClassificationService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/IntentClassificationService.java
@@ -46,6 +46,7 @@ public class IntentClassificationService {
     this.workflowMatchingService = workflowMatchingService;
   }
 
+  @Transactional
   public IntentClassificationResult classify(IntentClassificationCommand command) {
     if (workflowMatchingService.isEnabled()) {
       WorkflowMatchResult matchResult =

--- a/backend/src/test/java/com/init/workflowruntime/application/IntentClassificationServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/IntentClassificationServiceTest.java
@@ -9,6 +9,7 @@ import com.init.domainpack.domain.model.IntentDefinition;
 import com.init.domainpack.domain.repository.IntentDefinitionRepository;
 import com.init.workflowruntime.application.command.IntentClassificationCommand;
 import com.init.workflowruntime.application.dto.IntentClassificationResult;
+import com.init.workflowruntime.application.matching.WorkflowMatchCandidate;
 import com.init.workflowruntime.application.matching.WorkflowMatchResult;
 import com.init.workflowruntime.application.matching.WorkflowMatchingService;
 import com.init.workflowruntime.domain.ChatSession;
@@ -117,6 +118,166 @@ class IntentClassificationServiceTest {
 
     assertThat(result.status()).isEqualTo("UNKNOWN");
     assertThat(result.candidates()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("classify: 임베딩이 CONFIDENT를 반환하면 바로 확신 결과를 반환한다")
+  void should_returnConfidentFromEmbedding_when_matchIsConfident() {
+    given(workflowMatchingService.isEnabled()).willReturn(true);
+    WorkflowMatchCandidate candidate =
+        new WorkflowMatchCandidate(
+            10L,
+            20L,
+            "refund_policy",
+            "환불 규정",
+            "WF-REFUND",
+            "환불 워크플로우",
+            "v1",
+            0.93,
+            0.9,
+            0.8,
+            0.7,
+            0.6,
+            0.85,
+            0.1,
+            true,
+            false,
+            null,
+            null);
+    given(workflowMatchingService.match(any(), any(), any()))
+        .willReturn(WorkflowMatchResult.confident(candidate));
+
+    IntentClassificationResult result = service.classify(command("환불하고 싶어요", ""));
+
+    assertThat(result.status()).isEqualTo("CONFIDENT");
+    assertThat(result.intentCode()).isEqualTo("refund_policy");
+    assertThat(result.confidence()).isEqualTo(0.93);
+    assertThat(result.candidates()).hasSize(1);
+    assertThat(result.candidates().get(0).intentCode()).isEqualTo("refund_policy");
+  }
+
+  @Test
+  @DisplayName("classify: 임베딩이 AMBIGUOUS를 반환하면 확인 질문과 후보 목록을 반환한다")
+  void should_returnAmbiguousFromEmbedding_when_matchIsAmbiguous() {
+    given(workflowMatchingService.isEnabled()).willReturn(true);
+    WorkflowMatchCandidate c1 =
+        new WorkflowMatchCandidate(
+            10L,
+            20L,
+            "refund_policy",
+            "환불 규정",
+            "WF-REFUND",
+            "환불",
+            "v1",
+            0.75,
+            0.7,
+            0.6,
+            0.5,
+            0.4,
+            0.65,
+            0.0,
+            true,
+            false,
+            null,
+            null);
+    WorkflowMatchCandidate c2 =
+        new WorkflowMatchCandidate(
+            11L,
+            21L,
+            "cancellation_policy",
+            "취소 규정",
+            "WF-CANCEL",
+            "취소",
+            "v1",
+            0.72,
+            0.7,
+            0.6,
+            0.5,
+            0.4,
+            0.65,
+            0.0,
+            true,
+            false,
+            null,
+            null);
+    given(workflowMatchingService.match(any(), any(), any()))
+        .willReturn(WorkflowMatchResult.ambiguous("환불인가요, 취소인가요?", List.of(c1, c2)));
+
+    IntentClassificationResult result = service.classify(command("변경하거나 취소하고 싶어요", ""));
+
+    assertThat(result.status()).isEqualTo("AMBIGUOUS");
+    assertThat(result.confirmationQuestion()).isEqualTo("환불인가요, 취소인가요?");
+    assertThat(result.candidates()).hasSize(2);
+  }
+
+  @Test
+  @DisplayName("classify: 임베딩이 UNKNOWN을 반환하면 키워드 폴백 없이 UNKNOWN을 반환한다")
+  void should_returnUnknown_when_embeddingMatchReturnsUnknown() {
+    // UNKNOWN ≠ UNAVAILABLE: UNAVAILABLE 만 키워드 폴백 트리거. UNKNOWN 은 바로 반환된다.
+    given(workflowMatchingService.isEnabled()).willReturn(true);
+    given(workflowMatchingService.match(any(), any(), any()))
+        .willReturn(WorkflowMatchResult.unknown("입력이 불충분합니다"));
+
+    IntentClassificationResult result = service.classify(command("음", ""));
+
+    assertThat(result.status()).isEqualTo("UNKNOWN");
+    assertThat(result.message()).isEqualTo("입력이 불충분합니다");
+  }
+
+  @Test
+  @DisplayName("classify: 임베딩이 BLOCKED를 반환하면 키워드 폴백 없이 UNKNOWN 메시지를 반환한다")
+  void should_returnUnknownMessage_when_embeddingMatchReturnsBlocked() {
+    given(workflowMatchingService.isEnabled()).willReturn(true);
+    WorkflowMatchCandidate blocked =
+        new WorkflowMatchCandidate(
+            10L,
+            20L,
+            "refund_policy",
+            "환불 규정",
+            "WF-REFUND",
+            "환불",
+            "v1",
+            0.85,
+            0.8,
+            0.7,
+            0.6,
+            0.5,
+            0.75,
+            0.0,
+            false,
+            true,
+            "low_replay_fitness",
+            null);
+    given(workflowMatchingService.match(any(), any(), any()))
+        .willReturn(WorkflowMatchResult.blocked("신뢰도 미달", List.of(blocked)));
+
+    IntentClassificationResult result = service.classify(command("환불하고 싶어요", ""));
+
+    assertThat(result.status()).isEqualTo("UNKNOWN");
+    assertThat(result.message()).isEqualTo("신뢰도 미달");
+  }
+
+  @Test
+  @DisplayName("classify: @Transactional 오버라이드로 @Async 핸들러에서도 match 결과 기록이 가능하다")
+  void should_handleMatchResult_when_calledWithoutOuterTransaction() {
+    // @Async LlmResponseHandler 에서 아웃 트랜잭션 없이 호출될 때 발생했던 readOnly 트랜잭션
+    // 제약(DML 불가) 버그를 재현하는 시나리오. classify 메서드에 @Transactional 을 추가해
+    // 독립 읽기-쓰기 트랜잭션을 시작함으로써 match 의 decision 기록이 정상 동작해야 한다.
+    // (단위 테스트에서 트랜잭션을 직접 검증할 수 없으므로 동작 흐름만 확인한다.)
+    givenSession();
+    given(workflowMatchingService.isEnabled()).willReturn(true);
+    given(workflowMatchingService.match(any(), any(), any()))
+        .willReturn(WorkflowMatchResult.unavailable()); // 프로덕션: 프로필 없음 → unavailable
+    given(intentDefinitionRepository.findByDomainPackVersionId(101L))
+        .willReturn(
+            List.of(
+                intent("cancellation_refund_policy", "취소 및 환불 규정", "예약 취소, 환불 절차", "PUBLISHED")));
+
+    IntentClassificationResult result = service.classify(command("여행 상품 구매한 것을 환불하고 싶어요", ""));
+
+    // 임베딩 매칭 프로필 없음 → 키워드 폴백 → 환불 intent 확신 매칭
+    assertThat(result.status()).isEqualTo("CONFIDENT");
+    assertThat(result.intentCode()).isEqualTo("cancellation_refund_policy");
   }
 
   @Test


### PR DESCRIPTION
## 개요

운영자 미리보기(`/chat/:workspaceId`) 경로에서 채팅 메시지를 보낼 때 발생한 두 가지 문제를 수정합니다.

Closes #903
Closes #905

---

## 근본 원인 분석

### 문제 재현 환경
- prod: `https://app.ajou-cstone.com/chat/1` (인증된 운영자 미리보기)
- 비교 대상: `https://app.ajou-cstone.com/demo/chat/1` (공개 데모 — 정상 동작)

### 원인

`IntentClassificationService`는 클래스 레벨 `@Transactional(readOnly=true)` 어노테이션을 갖습니다. `classify` 메서드는 내부적으로 `WorkflowMatchingService.match`를 호출하고, 이 메서드는 `WorkflowMatchDecisionRecorder`를 통해 `workflow_match_decision` 테이블에 `INSERT`를 수행합니다.

**Demo 경로 (`/demo/chat/:id`)**  
`DemoChatSessionRegistrationService.appendMessage`가 `@Transactional`(읽기-쓰기) 메서드이므로, `classify` 호출 시 외부 읽기-쓰기 트랜잭션에 참여합니다. → INSERT 성공 ✓

**인증 경로 (`/chat/:id`)**  
`LlmResponseHandler.handleChatMessageReceived`는 `@Async` 핸들러이며 외부 트랜잭션이 없습니다. `classify` 호출 시 클래스 레벨 `@Transactional(readOnly=true)` 트랜잭션이 독립적으로 시작됩니다. PostgreSQL은 읽기 전용 트랜잭션에서의 INSERT를 거부합니다 (`cannot execute INSERT in a read-only transaction`).

이 예외는 `WorkflowAssistantTools.classifyIntent`의 `catch (BusinessException | IllegalArgumentException)` 절을 우회해 Spring AI 프레임워크로 전파되고, AI 모델이 tool failure로 해석하여 **"일시적인 시스템 오류가 발생했습니다"** 응답을 생성합니다.

---

## 수정 내용

```java
// IntentClassificationService.java
@Transactional  // 추가: 클래스 레벨 readOnly=true 오버라이드
public IntentClassificationResult classify(IntentClassificationCommand command) {
    // ...
}
```

`classify` 메서드에 `@Transactional`을 추가해, 외부 트랜잭션 없이 호출될 때도 독립 읽기-쓰기 트랜잭션을 시작합니다.

---

## 검증

### prod 원인 분석
- `/chat/1` 새 세션에서 메시지 전송 → 기존: "시스템 오류" 응답, 수정 후: 워크플로우 매칭 정상 동작 확인

### localhost:5173 검증
- `/chat/1` (인증 경로): 수정 전 "시스템 오류", 수정 후 "요청하신 업무를 확인하겠습니다." (환불 워크플로우 진입) ✓
- `/demo/chat/1` (데모 경로): 동일 응답 유지, 기존 동작 회귀 없음 ✓

### 테스트
- 기존 `IntentClassificationServiceTest` 전체 통과
- 임베딩 매칭 결과별 신규 테스트 5건 추가 (CONFIDENT, AMBIGUOUS, UNKNOWN, BLOCKED, @Async 시나리오)
- 전체 백엔드 테스트 통과: `./gradlew test`

### 커버리지 (coverage-diff.py)
```json
{"newCoverage": null, "passed": true}
```
추가된 줄이 어노테이션(비실행 라인)이므로 N/A → passed.

---

## 변경 파일

| 파일 | 변경 |
|------|------|
| `IntentClassificationService.java` | `classify`에 `@Transactional` 추가 |
| `IntentClassificationServiceTest.java` | 임베딩 결과 유형별 테스트 5건 신규 추가 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 의도 분류 기능의 트랜잭션 처리를 최적화하여 데이터 일관성 강화

* **Tests**
  * 임베딩 매칭 결과(확신, 모호, 불명확)별 분류 동작 검증 테스트 추가
  * 트랜잭션 환경에서의 매칭 결과 기록 흐름 검증 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->