### PR TITLE
fix(intent): #910 연결된 워크플로우를 내부 리소스 하위로 이동해 세부정보 가림 해결

### DIFF
--- a/.agent/specs/910.md
+++ b/.agent/specs/910.md
@@ -1,0 +1,49 @@
+# 910 - intent 세부 정보 화면에서 할당된 워크플로우가 세부 정보를 가리는 문제
+
+## 배경
+
+Domain Pack의 intent 상세 화면(`IntentDraftReadPage` → `IntentDetailPanel`)은 헤더 아래에
+intent 핵심 정보(상태/분류 단계 카드, **내부 리소스** = 관련 키워드·대표 문장)를 표시하고,
+그 아래에 해당 intent에 연결된 워크플로우 목록(`MatchedWorkflowSection`)을 보여준다.
+
+## 문제
+
+intent에 워크플로우가 여러 개(예: 49개) 할당되면 워크플로우 목록이 화면을 가득 채우고,
+정작 intent의 내부 리소스 등 세부 정보가 화면에서 밀려나 보이지 않는다.
+
+### 원인
+
+- `IntentDetailPanel`(`frontend/src/entities/intent/ui/IntentDetailPanel.tsx`)의 루트 `.panel`은
+  `display:flex; flex-direction:column; overflow:hidden` 인 세로 flex 컨테이너다.
+- intent 핵심 정보(상태 카드 + 내부 리소스)는 `flex:1; overflow:auto` 인 `.body` **안에서** 스크롤된다.
+- 그런데 `MatchedWorkflowSection`은 `IntentDetailPanel`의 `children`으로 전달되어
+  `.body` **바깥의 형제(sibling) flex 아이템**으로 렌더링된다.
+- 이 워크플로우 섹션은 높이/overflow 제약이 없어 워크플로우가 많을수록 고유 높이가 커지고,
+  `overflow:hidden` 패널 안에서 `flex:1` 인 `.body`를 0에 가깝게 압축한다.
+  결과적으로 워크플로우 목록이 세로 공간을 독점하고 intent 세부 정보가 가려진다.
+- 워크플로우가 1~2개일 때는 재현되지 않고, 여러 개 할당된 intent에서만 발생한다.
+
+## 변경 범위
+
+- `IntentDetailPanel`의 `children`(=`MatchedWorkflowSection`)을 `.panel` 직속 형제가 아니라
+  스크롤되는 `.body` 안 **내부 리소스 섹션 아래**로 이동시킨다.
+- 이로써 워크플로우 목록이 별도 flex 아이템으로 body를 압축하지 않고,
+  intent 세부 정보와 함께 동일한 스크롤 영역에서 표시된다. (이슈의 개선안과 동일)
+
+## 비범위
+
+- `MatchedWorkflowSection` 자체 동작/스타일 변경 없음 (목록 조회·렌더 로직 유지).
+- 백엔드/API 변경 없음.
+- 페이지 라우팅 구조(`IntentDraftReadPage`의 render prop 전달) 변경 없음.
+
+## 기대 동작
+
+1. intent 상세 화면 진입 시 헤더 → 상태/분류 카드 → 내부 리소스 → **연결된 워크플로우** 순서로 표시된다.
+2. 워크플로우가 49개처럼 많아도 내부 리소스 등 intent 세부 정보가 가려지지 않는다.
+3. 워크플로우 목록을 포함한 전체 detail 콘텐츠가 `.body`의 단일 스크롤 영역에서 함께 스크롤된다.
+
+## 검증
+
+- 워크플로우가 여러 개 연결된 intent를 선택해도 내부 리소스 섹션이 화면에 보인다.
+- `IntentDetailPanel` / `IntentDraftReadPage` 단위 테스트(연결된 워크플로우 렌더 위치 포함) 통과.
+- `pnpm test`, lint 통과.

--- a/frontend/src/entities/intent/ui/IntentDetailPanel.test.tsx
+++ b/frontend/src/entities/intent/ui/IntentDetailPanel.test.tsx
@@ -181,6 +181,24 @@ describe("IntentDetailPanel", () => {
     expect(screen.getByText("INTENT_001")).toBeInTheDocument();
   });
 
+  it("children은 스크롤되는 body 안 내부 리소스 섹션 아래에 렌더링된다 (#910)", () => {
+    mockedUseIntentDetail.mockReturnValue(readyDetail(stubDetail));
+    const childrenFn = vi.fn(() => <div data-testid="children">workflows</div>);
+
+    renderPanel({ children: childrenFn });
+
+    const body = screen.getByTestId("intent-detail-body");
+    const child = screen.getByTestId("children");
+    const resourceTitle = screen.getByText("내부 리소스");
+
+    // 워크플로우 등 children은 body 바깥 형제가 아니라 스크롤 영역 안에 있어야 한다.
+    expect(body).toContainElement(child);
+    // 내부 리소스 섹션보다 뒤(아래)에 렌더링되어야 한다.
+    expect(
+      resourceTitle.compareDocumentPosition(child) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
   it("내부 리소스 요약 화면에서 cluster 관련 키워드와 evidence 대표 문장을 표시한다", () => {
     mockedUseIntentDetail.mockReturnValue(
       readyDetail({

--- a/frontend/src/entities/intent/ui/IntentDetailPanel.tsx
+++ b/frontend/src/entities/intent/ui/IntentDetailPanel.tsx
@@ -93,7 +93,7 @@ export function IntentDetailPanel({
     <section className={styles.panel} aria-label="상담 유형 상세">
       <DetailHeader detail={state.data} actions={headerActions?.(state.data)} />
       {afterHeader?.(state.data)}
-      <div className={styles.body}>
+      <div className={styles.body} data-testid="intent-detail-body">
         <div className={styles.grid}>
           <InfoCard
             label="상태"
@@ -116,8 +116,8 @@ export function IntentDetailPanel({
         <section className={styles.resourceSection} aria-labelledby="intent-resource-section-title">
           <IntentResourceSection detail={state.data} />
         </section>
+        {children?.(state.data)}
       </div>
-      {children?.(state.data)}
     </section>
   );
 }


### PR DESCRIPTION
## 배경
Closes #910

intent에 워크플로우가 여러 개(예: 49개) 할당되면 `MatchedWorkflowSection`(연결된 워크플로우 목록)이 화면을 가득 채워, intent의 내부 리소스 등 세부 정보가 화면에서 밀려나 보이지 않는 문제가 있었다.

## 원인
- `IntentDetailPanel`의 루트 `.panel`은 `display:flex; flex-direction:column; overflow:hidden` 인 세로 flex 컨테이너다.
- intent 핵심 정보(상태 카드 + 내부 리소스)는 `flex:1; overflow:auto` 인 `.body` **안에서** 스크롤된다.
- 그런데 `MatchedWorkflowSection`은 `children`으로 전달되어 `.body` **바깥의 형제 flex 아이템**으로 렌더링되었고, 높이 제약이 없어 워크플로우가 많을수록 `flex:1` 인 `.body`를 0에 가깝게 압축했다.
- 워크플로우 1~2개에서는 재현되지 않고 여러 개 할당된 intent에서만 발생했다.

## 변경 내용
- `children`(= 워크플로우 섹션)을 `.panel` 직속 형제가 아니라 스크롤되는 `.body` 안 **내부 리소스 섹션 아래**로 이동 (이슈의 개선안과 동일).
- 워크플로우 목록이 별도 flex 아이템으로 body를 압축하지 않고 detail 콘텐츠와 같은 스크롤 영역에서 함께 표시된다.
- 회귀 방지용 단위 테스트 추가: children이 body 안 + 내부 리소스 섹션 뒤에 렌더되는지 검증.

## 비범위
- `MatchedWorkflowSection` 동작/스타일 변경 없음
- 백엔드/API 변경 없음

## 검증
- `IntentDetailPanel.test.tsx` 19 tests passed (신규 #910 회귀 테스트 포함)
- 변경 파일 eslint 통과

스펙 문서: `.agent/specs/910.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * IntentDetailPanel의 컴포넌트 배치가 개선되었습니다. 이전에는 스크롤 가능한 본문 영역 외부에 배치되던 항목들이 이제 본문 영역 내부의 적절한 위치로 이동하여, 많은 항목이 있을 때도 모든 세부 정보가 올바르게 표시됩니다.

* **Tests**
  * 컴포넌트의 올바른 렌더링 위치와 스크롤 영역 내 정확한 배치를 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->