### PR TITLE
fix(workflow): #911 draft 편집 화면 잘림/저장·취소 버튼 미노출 해결

### DIFF
--- a/.agent/specs/911.md
+++ b/.agent/specs/911.md
@@ -1,0 +1,44 @@
+# #911 워크플로우(draft) 편집 화면 잘림 / 저장·취소 버튼 미노출 수정
+
+## 배경 / 문제
+
+draft 상태 워크플로우의 인라인 편집 화면(`WorkflowDraftReadPage` → `InlineWorkflowEditor` → `WorkflowEditForm`)에서 다음 세 가지 문제가 보고됨(이슈 #911):
+
+1. 상위 항목들로 인해 편집 화면이 잘려서 항목을 제대로 확인할 수 없음 → 스크롤 필요
+2. 저장 버튼이 보이지 않아 수정사항을 저장할 수 없음
+3. 취소 버튼이 보이지 않아 이전 화면으로 돌아갈 수 없음
+
+## 원인 분석
+
+세 증상은 **동일한 단일 원인**이다.
+
+- 편집 폼은 이미 footer에 `취소`/`저장` 버튼을 모두 렌더링하고 있다
+  ([WorkflowEditForm.tsx](../../frontend/src/features/update-workflow/ui/WorkflowEditForm.tsx) `data-testid="workflow-edit-cancel"`, `workflow-edit-save`).
+- 편집기를 감싸는 `.canvasFrame` 컨테이너가
+  [workflow-draft-read-page.module.css](../../frontend/src/pages/domain-pack/ui/workflow-draft-read-page.module.css)
+  에서 `flex: 0 0 min(52vh, 560px)` 고정 높이 + `overflow: hidden` 으로 설정되어 있다.
+- 편집 폼 내용(이름/설명 필드 + 고급 아코디언 + 범례 + `min-height: 360px` 그래프 에디터 + footer)의
+  총 높이가 이 고정 프레임 높이를 초과하면, 초과분인 **footer(저장·취소 버튼)가 `overflow: hidden` 으로 잘려서**
+  화면 밖으로 사라진다. 버튼은 DOM에 존재하지만 보이지 않으므로 "버튼이 없다"고 인지된 것.
+
+즉 화면 잘림 = 저장/취소 버튼 미노출은 같은 클리핑 문제이다.
+
+## 해결 방안
+
+편집 모드일 때 `.canvasFrame` 가 고정 높이로 내용을 자르지 않고 내용 높이에 맞춰 늘어나도록 하고,
+화면이 작을 때는 페이지 레벨 스크롤(`.detailPage { overflow: auto }`)로 footer까지 도달할 수 있게 한다.
+
+- `.canvasFrame[data-editing="true"]` 에 `flex: 0 0 auto` + `height: auto` + 넉넉한 `min-height`(`min(72vh, 680px)`) 적용
+- 비편집(그래프 뷰어) 모드는 기존 고정 높이 캔버스 유지 — 회귀 없음
+- 그래프 에디터는 `editorSlot { min-height: 360px }` 로 충분한 정의된 높이를 유지
+
+## 변경 파일
+
+- `frontend/src/pages/domain-pack/ui/workflow-draft-read-page.module.css`
+  - `.canvasFrame[data-editing="true"]` 규칙에 내용 기반 높이 + min-height 추가
+
+## 검증
+
+- 편집 진입 시 저장/취소 버튼이 항상 화면에 노출되거나, 화면이 작으면 페이지 스크롤로 도달 가능
+- 비편집 그래프 뷰어 레이아웃은 변화 없음
+- `WorkflowDraftReadPage` / `WorkflowEditForm` 테스트 통과

--- a/frontend/src/pages/domain-pack/ui/workflow-draft-read-page.module.css
+++ b/frontend/src/pages/domain-pack/ui/workflow-draft-read-page.module.css
@@ -123,6 +123,14 @@
 .canvasFrame[data-editing="true"] {
   border-color: var(--line);
   background: var(--paper-2);
+  /* In edit mode the form (meta fields + advanced accordion + legend + graph
+     editor + save/cancel footer) is taller than the fixed canvas height. Let
+     the frame grow to fit its content instead of clipping the footer, and rely
+     on the page-level scroll (.detailPage { overflow: auto }) so the
+     저장/취소 buttons are always reachable. */
+  flex: 0 0 auto;
+  height: auto;
+  min-height: min(72vh, 680px);
 }
 
 .centerState {


### PR DESCRIPTION
## 개요
Closes #911

draft 상태 워크플로우 인라인 편집 화면에서 보고된 3가지 문제(편집 화면 잘림, 저장 버튼 미노출, 취소 버튼 미노출)를 해결합니다.

## 원인
세 증상은 **동일한 단일 원인**입니다.

- 편집 폼은 이미 footer에 `취소`/`저장` 버튼을 둘 다 렌더링하고 있음 (`WorkflowEditForm.tsx`)
- 그러나 편집기를 감싸는 `.canvasFrame` 컨테이너가 `flex: 0 0 min(52vh, 560px)` **고정 높이 + `overflow: hidden`** 으로 설정됨
- 편집 폼 내용(이름/설명 필드 + 고급 아코디언 + 범례 + `min-height: 360px` 그래프 에디터 + footer)이 고정 높이를 초과하면, 초과분인 **footer(저장·취소 버튼)가 잘려서** 화면 밖으로 사라짐 → "버튼이 없다 / 화면이 잘린다"로 인지됨

## 변경
- `workflow-draft-read-page.module.css` — `.canvasFrame[data-editing="true"]` 가 편집 모드에서만 내용 높이에 맞춰 늘어나도록 변경 (`flex: 0 0 auto; height: auto; min-height: min(72vh, 680px)`). 작은 화면에서는 페이지 레벨 스크롤(`.detailPage { overflow: auto }`)로 footer까지 도달 가능
- 비편집(그래프 뷰어) 레이아웃은 변경 없음 — 회귀 없음

## 검증
- `WorkflowDraftReadPage` + `WorkflowEditForm` 테스트 36개 전부 통과 (`vp test`)
- 스펙 문서: `.agent/specs/911.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 워크플로우 초안 편집 화면에서 저장·취소 버튼이 잘려 보이는 문제 해결
  * 편집 모드에서 화면 크기에 따라 자동으로 스크롤되도록 개선
  * 편집 폼의 모든 내용이 제대로 노출되도록 레이아웃 조정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->