### PR TITLE
feat(simulation): #882 LLM 구조 패치 검토 UI와 응답 정규화 추가

### DIFF
--- a/.agent/specs/882.md
+++ b/.agent/specs/882.md
@@ -1,0 +1,96 @@
+# Spec — #882 LLM 구조적 Domain Pack 패치 검토 UI
+
+## Goal
+
+LLM이 생성한 `simulation-structural-patch.v1` 구조적 패치를 운영자가 원본 JSON이 아닌 **도메인 용어 diff**로 이해하고 안전하게 승인/반려할 수 있는 검토 표면을 제공한다. 운영자는 (1) 어떤 근거로 제안됐는지, (2) 어떤 Domain Pack 요소가 바뀌는지, (3) before/after 차이, (4) 패치가 검증을 통과했는지, (5) 승인 후 어떤 골든 케이스를 재생해야 하는지를 알 수 있어야 한다. 이 UI는 자기개선 워크플로우 루프의 신뢰 계층이다.
+
+## Scope
+
+- 백엔드(read-side 정규화): 후보 응답에 정규화·검증 데이터를 추가한다. 구조적 패치 적용·생성은 다루지 않는다.
+  - `SimulationImprovementCandidateResponse`에 `patchSchemaVersion`, `patchSummary`, `patchValidationStatus`, `patchValidationErrors`, `operations` 추가.
+  - `SimulationCandidatePatchViewMapper`가 `draftPatchJson`을 파싱·검증해 위 필드를 채운다(list·detail 동일 경로).
+  - `approve` 경로에서 `INVALID` 구조 패치를 schema-integrity 게이트로 거부(stale/forged client 방어). DB target resolution·apply는 하지 않는다.
+- 프론트엔드(검토 UI): 후보 카드에서 구조 패치를 개요·근거·diff·가드레일로 렌더한다.
+  - operation별 before/after diff(MARK_SLOT_REQUIRED, ADD_WORKFLOW_NODE, UPDATE_TRANSITION, UPDATE_POLICY_CONDITION, UPDATE_RESPONSE_COPY + 그 외 op 폴백).
+  - 승인 가드레일: 검증 통과 + 모든 op 대상 확정 + 명시적 "구조 변경 검토 완료" 확인. 무효/모호 패치는 승인 비활성화 + 사유 표시.
+  - raw JSON은 `<details>` 뒤로 보조 표면화. 레거시 설명형 패치는 기존 UI로 계속 가독.
+  - 승인 후 적용된 draft 버전 id 표시 + 골든 케이스 리플레이 다음 액션.
+
+## Non-goals (이슈 명시)
+
+- LLM 패치 생성은 다루지 않는다(#880).
+- 백엔드 구조 패치 적용은 다루지 않는다(#881).
+- 전체 워크플로우 그래프 편집기를 만들지 않는다. 이것은 검토 표면이지 저작 캔버스가 아니다.
+
+## Affected Modules
+
+`backend` / `workflow-runtime` bounded context + `frontend` / simulation feature·workspace page.
+
+검증한 기존 경로:
+- `backend/src/main/java/com/init/workflowruntime/application/dto/SimulationImprovementCandidateResponse.java` — 응답 DTO(확장 대상). 기존엔 `draftPatchJson` 원본만 노출.
+- `backend/src/main/java/com/init/workflowruntime/application/SimulationImprovementCandidateService.java` — create/get/updateStatus/approve/reject/list 응답 빌더. 정적 `from(candidate)` 다중 호출.
+- `backend/src/main/java/com/init/workflowruntime/application/dto/SimulationImprovementCandidatePageResponse.java` — list 응답 매핑.
+- `backend/src/main/java/com/init/workflowruntime/application/StructuralDomainPackPatchParser.java`(#879 `@Component`, 재사용) — JSON → `StructuralDomainPackPatch` VO, 잘못된 스키마에 `InvalidStructuralPatchException`.
+- `backend/src/main/java/com/init/workflowruntime/domain/StructuralPatchOperation.java`(`ElementAttribute`/`WorkflowNode`/`WorkflowTransition`), `StructuralPatchOperationType.java`, `StructuralDomainPackPatch.java`, `StructuralPatchEvidence.java` — 패치 VO(재사용).
+- `frontend/src/features/simulation/api/simulationApi.ts` — `SimulationImprovementCandidate` 타입·후보 API.
+- `frontend/src/pages/workspace/ui/WorkspaceSimulationPage.tsx` — 후보 카드·승인 흐름·골든 케이스 리플레이(`handleReplayGoldenCase`, `candidateApprovalGuide`). 기존 인라인 `CandidatePatchReview`는 레거시 경로로 보존.
+
+## Patch Classification (검증된 근거)
+
+`SimulationCandidatePatchViewMapper.map(draftPatchJson)`는 다음 순서로 `SimulationPatchValidationStatus`를 결정한다:
+
+1. blank / `null` / `{}` / `[]` → `NONE` (정보 없음).
+2. `schemaVersion` 이 정확히 `simulation-candidate-draft-patch.v1` → `LEGACY` (기존 설명형, 프론트가 기존 렌더 경로 사용).
+3. `StructuralDomainPackPatchParser.parse` 성공(`simulation-structural-patch.v1`) → `VALID` (정규화 operations·summary 산출).
+4. 그 외(파싱 오류, 미상/누락 `schemaVersion`, 비-object root) → `INVALID` (오류 메시지 수집).
+
+생성 실패 envelope(`simulation-structural-patch-generation.v1`)는 `INVALID`로 분류되어 승인이 거부된다(의도된 안전 동작).
+
+## Class / Type Design
+
+### 백엔드
+
+- `SimulationPatchValidationStatus`(enum): `VALID`, `INVALID`, `LEGACY`, `NONE`.
+- `NormalizedPatchOperationView`(record, flat): `operationType`, `kind`(ELEMENT/WORKFLOW_NODE/WORKFLOW_TRANSITION), `targetCategory`, `targetCode`, `targetId`, `value`, `nodeId`, `nodeType`, `slotCode`, `prompt`, `from`, `to`, `condition`, `reason`, `targetComplete`. 제안("after") 측만 담는다. `from(StructuralPatchOperation)` 정적 팩토리가 sealed 분기로 매핑하고 `targetComplete`를 op별 식별자 규칙으로 계산한다:
+  - ElementAttribute: `targetCategory != null && (targetCode 비어있지 않음 || targetId != null)`.
+  - WorkflowNode: `(workflowCode 비어있지 않음 || workflowDefinitionId != null) && nodeId 비어있지 않음`.
+  - WorkflowTransition: 위 + `from`·`to` 비어있지 않음.
+- `SimulationCandidatePatchViewMapper`(`@Component`): `StructuralDomainPackPatchParser`·`ObjectMapper` 주입. `PatchView(schemaVersion, summary, validationStatus, errors, operations)` 반환.
+- `SimulationImprovementCandidateResponse.from(candidate, patchView)`로 일원화(무인자 `from` 제거 → 컴파일 강제). list/detail 모두 mapper 경유.
+
+### 프론트엔드
+
+- `structuralPatchReview.ts`(순수 로직): `buildStructuralPatchReview`(VALID→structural, LEGACY→legacy, INVALID→invalid, NONE→missing), `buildOperationDiff`(op별 before/after 디스크립터), `operationTypeLabel`(도메인 용어), `isWorkflowStructureOperation`, `evaluateApprovalGuardrail`(가드레일 + 비활성 사유).
+- `StructuralPatchReviewPanel.tsx`(컴포넌트, export `StructuralPatchReview`): Candidate Overview·Evidence Panel·Structural Diff Panel·Approval Guardrails·raw JSON details·승인 후 리플레이 CTA. 워크플로우 구조 op 포함 시 "워크플로우 구조 변경" 뱃지. 승인 전 미적용 문구로 "이미 적용됨" 오인 방지.
+- `WorkspaceSimulationPage.tsx`: `patchValidationStatus`로 라우팅 — VALID/INVALID는 새 패널, NONE/LEGACY는 기존 `CandidatePatchReview`. 승인 버튼 disabled는 structural의 경우 `evaluateApprovalGuardrail`로 결정. 승인 후 `appliedDomainPackVersionId` 표시 + 기존 리플레이 흐름 재사용(null이면 "적용 버전 응답 대기"로 구분).
+
+## Guardrail Requirements (이슈 매핑)
+
+| 요구사항 | 구현 위치 |
+|---|---|
+| 패치가 파싱되어야 함 | 백엔드 mapper `patchValidationStatus` |
+| 백엔드 검증 통과 | 백엔드 mapper(파싱·스키마) + approve INVALID 거부 |
+| 대상 확정 | op별 `targetComplete`(백엔드 계산) → 프론트 가드레일 |
+| 명시적 구조 변경 확인 | 프론트 체크박스 → `evaluateApprovalGuardrail` |
+| 무효/모호 패치 승인 차단 | 프론트 disabled + 사유, 백엔드 approve 방어 |
+| 레거시 가독 유지 | NONE/LEGACY 라우팅으로 기존 UI 보존 |
+
+## Tests
+
+- 백엔드 `SimulationCandidatePatchViewMapperTest`(단위): NONE/LEGACY/VALID/INVALID 분류; op별 정규화·`targetComplete`(5개 명명 op); parser 거부 케이스. 비고: parser가 식별자 누락 op를 모두 거부하므로 VALID 패치 op는 항상 `targetComplete=true` — `false` 차단은 프론트 로직 단위에서 검증.
+- 백엔드 `SimulationImprovementCandidateServiceTest`(보강): list·detail 정규화 회귀; approve가 INVALID 거부·VALID/LEGACY/NONE 정상 승인.
+- 프론트 `structuralPatchReview.test.ts`(단위): 분기·op별 diff·가드레일(targetComplete=false 차단 포함).
+- 프론트 `WorkspaceSimulationPage.structural.test.tsx`(통합): structural 카드 요약·뱃지·diff; 워크플로우 구조 뱃지; 확인 전후 승인 disabled/enabled; INVALID 오류·차단; 승인 후 적용 버전·리플레이 CTA; 레거시 가독.
+- 기존 시뮬레이션 페이지 테스트는 그대로 통과한다.
+
+## Acceptance Criteria
+
+- 후보 리스트/카드가 구조 패치 요약과 검증 상태를 렌더한다.
+- 구조 operation이 읽기 쉬운 before/after diff로 표시된다(명명 op 5종 + 폴백).
+- 무효이거나 대상이 모호한 패치는 승인이 비활성화되고 검증 오류가 표시된다.
+- 구조 변경 승인은 명시적 확인을 요구한다.
+- 레거시 설명형 패치는 계속 읽을 수 있다.
+- 그래프 op가 있을 때 "워크플로우 구조 변경"으로 표기하고 승인 전 적용을 암시하지 않으며, generated/review/approved/applied 상태를 구분한다.
+- 승인 후 적용된 draft 버전 id와 골든 케이스 리플레이 다음 액션을 보여준다.
+- 백엔드 응답이 정규화 필드(`patchSchemaVersion`/`patchSummary`/`patchValidationStatus`/`patchValidationErrors`/`operations`)를 노출한다.
+- 단위 테스트가 operation 렌더링과 승인 가드레일(프론트), mapper 정규화와 approve INVALID 거부(백엔드)를 덮고 기존 테스트가 통과한다.

--- a/backend/src/main/java/com/init/workflowruntime/application/SimulationCandidatePatchViewMapper.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/SimulationCandidatePatchViewMapper.java
@@ -1,0 +1,118 @@
+package com.init.workflowruntime.application;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.workflowruntime.application.dto.NormalizedPatchOperationView;
+import com.init.workflowruntime.domain.InvalidStructuralPatchException;
+import com.init.workflowruntime.domain.SimulationPatchValidationStatus;
+import com.init.workflowruntime.domain.StructuralDomainPackPatch;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+/**
+ * 후보 draft patch JSON을 read-side에서 정규화·검증해 리뷰 화면용 {@link PatchView}로 변환한다. 어떤 DB 접근도 하지 않으며 구조 패치를
+ * 적용하지도 않는다. 분류는 NONE → LEGACY → VALID → INVALID 순서로 fail-closed 한다.
+ */
+@Component
+public class SimulationCandidatePatchViewMapper {
+
+  private static final String LEGACY_SCHEMA_VERSION = "simulation-candidate-draft-patch.v1";
+
+  private final StructuralDomainPackPatchParser parser;
+  private final ObjectMapper objectMapper;
+
+  public SimulationCandidatePatchViewMapper(
+      StructuralDomainPackPatchParser parser, ObjectMapper objectMapper) {
+    this.parser = parser;
+    this.objectMapper = objectMapper;
+  }
+
+  /** 정규화 결과. operations는 VALID일 때만 채워지며, INVALID일 때 errors에 사유가 담긴다. */
+  public record PatchView(
+      String schemaVersion,
+      String summary,
+      SimulationPatchValidationStatus validationStatus,
+      List<String> errors,
+      List<NormalizedPatchOperationView> operations) {
+
+    public PatchView {
+      errors = errors == null ? List.of() : List.copyOf(errors);
+      operations = operations == null ? List.of() : List.copyOf(operations);
+    }
+  }
+
+  public PatchView map(String draftPatchJson) {
+    if (isEmptyPatch(draftPatchJson)) {
+      return none();
+    }
+
+    JsonNode root;
+    try {
+      root = objectMapper.readTree(draftPatchJson);
+    } catch (JsonProcessingException e) {
+      return invalid(e.getOriginalMessage());
+    }
+    if (root == null || !root.isObject()) {
+      return invalid("patch 문서는 JSON object여야 합니다.");
+    }
+
+    if (LEGACY_SCHEMA_VERSION.equals(readText(root, "schemaVersion"))) {
+      return legacy(readText(root, "summary"));
+    }
+
+    try {
+      StructuralDomainPackPatch patch = parser.parse(draftPatchJson);
+      return valid(patch);
+    } catch (InvalidStructuralPatchException e) {
+      return invalid(e.getMessage());
+    }
+  }
+
+  private boolean isEmptyPatch(String draftPatchJson) {
+    if (draftPatchJson == null || draftPatchJson.isBlank()) {
+      return true;
+    }
+    String trimmed = draftPatchJson.trim();
+    return "{}".equals(trimmed) || "[]".equals(trimmed) || "null".equals(trimmed);
+  }
+
+  private PatchView none() {
+    return new PatchView(null, null, SimulationPatchValidationStatus.NONE, List.of(), List.of());
+  }
+
+  private PatchView legacy(String summary) {
+    return new PatchView(
+        LEGACY_SCHEMA_VERSION,
+        summary,
+        SimulationPatchValidationStatus.LEGACY,
+        List.of(),
+        List.of());
+  }
+
+  private PatchView valid(StructuralDomainPackPatch patch) {
+    List<NormalizedPatchOperationView> operations =
+        patch.operations().stream().map(NormalizedPatchOperationView::from).toList();
+    return new PatchView(
+        patch.schemaVersion(),
+        patch.summary(),
+        SimulationPatchValidationStatus.VALID,
+        List.of(),
+        operations);
+  }
+
+  private PatchView invalid(String message) {
+    String error = message == null || message.isBlank() ? "구조 패치를 파싱할 수 없습니다." : message;
+    return new PatchView(
+        null, null, SimulationPatchValidationStatus.INVALID, List.of(error), List.of());
+  }
+
+  private String readText(JsonNode node, String field) {
+    JsonNode value = node.get(field);
+    if (value == null || value.isNull() || !value.isTextual()) {
+      return null;
+    }
+    String text = value.asText();
+    return text.isBlank() ? null : text.strip();
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/application/SimulationImprovementCandidateService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/SimulationImprovementCandidateService.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.init.review.domain.model.ReviewTask;
 import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.NotFoundException;
+import com.init.workflowruntime.application.SimulationCandidatePatchViewMapper.PatchView;
 import com.init.workflowruntime.application.command.ApproveSimulationImprovementCandidateCommand;
 import com.init.workflowruntime.application.command.CreateSimulationImprovementCandidateCommand;
 import com.init.workflowruntime.application.command.RejectSimulationImprovementCandidateCommand;
@@ -16,6 +17,7 @@ import com.init.workflowruntime.domain.ChatSession;
 import com.init.workflowruntime.domain.ChatSessionRepository;
 import com.init.workflowruntime.domain.DomainPage;
 import com.init.workflowruntime.domain.DomainPageRequest;
+import com.init.workflowruntime.domain.InvalidStructuralPatchException;
 import com.init.workflowruntime.domain.SimulationFeedback;
 import com.init.workflowruntime.domain.SimulationFeedbackRepository;
 import com.init.workflowruntime.domain.SimulationFeedbackStatus;
@@ -26,6 +28,7 @@ import com.init.workflowruntime.domain.SimulationImprovementCandidateRepository;
 import com.init.workflowruntime.domain.SimulationImprovementCandidateStatus;
 import com.init.workflowruntime.domain.SimulationImprovementCandidateTargetType;
 import com.init.workflowruntime.domain.SimulationImprovementCandidateType;
+import com.init.workflowruntime.domain.SimulationPatchValidationStatus;
 import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
 import com.init.workspace.domain.repository.WorkspaceMemberRepository;
 import java.util.Locale;
@@ -49,6 +52,7 @@ public class SimulationImprovementCandidateService {
   private final SimulationImprovementCandidateReviewTaskService reviewTaskService;
   private final SimulationImprovementCandidateDecisionService decisionService;
   private final SimulationStructuralPatchGenerationService structuralPatchGenerationService;
+  private final SimulationCandidatePatchViewMapper patchViewMapper;
   private final ObjectMapper objectMapper;
   private final boolean structuralPatchEnabled;
 
@@ -60,6 +64,7 @@ public class SimulationImprovementCandidateService {
       SimulationImprovementCandidateReviewTaskService reviewTaskService,
       SimulationImprovementCandidateDecisionService decisionService,
       SimulationStructuralPatchGenerationService structuralPatchGenerationService,
+      SimulationCandidatePatchViewMapper patchViewMapper,
       ObjectMapper objectMapper,
       @Value("${app.simulation.structural-patch.enabled:false}") boolean structuralPatchEnabled) {
     this.feedbackRepository = feedbackRepository;
@@ -69,6 +74,7 @@ public class SimulationImprovementCandidateService {
     this.reviewTaskService = reviewTaskService;
     this.decisionService = decisionService;
     this.structuralPatchGenerationService = structuralPatchGenerationService;
+    this.patchViewMapper = patchViewMapper;
     this.objectMapper = objectMapper;
     this.structuralPatchEnabled = structuralPatchEnabled;
   }
@@ -82,7 +88,7 @@ public class SimulationImprovementCandidateService {
 
     return candidateRepository
         .findByFeedbackId(feedback.getId())
-        .map(SimulationImprovementCandidateResponse::from)
+        .map(this::toResponse)
         .orElseGet(() -> createNewCandidate(command, feedback));
   }
 
@@ -96,7 +102,7 @@ public class SimulationImprovementCandidateService {
             ? candidateRepository.findByWorkspaceId(workspaceId, pageRequest)
             : candidateRepository.findByWorkspaceIdAndStatus(
                 workspaceId, parsedStatus, pageRequest);
-    return SimulationImprovementCandidatePageResponse.from(candidatePage);
+    return SimulationImprovementCandidatePageResponse.from(candidatePage, this::toResponse);
   }
 
   public SimulationImprovementCandidateResponse getCandidate(
@@ -104,7 +110,7 @@ public class SimulationImprovementCandidateService {
     validateWorkspaceMembership(workspaceId, userId);
     SimulationImprovementCandidate candidate = findCandidate(candidateId);
     validateCandidateWorkspace(workspaceId, candidate);
-    return SimulationImprovementCandidateResponse.from(candidate);
+    return toResponse(candidate);
   }
 
   @Transactional
@@ -122,7 +128,7 @@ public class SimulationImprovementCandidateService {
     }
     ReviewTask task = reviewTaskService.ensureReviewTask(candidate, command.userId());
     candidate.submitForReview(task.getReviewSessionId(), task.getId());
-    return SimulationImprovementCandidateResponse.from(candidateRepository.save(candidate));
+    return toResponse(candidateRepository.save(candidate));
   }
 
   @Transactional
@@ -131,11 +137,17 @@ public class SimulationImprovementCandidateService {
     validateWorkspaceMembership(command.workspaceId(), command.userId());
     SimulationImprovementCandidate candidate = findCandidate(command.candidateId());
     validateCandidateWorkspace(command.workspaceId(), candidate);
+    PatchView patchView = patchViewMapper.map(candidate.getDraftPatchJson());
+    if (patchView.validationStatus() == SimulationPatchValidationStatus.INVALID) {
+      throw new InvalidStructuralPatchException("승인할 수 없는 INVALID 구조 패치입니다.");
+    }
     SimulationFeedback feedback = findFeedbackForUpdate(candidate.getFeedbackId());
     validateFeedbackWorkspace(command.workspaceId(), feedback);
-    return SimulationImprovementCandidateResponse.from(
+    SimulationImprovementCandidate approved =
         decisionService.approve(
-            command.workspaceId(), command.userId(), command.reason(), candidate, feedback));
+            command.workspaceId(), command.userId(), command.reason(), candidate, feedback);
+    return SimulationImprovementCandidateResponse.from(
+        approved, patchViewMapper.map(approved.getDraftPatchJson()));
   }
 
   @Transactional
@@ -146,7 +158,7 @@ public class SimulationImprovementCandidateService {
     validateCandidateWorkspace(command.workspaceId(), candidate);
     SimulationFeedback feedback = findFeedbackForUpdate(candidate.getFeedbackId());
     validateFeedbackWorkspace(command.workspaceId(), feedback);
-    return SimulationImprovementCandidateResponse.from(
+    return toResponse(
         decisionService.reject(command.userId(), command.reason(), candidate, feedback));
   }
 
@@ -170,7 +182,13 @@ public class SimulationImprovementCandidateService {
     SimulationImprovementCandidate saved = candidateRepository.save(candidate);
     feedback.markCandidateCreated();
     feedbackRepository.save(feedback);
-    return SimulationImprovementCandidateResponse.from(saved);
+    return toResponse(saved);
+  }
+
+  private SimulationImprovementCandidateResponse toResponse(
+      SimulationImprovementCandidate candidate) {
+    PatchView patchView = patchViewMapper.map(candidate.getDraftPatchJson());
+    return SimulationImprovementCandidateResponse.from(candidate, patchView);
   }
 
   private String buildDraftPatch(

--- a/backend/src/main/java/com/init/workflowruntime/application/dto/NormalizedPatchOperationView.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/dto/NormalizedPatchOperationView.java
@@ -1,0 +1,107 @@
+package com.init.workflowruntime.application.dto;
+
+import com.init.workflowruntime.domain.StructuralPatchOperation;
+
+/**
+ * 단일 구조 패치 operation을 프론트 리뷰 화면이 바로 렌더할 수 있도록 평탄화(flat)한 read-side view. 제안된("after") 값만 노출하며, 해당
+ * operation 종류에 무관한 필드는 null이다. {@code targetComplete}는 target 식별 정보가 충분한지를 백엔드에서 계산한 결과다.
+ */
+public record NormalizedPatchOperationView(
+    String operationType,
+    String kind,
+    String targetCategory,
+    String targetCode,
+    Long targetId,
+    String value,
+    String nodeId,
+    String nodeType,
+    String slotCode,
+    String prompt,
+    String from,
+    String to,
+    String condition,
+    String reason,
+    boolean targetComplete) {
+
+  public static NormalizedPatchOperationView from(StructuralPatchOperation op) {
+    return switch (op) {
+      case StructuralPatchOperation.ElementAttribute element -> fromElement(element);
+      case StructuralPatchOperation.WorkflowNode node -> fromWorkflowNode(node);
+      case StructuralPatchOperation.WorkflowTransition transition -> fromTransition(transition);
+    };
+  }
+
+  private static NormalizedPatchOperationView fromElement(
+      StructuralPatchOperation.ElementAttribute element) {
+    boolean targetComplete =
+        element.category() != null
+            && (!isBlank(element.targetCode()) || element.targetId() != null);
+    return new NormalizedPatchOperationView(
+        element.type().name(),
+        "ELEMENT",
+        element.category().name(),
+        element.targetCode(),
+        element.targetId(),
+        element.value(),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        element.reason(),
+        targetComplete);
+  }
+
+  private static NormalizedPatchOperationView fromWorkflowNode(
+      StructuralPatchOperation.WorkflowNode node) {
+    boolean targetComplete =
+        (!isBlank(node.workflowCode()) || node.workflowDefinitionId() != null)
+            && !isBlank(node.nodeId());
+    return new NormalizedPatchOperationView(
+        node.type().name(),
+        "WORKFLOW_NODE",
+        "WORKFLOW",
+        node.workflowCode(),
+        null,
+        null,
+        node.nodeId(),
+        node.nodeType(),
+        node.slotCode(),
+        node.prompt(),
+        null,
+        null,
+        null,
+        node.reason(),
+        targetComplete);
+  }
+
+  private static NormalizedPatchOperationView fromTransition(
+      StructuralPatchOperation.WorkflowTransition transition) {
+    boolean targetComplete =
+        (!isBlank(transition.workflowCode()) || transition.workflowDefinitionId() != null)
+            && !isBlank(transition.from())
+            && !isBlank(transition.to());
+    return new NormalizedPatchOperationView(
+        transition.type().name(),
+        "WORKFLOW_TRANSITION",
+        "WORKFLOW",
+        transition.workflowCode(),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        transition.from(),
+        transition.to(),
+        transition.condition(),
+        transition.reason(),
+        targetComplete);
+  }
+
+  private static boolean isBlank(String value) {
+    return value == null || value.isBlank();
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/application/dto/SimulationImprovementCandidatePageResponse.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/dto/SimulationImprovementCandidatePageResponse.java
@@ -3,6 +3,7 @@ package com.init.workflowruntime.application.dto;
 import com.init.workflowruntime.domain.DomainPage;
 import com.init.workflowruntime.domain.SimulationImprovementCandidate;
 import java.util.List;
+import java.util.function.Function;
 
 public record SimulationImprovementCandidatePageResponse(
     List<SimulationImprovementCandidateResponse> content,
@@ -12,9 +13,10 @@ public record SimulationImprovementCandidatePageResponse(
     int totalPages) {
 
   public static SimulationImprovementCandidatePageResponse from(
-      DomainPage<SimulationImprovementCandidate> page) {
+      DomainPage<SimulationImprovementCandidate> page,
+      Function<SimulationImprovementCandidate, SimulationImprovementCandidateResponse> mapper) {
     return new SimulationImprovementCandidatePageResponse(
-        page.content().stream().map(SimulationImprovementCandidateResponse::from).toList(),
+        page.content().stream().map(mapper).toList(),
         page.page(),
         page.size(),
         page.totalElements(),

--- a/backend/src/main/java/com/init/workflowruntime/application/dto/SimulationImprovementCandidateResponse.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/dto/SimulationImprovementCandidateResponse.java
@@ -1,10 +1,13 @@
 package com.init.workflowruntime.application.dto;
 
+import com.init.workflowruntime.application.SimulationCandidatePatchViewMapper.PatchView;
 import com.init.workflowruntime.domain.SimulationImprovementCandidate;
 import com.init.workflowruntime.domain.SimulationImprovementCandidateStatus;
 import com.init.workflowruntime.domain.SimulationImprovementCandidateTargetType;
 import com.init.workflowruntime.domain.SimulationImprovementCandidateType;
+import com.init.workflowruntime.domain.SimulationPatchValidationStatus;
 import java.time.OffsetDateTime;
+import java.util.List;
 
 public record SimulationImprovementCandidateResponse(
     Long id,
@@ -30,10 +33,15 @@ public record SimulationImprovementCandidateResponse(
     SimulationImprovementCandidateStatus status,
     Long createdBy,
     OffsetDateTime createdAt,
-    OffsetDateTime updatedAt) {
+    OffsetDateTime updatedAt,
+    String patchSchemaVersion,
+    String patchSummary,
+    SimulationPatchValidationStatus patchValidationStatus,
+    List<String> patchValidationErrors,
+    List<NormalizedPatchOperationView> operations) {
 
   public static SimulationImprovementCandidateResponse from(
-      SimulationImprovementCandidate candidate) {
+      SimulationImprovementCandidate candidate, PatchView patchView) {
     return new SimulationImprovementCandidateResponse(
         candidate.getId(),
         candidate.getWorkspaceId(),
@@ -58,6 +66,11 @@ public record SimulationImprovementCandidateResponse(
         candidate.getStatus(),
         candidate.getCreatedBy(),
         candidate.getCreatedAt(),
-        candidate.getUpdatedAt());
+        candidate.getUpdatedAt(),
+        patchView.schemaVersion(),
+        patchView.summary(),
+        patchView.validationStatus(),
+        patchView.errors(),
+        patchView.operations());
   }
 }

--- a/backend/src/main/java/com/init/workflowruntime/domain/SimulationPatchValidationStatus.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/SimulationPatchValidationStatus.java
@@ -1,0 +1,13 @@
+package com.init.workflowruntime.domain;
+
+/** 후보 draft patch JSON을 read-side에서 정규화·검증한 결과 상태. */
+public enum SimulationPatchValidationStatus {
+  /** {@code simulation-structural-patch.v1} 스키마로 파싱·검증을 통과한 구조 패치. */
+  VALID,
+  /** 구조 패치 스키마이지만 파싱/검증에 실패한 패치(프론트는 오류만 노출). */
+  INVALID,
+  /** 구버전 {@code simulation-candidate-draft-patch.v1} 패치(프론트가 기존 방식으로 렌더). */
+  LEGACY,
+  /** 정규화할 구조 패치가 없는 상태(빈 object/배열/null). */
+  NONE
+}

--- a/backend/src/test/java/com/init/workflowruntime/application/SimulationCandidatePatchViewMapperTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/SimulationCandidatePatchViewMapperTest.java
@@ -1,0 +1,425 @@
+package com.init.workflowruntime.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.workflowruntime.application.dto.NormalizedPatchOperationView;
+import com.init.workflowruntime.domain.SimulationPatchValidationStatus;
+import com.init.workflowruntime.domain.StructuralDomainPackPatch;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayName("SimulationCandidatePatchViewMapper")
+class SimulationCandidatePatchViewMapperTest {
+
+  private static final String SCHEMA_V1 = StructuralDomainPackPatch.SCHEMA_VERSION;
+  private static final String FAILURE_SUMMARY = "expected ASK_SLOT but got NEED_INTENT";
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final SimulationCandidatePatchViewMapper mapper =
+      new SimulationCandidatePatchViewMapper(
+          new StructuralDomainPackPatchParser(objectMapper), objectMapper);
+
+  // ---- NONE: 빈 패치 ----
+
+  @ParameterizedTest(name = "[{index}] ''{0}'' → NONE")
+  @NullAndEmptySource
+  @ValueSource(strings = {"{}", "[]", "null", "   "})
+  @DisplayName("map: 빈/blank/null/빈 object/배열 → NONE 반환, operations 비어있음")
+  void returnsNoneForEmptyPatches(String input) {
+    var view = mapper.map(input);
+
+    assertThat(view.validationStatus()).isEqualTo(SimulationPatchValidationStatus.NONE);
+    assertThat(view.operations()).isEmpty();
+    assertThat(view.errors()).isEmpty();
+    assertThat(view.schemaVersion()).isNull();
+    assertThat(view.summary()).isNull();
+  }
+
+  // ---- LEGACY: 구버전 schemaVersion ----
+
+  @Test
+  @DisplayName("map: schemaVersion=simulation-candidate-draft-patch.v1 → LEGACY 반환, operations 비어있음")
+  void returnsLegacyForLegacySchemaVersion() {
+    String json =
+        """
+        {
+          "schemaVersion": "simulation-candidate-draft-patch.v1",
+          "operation": "UPDATE_DESCRIPTION",
+          "summary": "슬롯 설명 보강"
+        }
+        """;
+
+    var view = mapper.map(json);
+
+    assertThat(view.validationStatus()).isEqualTo(SimulationPatchValidationStatus.LEGACY);
+    assertThat(view.schemaVersion()).isEqualTo("simulation-candidate-draft-patch.v1");
+    assertThat(view.operations()).isEmpty();
+    assertThat(view.errors()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("map: LEGACY 패치에 summary 필드가 있으면 summary를 추출한다")
+  void extractsSummaryFromLegacyPatch() {
+    String json =
+        """
+        {
+          "schemaVersion": "simulation-candidate-draft-patch.v1",
+          "summary": "레거시 패치 요약"
+        }
+        """;
+
+    var view = mapper.map(json);
+
+    assertThat(view.validationStatus()).isEqualTo(SimulationPatchValidationStatus.LEGACY);
+    assertThat(view.summary()).isEqualTo("레거시 패치 요약");
+  }
+
+  @Test
+  @DisplayName("map: LEGACY 패치에 summary 필드가 없으면 summary는 null이다")
+  void returnsNullSummaryWhenLegacyPatchHasNoSummary() {
+    String json =
+        """
+        {
+          "schemaVersion": "simulation-candidate-draft-patch.v1"
+        }
+        """;
+
+    var view = mapper.map(json);
+
+    assertThat(view.validationStatus()).isEqualTo(SimulationPatchValidationStatus.LEGACY);
+    assertThat(view.summary()).isNull();
+  }
+
+  // ---- VALID: 구조적 패치 v1 ----
+
+  @Test
+  @DisplayName("map: 유효한 simulation-structural-patch.v1 → VALID, schemaVersion·summary·operations 채워짐")
+  void returnsValidForWellFormedStructuralPatch() {
+    String json = structuralPatch(slotRequiredOp("order_number"));
+
+    var view = mapper.map(json);
+
+    assertThat(view.validationStatus()).isEqualTo(SimulationPatchValidationStatus.VALID);
+    assertThat(view.schemaVersion()).isEqualTo(SCHEMA_V1);
+    assertThat(view.summary()).isEqualTo("workflow 보강");
+    assertThat(view.errors()).isEmpty();
+    assertThat(view.operations()).hasSize(1);
+  }
+
+  @Test
+  @DisplayName("map: VALID 패치에 여러 operations가 있으면 모두 정규화된다")
+  void normalizesMultipleOperations() {
+    String json =
+        structuralPatchWithOps(
+            slotRequiredOp("order_number"),
+            """
+            {"op":"UPDATE_POLICY_CONDITION","policyCode":"refund_window",
+             "condition":"days <= 7","reason":"환불 기한 명시"}
+            """);
+
+    var view = mapper.map(json);
+
+    assertThat(view.validationStatus()).isEqualTo(SimulationPatchValidationStatus.VALID);
+    assertThat(view.operations()).hasSize(2);
+  }
+
+  // ---- INVALID: 파싱 불가 또는 스키마 오류 ----
+
+  @Test
+  @DisplayName("map: 깨진 JSON → INVALID, errors에 사유 포함")
+  void returnsInvalidForMalformedJson() {
+    var view = mapper.map("{not valid json");
+
+    assertThat(view.validationStatus()).isEqualTo(SimulationPatchValidationStatus.INVALID);
+    assertThat(view.errors()).isNotEmpty();
+    assertThat(view.operations()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("map: schemaVersion 누락된 비-빈 object → INVALID (parser가 schemaVersion 불일치로 거부)")
+  void returnsInvalidWhenSchemaVersionMissing() {
+    String json =
+        """
+        {
+          "evidence": {"failureSummary": "missing slot"},
+          "operations": [{"op": "MARK_SLOT_REQUIRED", "slotCode": "a", "reason": "r"}]
+        }
+        """;
+
+    var view = mapper.map(json);
+
+    assertThat(view.validationStatus()).isEqualTo(SimulationPatchValidationStatus.INVALID);
+    assertThat(view.errors()).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("map: 미상 schemaVersion(simulation-structural-patch-generation.v1) → INVALID")
+  void returnsInvalidForUnknownSchemaVersion() {
+    String json =
+        """
+        {
+          "schemaVersion": "simulation-structural-patch-generation.v1",
+          "status": "INVALID_OUTPUT",
+          "summary": "생성 실패"
+        }
+        """;
+
+    var view = mapper.map(json);
+
+    assertThat(view.validationStatus()).isEqualTo(SimulationPatchValidationStatus.INVALID);
+    assertThat(view.errors()).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("map: JSON object이지만 배열 최상위 → INVALID")
+  void returnsInvalidForNonObjectRoot() {
+    // "[]"는 NONE이 아닌 INVALID를 반환한다 — 단, isEmptyPatch가 먼저 처리하므로
+    // object가 아닌 다른 구조(숫자 배열)로 검증
+    String json = "[1, 2, 3]";
+
+    var view = mapper.map(json);
+
+    // "[]"는 NONE이지만, 비어있지 않은 배열은 isEmptyPatch를 통과 후 object 검증에서 INVALID
+    assertThat(view.validationStatus()).isEqualTo(SimulationPatchValidationStatus.INVALID);
+    assertThat(view.errors()).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("map: evidence.failureSummary 누락 → INVALID")
+  void returnsInvalidWhenFailureSummaryMissing() {
+    String json =
+        """
+        {
+          "schemaVersion": "%s",
+          "evidence": {"feedbackId": 1},
+          "operations": [{"op": "MARK_SLOT_REQUIRED", "slotCode": "a", "reason": "r"}]
+        }
+        """.formatted(SCHEMA_V1);
+
+    var view = mapper.map(json);
+
+    assertThat(view.validationStatus()).isEqualTo(SimulationPatchValidationStatus.INVALID);
+    assertThat(view.errors()).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("map: 지원하지 않는 operation → INVALID")
+  void returnsInvalidForUnsupportedOperation() {
+    String json = structuralPatch("{\"op\":\"DELETE_EVERYTHING\",\"reason\":\"r\"}");
+
+    var view = mapper.map(json);
+
+    assertThat(view.validationStatus()).isEqualTo(SimulationPatchValidationStatus.INVALID);
+    assertThat(view.errors()).isNotEmpty();
+  }
+
+  // ---- op별 정규화 결과: targetComplete 및 필드 매핑 ----
+
+  @Test
+  @DisplayName("MARK_SLOT_REQUIRED(ElementAttribute, slotCode 있음) → targetComplete=true, SLOT category")
+  void normalizesMarkSlotRequiredWithTargetComplete() {
+    String json = structuralPatch(slotRequiredOp("order_number"));
+
+    NormalizedPatchOperationView op = firstOp(mapper.map(json));
+
+    assertThat(op.operationType()).isEqualTo("MARK_SLOT_REQUIRED");
+    assertThat(op.kind()).isEqualTo("ELEMENT");
+    assertThat(op.targetCategory()).isEqualTo("SLOT");
+    assertThat(op.targetCode()).isEqualTo("order_number");
+    assertThat(op.targetComplete()).isTrue();
+    // 값이 필요 없는 op → value null
+    assertThat(op.value()).isNull();
+  }
+
+  @Test
+  @DisplayName("UPDATE_POLICY_CONDITION(ElementAttribute, policyCode+condition) → targetComplete=true")
+  void normalizesPolicyConditionWithTargetComplete() {
+    String json =
+        structuralPatch(
+            """
+            {"op":"UPDATE_POLICY_CONDITION","policyCode":"refund_window",
+             "condition":"days <= 7","reason":"환불 기한 명시"}
+            """);
+
+    NormalizedPatchOperationView op = firstOp(mapper.map(json));
+
+    assertThat(op.operationType()).isEqualTo("UPDATE_POLICY_CONDITION");
+    assertThat(op.targetCategory()).isEqualTo("POLICY");
+    assertThat(op.targetCode()).isEqualTo("refund_window");
+    assertThat(op.value()).isEqualTo("days <= 7");
+    assertThat(op.targetComplete()).isTrue();
+  }
+
+  @Test
+  @DisplayName("UPDATE_RESPONSE_COPY(ElementAttribute, responseCode) → targetComplete=true, RESPONSE category")
+  void normalizesResponseCopyWithTargetComplete() {
+    String json =
+        structuralPatch(
+            """
+            {"op":"UPDATE_RESPONSE_COPY","responseCode":"greeting",
+             "copy":"안녕하세요, 무엇을 도와드릴까요?","reason":"문구 개선"}
+            """);
+
+    NormalizedPatchOperationView op = firstOp(mapper.map(json));
+
+    assertThat(op.operationType()).isEqualTo("UPDATE_RESPONSE_COPY");
+    assertThat(op.targetCategory()).isEqualTo("RESPONSE");
+    assertThat(op.targetCode()).isEqualTo("greeting");
+    assertThat(op.value()).isEqualTo("안녕하세요, 무엇을 도와드릴까요?");
+    assertThat(op.targetComplete()).isTrue();
+  }
+
+  @Test
+  @DisplayName("ADD_WORKFLOW_NODE(WorkflowNode, nodeId 있음) → targetComplete=true, nodeId/nodeType/prompt 매핑")
+  void normalizesAddWorkflowNodeWithTargetComplete() {
+    String json =
+        structuralPatch(
+            """
+            {"op":"ADD_WORKFLOW_NODE","workflowCode":"airport_pickup_flow",
+             "nodeId":"ask_pickup_date","nodeType":"ASK_SLOT",
+             "slotCode":"pickupDate","prompt":"픽업 날짜를 알려주세요","reason":"날짜 수집"}
+            """);
+
+    NormalizedPatchOperationView op = firstOp(mapper.map(json));
+
+    assertThat(op.operationType()).isEqualTo("ADD_WORKFLOW_NODE");
+    assertThat(op.kind()).isEqualTo("WORKFLOW_NODE");
+    assertThat(op.targetCategory()).isEqualTo("WORKFLOW");
+    assertThat(op.targetCode()).isEqualTo("airport_pickup_flow");
+    assertThat(op.nodeId()).isEqualTo("ask_pickup_date");
+    assertThat(op.nodeType()).isEqualTo("ASK_SLOT");
+    assertThat(op.slotCode()).isEqualTo("pickupDate");
+    assertThat(op.prompt()).isEqualTo("픽업 날짜를 알려주세요");
+    assertThat(op.targetComplete()).isTrue();
+  }
+
+  @Test
+  @DisplayName("UPDATE_TRANSITION(WorkflowTransition, from/to 있음) → targetComplete=true, from/to/condition 매핑")
+  void normalizesUpdateTransitionWithTargetComplete() {
+    String json =
+        structuralPatch(
+            """
+            {"op":"UPDATE_TRANSITION","workflowCode":"airport_pickup_flow",
+             "from":"start","to":"ask_pickup_date",
+             "condition":"missing(pickupDate)","reason":"조건 변경"}
+            """);
+
+    NormalizedPatchOperationView op = firstOp(mapper.map(json));
+
+    assertThat(op.operationType()).isEqualTo("UPDATE_TRANSITION");
+    assertThat(op.kind()).isEqualTo("WORKFLOW_TRANSITION");
+    assertThat(op.targetCategory()).isEqualTo("WORKFLOW");
+    assertThat(op.from()).isEqualTo("start");
+    assertThat(op.to()).isEqualTo("ask_pickup_date");
+    assertThat(op.condition()).isEqualTo("missing(pickupDate)");
+    assertThat(op.targetComplete()).isTrue();
+  }
+
+  @Test
+  @DisplayName("WorkflowNode: workflowDefinitionId만으로 식별 시 targetComplete=true")
+  void normalizesWorkflowNodeByDefinitionIdWithTargetComplete() {
+    String json =
+        structuralPatch(
+            """
+            {"op":"UPDATE_WORKFLOW_NODE","workflowDefinitionId":7,
+             "nodeId":"ask_pickup_date","nodeType":"ASK_SLOT","reason":"프롬프트 수정"}
+            """);
+
+    NormalizedPatchOperationView op = firstOp(mapper.map(json));
+
+    // workflowCode는 null이지만 workflowDefinitionId 있으므로 targetComplete=true
+    assertThat(op.targetCode()).isNull();
+    assertThat(op.targetId()).isNull(); // WorkflowNode는 targetId 미노출 (workflowDefinitionId 별도)
+    assertThat(op.targetComplete()).isTrue();
+  }
+
+  @Test
+  @DisplayName("targetComplete=false는 parser 통과 후 구성될 수 없다 — parser가 식별자 없는 op를 거부하므로")
+  void targetCompleteCannotBeFalseAfterParserValidation() {
+    // ElementAttribute: targetCode/targetId 모두 없으면 parser가 InvalidStructuralPatchException 발생
+    // WorkflowNode: workflowCode/workflowDefinitionId 없으면 거부, nodeId/nodeType 없으면 거부
+    // WorkflowTransition: from/to 없으면 거부
+    // 따라서 parser를 통과한 VALID 패치는 항상 targetComplete=true를 보장한다.
+    // 아래는 parser 거부를 확인하는 회귀 보호 케이스다.
+
+    // ELEMENT: code/targetId 모두 없음
+    String jsonElementNoTarget =
+        structuralPatch(
+            "{\"op\":\"UPDATE_SLOT_DESCRIPTION\",\"description\":\"x\",\"reason\":\"r\"}");
+    assertThat(mapper.map(jsonElementNoTarget).validationStatus())
+        .isEqualTo(SimulationPatchValidationStatus.INVALID);
+
+    // WorkflowNode: nodeId 없음
+    String jsonNodeNoId =
+        structuralPatch(
+            "{\"op\":\"ADD_WORKFLOW_NODE\",\"workflowCode\":\"w\",\"nodeType\":\"ASK_SLOT\",\"reason\":\"r\"}");
+    assertThat(mapper.map(jsonNodeNoId).validationStatus())
+        .isEqualTo(SimulationPatchValidationStatus.INVALID);
+
+    // WorkflowTransition: to 없음
+    String jsonTransitionNoTo =
+        structuralPatch(
+            "{\"op\":\"ADD_TRANSITION\",\"workflowCode\":\"w\",\"from\":\"a\",\"reason\":\"r\"}");
+    assertThat(mapper.map(jsonTransitionNoTo).validationStatus())
+        .isEqualTo(SimulationPatchValidationStatus.INVALID);
+  }
+
+  @Test
+  @DisplayName("NormalizedPatchOperationView.from은 모든 StructuralPatchOperationType enum 분기를 커버한다")
+  void fromCoverAllOperationTypeKinds() {
+    // ELEMENT kind
+    var elementJson = structuralPatch(slotRequiredOp("s1"));
+    assertThat(firstOp(mapper.map(elementJson)).kind()).isEqualTo("ELEMENT");
+
+    // WORKFLOW_NODE kind
+    var nodeJson =
+        structuralPatch(
+            "{\"op\":\"ADD_WORKFLOW_NODE\",\"workflowCode\":\"w\","
+                + "\"nodeId\":\"n\",\"nodeType\":\"ASK_SLOT\",\"reason\":\"r\"}");
+    assertThat(firstOp(mapper.map(nodeJson)).kind()).isEqualTo("WORKFLOW_NODE");
+
+    // WORKFLOW_TRANSITION kind
+    var transitionJson =
+        structuralPatch(
+            "{\"op\":\"ADD_TRANSITION\",\"workflowCode\":\"w\","
+                + "\"from\":\"a\",\"to\":\"b\",\"reason\":\"r\"}");
+    assertThat(firstOp(mapper.map(transitionJson)).kind()).isEqualTo("WORKFLOW_TRANSITION");
+  }
+
+  // ---- helpers ----
+
+  private NormalizedPatchOperationView firstOp(
+      SimulationCandidatePatchViewMapper.PatchView view) {
+    assertThat(view.operations()).isNotEmpty();
+    return view.operations().get(0);
+  }
+
+  private static String slotRequiredOp(String slotCode) {
+    return "{\"op\":\"MARK_SLOT_REQUIRED\",\"slotCode\":\"%s\",\"reason\":\"필수\"}".formatted(slotCode);
+  }
+
+  private static String structuralPatch(String operationJson) {
+    return structuralPatchWithOps(operationJson);
+  }
+
+  private static String structuralPatchWithOps(String... operationJsons) {
+    String ops = String.join(",", operationJsons);
+    return """
+        {
+          "schemaVersion": "%s",
+          "summary": "workflow 보강",
+          "evidence": {
+            "feedbackId": 123,
+            "simulationSessionId": 456,
+            "failureSummary": "%s"
+          },
+          "operations": [%s]
+        }
+        """.formatted(SCHEMA_V1, FAILURE_SUMMARY, ops);
+  }
+}

--- a/backend/src/test/java/com/init/workflowruntime/application/SimulationImprovementCandidateServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/SimulationImprovementCandidateServiceTest.java
@@ -68,6 +68,8 @@ import com.init.workflowruntime.domain.SimulationImprovementCandidateRepository;
 import com.init.workflowruntime.domain.SimulationImprovementCandidateStatus;
 import com.init.workflowruntime.domain.SimulationImprovementCandidateTargetType;
 import com.init.workflowruntime.domain.SimulationImprovementCandidateType;
+import com.init.workflowruntime.domain.InvalidStructuralPatchException;
+import com.init.workflowruntime.domain.SimulationPatchValidationStatus;
 import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
 import com.init.workspace.domain.model.WorkspaceMember;
 import com.init.workspace.domain.model.WorkspaceMemberRole;
@@ -164,6 +166,8 @@ class SimulationImprovementCandidateServiceTest {
         reviewTaskService,
         decisionService,
         structuralPatchGenerationService,
+        new SimulationCandidatePatchViewMapper(
+            new StructuralDomainPackPatchParser(objectMapper), objectMapper),
         objectMapper,
         structuralPatchEnabled);
   }
@@ -1413,5 +1417,195 @@ class SimulationImprovementCandidateServiceTest {
             "{}",
             REVIEWED_AT);
     return reviewTaskWithId(task, id);
+  }
+
+  // ---- 정규화 필드 회귀 방지 ----
+
+  @Test
+  @DisplayName("getCandidate: VALID 패치 후보 조회 시 patchValidationStatus·operations·patchSummary가 채워진다")
+  void getCandidate_returnsNormalizedPatchFields_whenPatchIsValid() {
+    givenMembership();
+    SimulationImprovementCandidate candidate =
+        withCandidateId(candidate(feedback(SimulationFeedbackType.OTHER)), 1000L);
+    candidate.defineDraftPatch(validStructuralPatchJson());
+    given(candidateRepository.findById(1000L)).willReturn(Optional.of(candidate));
+
+    var result = service.getCandidate(WORKSPACE_ID, USER_ID, 1000L);
+
+    assertThat(result.patchValidationStatus()).isEqualTo(SimulationPatchValidationStatus.VALID);
+    assertThat(result.operations()).isNotEmpty();
+    assertThat(result.patchSummary()).isEqualTo("슬롯 보강");
+    assertThat(result.patchSchemaVersion()).isEqualTo("simulation-structural-patch.v1");
+  }
+
+  @Test
+  @DisplayName("listCandidates: VALID 패치 후보 목록 조회 시 operations가 채워진다")
+  void listCandidates_returnsNormalizedPatchFields_whenPatchIsValid() {
+    givenMembership();
+    SimulationImprovementCandidate candidate =
+        withCandidateId(candidate(feedback(SimulationFeedbackType.OTHER)), 1000L);
+    candidate.defineDraftPatch(validStructuralPatchJson());
+    given(candidateRepository.findByWorkspaceId(any(), any()))
+        .willReturn(new DomainPage<>(List.of(candidate), 0, 20, 1, 1));
+
+    var result = service.listCandidates(WORKSPACE_ID, USER_ID, null, 0, 20);
+
+    assertThat(result.content()).hasSize(1);
+    var item = result.content().get(0);
+    assertThat(item.patchValidationStatus()).isEqualTo(SimulationPatchValidationStatus.VALID);
+    assertThat(item.operations()).isNotEmpty();
+  }
+
+  // ---- approve INVALID 가드 ----
+
+  @Test
+  @DisplayName("approve: INVALID 패치(미상 schemaVersion) 후보를 승인하면 InvalidStructuralPatchException이 발생한다")
+  void approve_throwsInvalidStructuralPatchException_whenPatchIsInvalid_unknownSchemaVersion() {
+    givenMembership();
+    SimulationFeedback feedback =
+        withFeedbackId(feedback(SimulationFeedbackType.MISSING_SLOT_QUESTION), FEEDBACK_ID);
+    feedback.markCandidateCreated();
+    SimulationImprovementCandidate candidate =
+        withCandidateId(candidate(feedback), 1000L);
+    candidate.submitForReview(2000L, 3000L);
+    // generation failure envelope: 미상 schemaVersion → INVALID
+    String invalidPatch =
+        "{\"schemaVersion\":\"simulation-structural-patch-generation.v1\","
+            + "\"status\":\"INVALID_OUTPUT\",\"summary\":\"생성 실패\"}";
+    candidate.defineDraftPatch(invalidPatch);
+    given(candidateRepository.findById(1000L)).willReturn(Optional.of(candidate));
+    // patchView.validationStatus == INVALID 확인 후 즉시 예외 → feedbackRepository 호출 없음
+
+    assertThatThrownBy(
+            () ->
+                service.approve(
+                    new ApproveSimulationImprovementCandidateCommand(
+                        WORKSPACE_ID, USER_ID, 1000L, "반영합니다.")))
+        .isInstanceOf(InvalidStructuralPatchException.class)
+        .hasMessageContaining("INVALID 구조 패치");
+  }
+
+  @Test
+  @DisplayName("approve: INVALID 패치(깨진 JSON) 후보를 승인하면 InvalidStructuralPatchException이 발생한다")
+  void approve_throwsInvalidStructuralPatchException_whenPatchIsInvalid_malformedJson() {
+    givenMembership();
+    SimulationFeedback feedback =
+        withFeedbackId(feedback(SimulationFeedbackType.MISSING_SLOT_QUESTION), FEEDBACK_ID);
+    feedback.markCandidateCreated();
+    SimulationImprovementCandidate candidate =
+        withCandidateId(candidate(feedback), 1000L);
+    candidate.submitForReview(2000L, 3000L);
+    candidate.defineDraftPatch("{not valid json!!!");
+    given(candidateRepository.findById(1000L)).willReturn(Optional.of(candidate));
+    // patchView.validationStatus == INVALID 확인 후 즉시 예외 → feedbackRepository 호출 없음
+
+    assertThatThrownBy(
+            () ->
+                service.approve(
+                    new ApproveSimulationImprovementCandidateCommand(
+                        WORKSPACE_ID, USER_ID, 1000L, null)))
+        .isInstanceOf(InvalidStructuralPatchException.class)
+        .hasMessageContaining("INVALID 구조 패치");
+  }
+
+  // ---- approve 정상: VALID/LEGACY/NONE 패치 ----
+
+  @Test
+  @DisplayName("approve: NONE 패치('{}')를 가진 후보는 정상 승인된다")
+  void approve_succeedsForNonePatch() {
+    SimulationImprovementCandidate candidate =
+        readyCandidate(
+            SimulationImprovementCandidateTargetType.SLOT,
+            null,
+            "order_number",
+            "주문번호 질문을 추가합니다.");
+    // draftPatchJson 기본값 = "{}" → NONE
+    DomainPackVersion draftVersion =
+        DomainPackVersion.ofForTest(VERSION_ID, 50L, DomainPackVersion.STATUS_DRAFT);
+    SlotDefinition slot =
+        SlotDefinition.create(
+            VERSION_ID, "order_number", "주문번호", "기존 설명", "STRING", false, "{}", null, "{}");
+    givenApprovalBasics(candidate, draftVersion);
+    given(
+            slotDefinitionRepository.findByDomainPackVersionIdAndSlotCode(
+                VERSION_ID, "order_number"))
+        .willReturn(Optional.of(slot));
+    given(candidateRepository.save(any(SimulationImprovementCandidate.class)))
+        .willAnswer(invocation -> invocation.getArgument(0));
+
+    var result =
+        service.approve(
+            new ApproveSimulationImprovementCandidateCommand(WORKSPACE_ID, USER_ID, 1000L, null));
+
+    assertThat(result.status()).isEqualTo(SimulationImprovementCandidateStatus.APPLIED);
+    assertThat(result.patchValidationStatus()).isEqualTo(SimulationPatchValidationStatus.NONE);
+  }
+
+  @Test
+  @DisplayName("approve: LEGACY 패치 후보는 정상 승인된다")
+  void approve_succeedsForLegacyPatch() {
+    SimulationImprovementCandidate candidate =
+        readyCandidate(
+            SimulationImprovementCandidateTargetType.SLOT,
+            null,
+            "order_number",
+            "주문번호 질문 설명을 보강합니다.");
+    String legacyPatch =
+        "{\"schemaVersion\":\"simulation-candidate-draft-patch.v1\","
+            + "\"operation\":\"UPDATE_DESCRIPTION\"}";
+    candidate.defineDraftPatch(legacyPatch);
+    DomainPackVersion draftVersion =
+        DomainPackVersion.ofForTest(VERSION_ID, 50L, DomainPackVersion.STATUS_DRAFT);
+    SlotDefinition slot =
+        SlotDefinition.create(
+            VERSION_ID, "order_number", "주문번호", "기존 설명", "STRING", false, "{}", null, "{}");
+    givenApprovalBasics(candidate, draftVersion);
+    given(
+            slotDefinitionRepository.findByDomainPackVersionIdAndSlotCode(
+                VERSION_ID, "order_number"))
+        .willReturn(Optional.of(slot));
+    given(candidateRepository.save(any(SimulationImprovementCandidate.class)))
+        .willAnswer(invocation -> invocation.getArgument(0));
+
+    var result =
+        service.approve(
+            new ApproveSimulationImprovementCandidateCommand(WORKSPACE_ID, USER_ID, 1000L, null));
+
+    assertThat(result.status()).isEqualTo(SimulationImprovementCandidateStatus.APPLIED);
+    assertThat(result.patchValidationStatus()).isEqualTo(SimulationPatchValidationStatus.LEGACY);
+  }
+
+  @Test
+  @DisplayName("approve: VALID 패치 후보는 정상 승인되고 operations가 응답에 포함된다")
+  void approve_succeedsForValidPatch_andIncludesOperationsInResponse() {
+    SimulationImprovementCandidate candidate =
+        readyCandidate(
+            SimulationImprovementCandidateTargetType.SLOT,
+            null,
+            "order_number",
+            "주문번호 질문을 추가합니다.");
+    candidate.defineDraftPatch(validStructuralPatchJson());
+    DomainPackVersion draftVersion =
+        DomainPackVersion.ofForTest(VERSION_ID, 50L, DomainPackVersion.STATUS_DRAFT);
+    // VALID 구조 패치는 structuralPatchApplyService(mock)로 처리되므로 slot 조회가 발생하지 않는다
+    givenApprovalBasics(candidate, draftVersion);
+    given(candidateRepository.save(any(SimulationImprovementCandidate.class)))
+        .willAnswer(invocation -> invocation.getArgument(0));
+
+    var result =
+        service.approve(
+            new ApproveSimulationImprovementCandidateCommand(WORKSPACE_ID, USER_ID, 1000L, null));
+
+    assertThat(result.status()).isEqualTo(SimulationImprovementCandidateStatus.APPLIED);
+    assertThat(result.patchValidationStatus()).isEqualTo(SimulationPatchValidationStatus.VALID);
+    assertThat(result.operations()).isNotEmpty();
+  }
+
+  /** 서비스 테스트에서 재사용하는 유효한 simulation-structural-patch.v1 JSON fixture. */
+  private static String validStructuralPatchJson() {
+    return "{\"schemaVersion\":\"simulation-structural-patch.v1\",\"summary\":\"슬롯 보강\","
+        + "\"evidence\":{\"failureSummary\":\"missing slot\"},"
+        + "\"operations\":[{\"op\":\"MARK_SLOT_REQUIRED\",\"slotCode\":\"order_number\","
+        + "\"reason\":\"필수\"}]}";
   }
 }

--- a/backend/src/test/java/com/init/workflowruntime/presentation/SimulationImprovementCandidateControllerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/SimulationImprovementCandidateControllerTest.java
@@ -20,6 +20,7 @@ import com.init.workflowruntime.application.dto.SimulationImprovementCandidateRe
 import com.init.workflowruntime.domain.SimulationImprovementCandidateStatus;
 import com.init.workflowruntime.domain.SimulationImprovementCandidateTargetType;
 import com.init.workflowruntime.domain.SimulationImprovementCandidateType;
+import com.init.workflowruntime.domain.SimulationPatchValidationStatus;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -143,7 +144,12 @@ class SimulationImprovementCandidateControllerTest {
                 SimulationImprovementCandidateStatus.READY_FOR_REVIEW,
                 7L,
                 null,
-                null));
+                null,
+                null,
+                null,
+                SimulationPatchValidationStatus.NONE,
+                List.of(),
+                List.of()));
 
     mockMvc
         .perform(
@@ -263,7 +269,12 @@ class SimulationImprovementCandidateControllerTest {
         status,
         7L,
         null,
-        null);
+        null,
+        null,
+        null,
+        SimulationPatchValidationStatus.NONE,
+        List.of(),
+        List.of());
   }
 
   private UsernamePasswordAuthenticationToken auth() {

--- a/frontend/src/features/simulation/api/simulationApi.ts
+++ b/frontend/src/features/simulation/api/simulationApi.ts
@@ -71,6 +71,26 @@ export type SimulationImprovementCandidateStatus =
   | "APPLIED"
   | "REJECTED";
 
+export type SimulationPatchValidationStatus = "VALID" | "INVALID" | "LEGACY" | "NONE";
+
+export interface SimulationPatchOperationView {
+  operationType: string;
+  kind: "ELEMENT" | "WORKFLOW_NODE" | "WORKFLOW_TRANSITION";
+  targetCategory: string | null;
+  targetCode: string | null;
+  targetId: number | null;
+  value: string | null;
+  nodeId: string | null;
+  nodeType: string | null;
+  slotCode: string | null;
+  prompt: string | null;
+  from: string | null;
+  to: string | null;
+  condition: string | null;
+  reason: string | null;
+  targetComplete: boolean;
+}
+
 export type SimulationGoldenCaseReplayStatus = "PASS" | "FAIL";
 
 export interface SimulationFeedback {
@@ -134,6 +154,11 @@ export interface SimulationImprovementCandidate {
   createdBy: number;
   createdAt: string;
   updatedAt: string;
+  patchSchemaVersion: string | null;
+  patchSummary: string | null;
+  patchValidationStatus: SimulationPatchValidationStatus;
+  patchValidationErrors: string[];
+  operations: SimulationPatchOperationView[];
 }
 
 export interface SimulationImprovementCandidatePage {

--- a/frontend/src/features/simulation/index.ts
+++ b/frontend/src/features/simulation/index.ts
@@ -20,6 +20,8 @@ export type {
   SimulationImprovementCandidateStatus,
   SimulationImprovementCandidateTargetType,
   SimulationImprovementCandidateType,
+  SimulationPatchValidationStatus,
+  SimulationPatchOperationView,
   ReplaySimulationGoldenCasePayload,
   SendSimulationMessagePayload,
   SimulationSessionDetail,

--- a/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.structural.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.structural.test.tsx
@@ -1,0 +1,287 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { SimulationImprovementCandidate } from "@/features/simulation";
+import {
+  candidate,
+  mockedSimulationApi,
+  openCandidateTab,
+  renderPage,
+  toast,
+} from "./WorkspaceSimulationPage.test-helper";
+
+// structural 후보 픽스처 팩토리
+// patchValidationStatus="VALID" + operations 포함 = 구조 패치 검토 UI 경로
+function makeStructuralCandidate(
+  overrides: Partial<SimulationImprovementCandidate> = {},
+): SimulationImprovementCandidate {
+  return {
+    ...candidate,
+    id: 2000,
+    status: "READY_FOR_REVIEW",
+    patchValidationStatus: "VALID",
+    patchSummary: "주문번호 슬롯 필수화",
+    patchValidationErrors: [],
+    operations: [
+      {
+        operationType: "MARK_SLOT_REQUIRED",
+        kind: "ELEMENT",
+        targetCategory: "SLOT",
+        targetCode: "orderNo",
+        targetId: 55,
+        value: null,
+        nodeId: null,
+        nodeType: null,
+        slotCode: "orderNo",
+        prompt: null,
+        from: null,
+        to: null,
+        condition: null,
+        reason: "주문번호 없이 환불 처리 불가",
+        targetComplete: true,
+      },
+    ],
+    draftPatchJson: JSON.stringify({ schemaVersion: "v1", operations: [] }),
+    reviewSessionId: 200,
+    reviewTaskId: 300,
+    ...overrides,
+  };
+}
+
+function makeWorkflowStructuralCandidate(): SimulationImprovementCandidate {
+  return makeStructuralCandidate({
+    id: 2001,
+    patchSummary: "결제 확인 노드 추가",
+    operations: [
+      {
+        operationType: "ADD_WORKFLOW_NODE",
+        kind: "WORKFLOW_NODE",
+        targetCategory: null,
+        targetCode: null,
+        targetId: null,
+        value: null,
+        nodeId: "node-payment-check",
+        nodeType: "ASK_SLOT",
+        slotCode: null,
+        prompt: "결제 방법을 알려주세요.",
+        from: null,
+        to: null,
+        condition: null,
+        reason: "결제 정보 필요",
+        targetComplete: true,
+      },
+    ],
+  });
+}
+
+function candidatePage(items: SimulationImprovementCandidate[]) {
+  return {
+    content: items,
+    page: 0,
+    size: 20,
+    totalElements: items.length,
+    totalPages: 1,
+  };
+}
+
+describe("WorkspaceSimulationPage structural 후보 검토", () => {
+  it("structural 후보 카드가 patchSummary, 검증 통과 뱃지, operation diff를 렌더한다", async () => {
+    mockedSimulationApi.listImprovementCandidates.mockResolvedValue(
+      candidatePage([makeStructuralCandidate()]),
+    );
+    renderPage();
+
+    await openCandidateTab();
+
+    // 패치 요약
+    expect(await screen.findByText("주문번호 슬롯 필수화")).toBeInTheDocument();
+
+    // 검증 통과 뱃지
+    expect(screen.getByText("검증 통과")).toBeInTheDocument();
+
+    // operation diff — operationLabel 확인
+    expect(screen.getByText("슬롯 필수화")).toBeInTheDocument();
+
+    // Before/After 라벨
+    expect(screen.getAllByText("Before").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("After").length).toBeGreaterThan(0);
+  });
+
+  it("WORKFLOW_NODE op 포함 structural 후보는 '워크플로우 구조 변경' 뱃지를 표시한다", async () => {
+    mockedSimulationApi.listImprovementCandidates.mockResolvedValue(
+      candidatePage([makeWorkflowStructuralCandidate()]),
+    );
+    renderPage();
+
+    await openCandidateTab();
+
+    expect(await screen.findByText("워크플로우 구조 변경")).toBeInTheDocument();
+  });
+
+  it("구조 패치 검토 확인 전 승인 버튼이 disabled다", async () => {
+    mockedSimulationApi.listImprovementCandidates.mockResolvedValue(
+      candidatePage([makeStructuralCandidate()]),
+    );
+    renderPage();
+
+    await openCandidateTab();
+    await screen.findByText("검증 통과");
+
+    const approveButton = screen.getByRole("button", { name: "승인" });
+    expect(approveButton).toBeDisabled();
+  });
+
+  it("구조 패치 검토 확인 체크 후 승인 버튼이 활성화된다", async () => {
+    mockedSimulationApi.listImprovementCandidates.mockResolvedValue(
+      candidatePage([makeStructuralCandidate()]),
+    );
+    renderPage();
+
+    await openCandidateTab();
+    await screen.findByText("검증 통과");
+
+    const approveButton = screen.getByRole("button", { name: "승인" });
+    expect(approveButton).toBeDisabled();
+
+    // 구조 변경 검토 확인 체크박스 클릭
+    const checkbox = screen.getByRole("checkbox");
+    fireEvent.click(checkbox);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "승인" })).not.toBeDisabled();
+    });
+  });
+
+  it("patchValidationStatus=INVALID 후보는 검증 실패 뱃지, 오류 목록을 표시하고 승인 버튼이 disabled다", async () => {
+    mockedSimulationApi.listImprovementCandidates.mockResolvedValue(
+      candidatePage([
+        makeStructuralCandidate({
+          patchValidationStatus: "INVALID",
+          patchValidationErrors: ["operationType 필드 누락", "targetId가 양수가 아님"],
+          operations: [],
+        }),
+      ]),
+    );
+    renderPage();
+
+    await openCandidateTab();
+
+    // 검증 실패 뱃지
+    expect(await screen.findByText("검증 실패")).toBeInTheDocument();
+
+    // 오류 목록 (aria-label="검증 오류 목록")
+    const errorList = await screen.findByRole("list", { name: "검증 오류 목록" });
+    expect(errorList).toBeInTheDocument();
+    expect(errorList).toHaveTextContent("operationType 필드 누락");
+    expect(errorList).toHaveTextContent("targetId가 양수가 아님");
+
+    // 승인 버튼 disabled
+    expect(screen.getByRole("button", { name: "승인" })).toBeDisabled();
+  });
+
+  it("structural 후보 승인 후 APPLIED 상태와 리플레이 CTA를 표시한다", async () => {
+    const approvedCandidate = {
+      ...makeStructuralCandidate(),
+      status: "APPLIED" as const,
+      appliedDomainPackVersionId: 202,
+    };
+    mockedSimulationApi.listImprovementCandidates
+      .mockResolvedValueOnce(candidatePage([makeStructuralCandidate()]))
+      // 승인 후 목록 새로고침 시 APPLIED 상태 반환
+      .mockResolvedValue(candidatePage([approvedCandidate]));
+    mockedSimulationApi.approveImprovementCandidate.mockResolvedValue(approvedCandidate);
+    renderPage();
+
+    await openCandidateTab();
+    await screen.findByText("검증 통과");
+
+    // 체크박스 체크
+    fireEvent.click(screen.getByRole("checkbox"));
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "승인" })).not.toBeDisabled();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "승인" }));
+
+    await waitFor(() => {
+      expect(mockedSimulationApi.approveImprovementCandidate).toHaveBeenCalledWith(
+        1,
+        2000,
+        expect.any(Object),
+      );
+    });
+
+    // 승인 후 candidateApprovalNotice (<output>) 또는 ApprovedReplayCta (<div role=status>) 중
+    // 버전 정보("#202")가 포함된 요소가 화면에 나타남
+    const statusEls = await screen.findAllByRole("status");
+    const hasVersionText = statusEls.some((el) => el.textContent?.includes("202"));
+    expect(hasVersionText).toBe(true);
+
+    // 토스트 성공
+    expect(toast.success).toHaveBeenCalled();
+  });
+
+  it("appliedDomainPackVersionId=null APPLIED 후보는 '적용 버전 응답 대기' 메시지를 표시한다", async () => {
+    const approvedCandidateNullVersion = {
+      ...makeStructuralCandidate(),
+      status: "APPLIED" as const,
+      appliedDomainPackVersionId: null,
+    };
+    mockedSimulationApi.listImprovementCandidates
+      .mockResolvedValueOnce(candidatePage([makeStructuralCandidate()]))
+      // 승인 후 목록 새로고침 시 APPLIED 상태 (버전 없음) 반환
+      .mockResolvedValue(candidatePage([approvedCandidateNullVersion]));
+    mockedSimulationApi.approveImprovementCandidate.mockResolvedValue(approvedCandidateNullVersion);
+    renderPage();
+
+    await openCandidateTab();
+    await screen.findByText("검증 통과");
+
+    fireEvent.click(screen.getByRole("checkbox"));
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "승인" })).not.toBeDisabled();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "승인" }));
+
+    await waitFor(() => {
+      expect(mockedSimulationApi.approveImprovementCandidate).toHaveBeenCalled();
+    });
+
+    // candidateApprovalGuide()는 appliedDomainPackVersionId=null 시 "적용 version 응답 대기" 반환
+    // <output> 또는 role=status 중 하나에 해당 텍스트가 나타남
+    const statusEls = await screen.findAllByRole("status");
+    const hasWaitingText = statusEls.some((el) =>
+      el.textContent?.includes("적용 version 응답 대기"),
+    );
+    expect(hasWaitingText).toBe(true);
+  });
+
+  it("patchValidationStatus=NONE 레거시 후보는 기존 Draft patch 검토 UI로 렌더된다", async () => {
+    // NONE 상태 후보 = legacy 경로 → 기존 CandidatePatchReview 사용
+    mockedSimulationApi.listImprovementCandidates.mockResolvedValue(
+      candidatePage([
+        {
+          ...candidate,
+          id: 3000,
+          status: "READY_FOR_REVIEW",
+          patchValidationStatus: "NONE",
+          patchSummary: null,
+          patchValidationErrors: [],
+          operations: [],
+          draftPatchJson: "{}",
+          reviewSessionId: 200,
+          reviewTaskId: 300,
+        },
+      ]),
+    );
+    renderPage();
+
+    await openCandidateTab();
+
+    // 기존 레거시 UI 노출 확인 — 새 structural 뱃지("검증 통과"/"검증 실패")가 없어야 함
+    expect(await screen.findByText("Draft patch 검토")).toBeInTheDocument();
+    expect(screen.queryByText("검증 통과")).not.toBeInTheDocument();
+    expect(screen.queryByText("검증 실패")).not.toBeInTheDocument();
+    expect(screen.queryByText("워크플로우 구조 변경")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.test-helper.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.test-helper.tsx
@@ -170,6 +170,11 @@ const candidate = {
   createdBy: 7,
   createdAt: "2026-06-04T10:45:00Z",
   updatedAt: "2026-06-04T10:45:00Z",
+  patchSchemaVersion: null,
+  patchSummary: null,
+  patchValidationStatus: "NONE",
+  patchValidationErrors: [],
+  operations: [],
 } as const;
 
 const validDraftPatchJson = JSON.stringify({

--- a/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.tsx
@@ -52,6 +52,11 @@ import { LoadingSpinner } from "@/shared/ui/ostone/atoms/LoadingSpinner";
 import { ErrorState } from "@/shared/ui/ostone/atoms/ErrorState";
 import { EmptyState } from "@/shared/ui/ostone/atoms/EmptyState";
 
+import { StructuralPatchReview } from "./simulation/StructuralPatchReviewPanel";
+import {
+  buildStructuralPatchReview,
+  evaluateApprovalGuardrail,
+} from "./simulation/structuralPatchReview";
 import styles from "./simulation/workspace-simulation-page.module.css";
 
 const PAGE_SIZE = 20;
@@ -755,10 +760,19 @@ function buildCandidatePatchReview(
   };
 }
 
+function usesStructuralReview(candidate: SimulationImprovementCandidate): boolean {
+  const kind = buildStructuralPatchReview(candidate).kind;
+  return kind === "structural" || kind === "invalid";
+}
+
 function canApproveCandidate(
   candidate: SimulationImprovementCandidate,
   confirmed: boolean,
 ): boolean {
+  if (usesStructuralReview(candidate)) {
+    const model = buildStructuralPatchReview(candidate);
+    return evaluateApprovalGuardrail(model, confirmed).canApprove;
+  }
   return confirmed && buildCandidatePatchReview(candidate).kind === "ready";
 }
 
@@ -1509,11 +1523,22 @@ export function WorkspaceSimulationPage() {
   ) => {
     const confirmationKey = candidatePatchConfirmationKey(candidate);
     setConfirmedCandidatePatchKeys((current) => {
-      if (current.has(confirmationKey)) return current;
       const next = new Set(current);
-      next.add(confirmationKey);
+      if (next.has(confirmationKey)) {
+        next.delete(confirmationKey);
+      } else {
+        next.add(confirmationKey);
+      }
       return next;
     });
+  };
+
+  const handleReplayAppliedVersion = (versionId: number) => {
+    setReplayVersionId(String(versionId));
+    setActiveSideTab("state");
+    toast.success(
+      `검증 케이스에서 version #${versionId} 기준으로 Replay를 실행하세요.`,
+    );
   };
 
   const handleRejectCandidate = async (
@@ -2519,15 +2544,33 @@ export function WorkspaceSimulationPage() {
                             </dd>
                           </div>
                         </dl>
-                        <CandidatePatchReview
-                          candidate={candidate}
-                          confirmed={confirmedCandidatePatchKeys.has(
-                            candidatePatchConfirmationKey(candidate),
-                          )}
-                          onConfirm={() =>
-                            handleConfirmCandidatePatch(candidate)
-                          }
-                        />
+                        {usesStructuralReview(candidate) ? (
+                          <StructuralPatchReview
+                            candidate={candidate}
+                            confirmed={confirmedCandidatePatchKeys.has(
+                              candidatePatchConfirmationKey(candidate),
+                            )}
+                            onToggleConfirm={() => handleConfirmCandidatePatch(candidate)}
+                            onReplayAppliedVersion={handleReplayAppliedVersion}
+                            legacyFallback={
+                              <CandidatePatchReview
+                                candidate={candidate}
+                                confirmed={confirmedCandidatePatchKeys.has(
+                                  candidatePatchConfirmationKey(candidate),
+                                )}
+                                onConfirm={() => handleConfirmCandidatePatch(candidate)}
+                              />
+                            }
+                          />
+                        ) : (
+                          <CandidatePatchReview
+                            candidate={candidate}
+                            confirmed={confirmedCandidatePatchKeys.has(
+                              candidatePatchConfirmationKey(candidate),
+                            )}
+                            onConfirm={() => handleConfirmCandidatePatch(candidate)}
+                          />
+                        )}
                         {candidate.status === "DRAFT" ? (
                           <div className={styles.candidateActions}>
                             <Button

--- a/frontend/src/pages/workspace/ui/simulation/StructuralPatchReviewPanel.tsx
+++ b/frontend/src/pages/workspace/ui/simulation/StructuralPatchReviewPanel.tsx
@@ -1,0 +1,299 @@
+import type { ReactNode } from "react";
+
+import type {
+  SimulationImprovementCandidate,
+  SimulationImprovementCandidateStatus,
+} from "@/features/simulation";
+import { Button } from "@/shared/ui/button";
+
+import {
+  buildStructuralPatchReview,
+  evaluateApprovalGuardrail,
+  type PatchOperationDiff,
+  type StructuralPatchReviewModel,
+} from "./structuralPatchReview";
+import styles from "./workspace-simulation-page.module.css";
+
+interface StructuralPatchReviewProps {
+  readonly candidate: SimulationImprovementCandidate;
+  readonly confirmed: boolean;
+  readonly onToggleConfirm: () => void;
+  readonly legacyFallback: ReactNode;
+  readonly onReplayAppliedVersion?: (versionId: number) => void;
+}
+
+const APPLIED_STATUS: SimulationImprovementCandidateStatus = "APPLIED";
+
+function candidateStatusBadgeLabel(candidate: SimulationImprovementCandidate): string {
+  switch (candidate.status) {
+    case "DRAFT":
+      return "초안 패치";
+    case "READY_FOR_REVIEW":
+      return "리뷰 대기";
+    case "APPLIED":
+      return candidate.appliedDomainPackVersionId
+        ? "초안 버전 반영됨"
+        : "승인됨 · 적용 버전 응답 대기";
+    case "REJECTED":
+      return "반려됨";
+    default:
+      return candidate.status;
+  }
+}
+
+function patchValidationBadgeLabel(model: StructuralPatchReviewModel): string {
+  switch (model.status) {
+    case "VALID":
+      return "검증 통과";
+    case "INVALID":
+      return "검증 실패";
+    case "LEGACY":
+      return "레거시 패치";
+    case "NONE":
+    default:
+      return "패치 없음";
+  }
+}
+
+function StructuralReviewShell({
+  candidate,
+  model,
+  children,
+}: Readonly<{
+  candidate: SimulationImprovementCandidate;
+  model: StructuralPatchReviewModel;
+  children: ReactNode;
+}>) {
+  return (
+    <section className={styles.candidatePatchPanel} aria-label="구조 패치 검토">
+      <div className={styles.candidatePatchHeader}>
+        <div>
+          <strong>구조 패치 검토</strong>
+          <span>승인 시 초안 Domain Pack 버전에 반영됩니다. 아직 운영에 적용된 변경이 아닙니다.</span>
+        </div>
+        <span className={styles.structuralBadgeGroup}>
+          {model.hasWorkflowStructureChange ? (
+            <span className={styles.workflowStructureBadge}>워크플로우 구조 변경</span>
+          ) : null}
+          <span
+            className={
+              model.status === "VALID" ? styles.patchStatusReady : styles.patchStatusBlocked
+            }
+          >
+            {patchValidationBadgeLabel(model)}
+          </span>
+          <span className={styles.statusPill}>{candidateStatusBadgeLabel(candidate)}</span>
+        </span>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function CandidateOverview({
+  candidate,
+  model,
+}: Readonly<{
+  candidate: SimulationImprovementCandidate;
+  model: StructuralPatchReviewModel;
+}>) {
+  const targetReference = [
+    candidate.targetElementKey,
+    candidate.targetElementId !== null ? `#${candidate.targetElementId}` : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+  return (
+    <dl className={styles.patchMetaList} aria-label="패치 개요">
+      <div>
+        <dt>대상 요소</dt>
+        <dd>{candidate.targetElementType}</dd>
+      </div>
+      <div>
+        <dt>대상 식별자</dt>
+        <dd>{targetReference || "(미지정)"}</dd>
+      </div>
+      <div>
+        <dt>출처</dt>
+        <dd>
+          세션 #{candidate.sessionId} · 피드백 #{candidate.feedbackId}
+        </dd>
+      </div>
+      {model.summary ? (
+        <div>
+          <dt>패치 요약</dt>
+          <dd>{model.summary}</dd>
+        </div>
+      ) : null}
+    </dl>
+  );
+}
+
+function EvidencePanel({ candidate }: Readonly<{ candidate: SimulationImprovementCandidate }>) {
+  return (
+    <div className={styles.evidencePanel} aria-label="검토 근거">
+      <span>근거</span>
+      <p>{candidate.evidenceSummary}</p>
+      <ul>
+        <li>세션 #{candidate.sessionId}</li>
+        {candidate.chatMessageId ? <li>메시지 #{candidate.chatMessageId}</li> : null}
+        <li>피드백 #{candidate.feedbackId}</li>
+      </ul>
+    </div>
+  );
+}
+
+function StructuralDiffCard({ diff }: Readonly<{ diff: PatchOperationDiff }>) {
+  return (
+    <article className={styles.diffOpCard}>
+      <header className={styles.diffOpHeader}>
+        <strong>{diff.operationLabel}</strong>
+        <span>{diff.targetLabel}</span>
+      </header>
+      {diff.targetComplete ? null : (
+        <p className={styles.diffTargetWarning}>대상 확인 불가 — 적용 전 검증이 필요합니다.</p>
+      )}
+      <dl className={styles.patchChangeList}>
+        {diff.fields.map((field, index) => (
+          <div key={`${field.label}-${index}`} className={styles.diffBeforeAfter}>
+            <dt>{field.label}</dt>
+            <dd>
+              <span>Before</span>
+              <p>{field.before}</p>
+            </dd>
+            <dd>
+              <span>After</span>
+              <p>{field.after}</p>
+            </dd>
+          </div>
+        ))}
+      </dl>
+      {diff.reason ? (
+        <p className={styles.diffReason}>
+          <span>근거</span>
+          {diff.reason}
+        </p>
+      ) : null}
+    </article>
+  );
+}
+
+function RawPatchDetails({ candidate }: Readonly<{ candidate: SimulationImprovementCandidate }>) {
+  return (
+    <details className={styles.patchRawDetails}>
+      <summary>원본 patch JSON</summary>
+      <pre>
+        <code>{candidate.draftPatchJson}</code>
+      </pre>
+    </details>
+  );
+}
+
+function ApprovedReplayCta({
+  candidate,
+  onReplay,
+}: Readonly<{
+  candidate: SimulationImprovementCandidate;
+  onReplay: ((versionId: number) => void) | undefined;
+}>) {
+  if (candidate.status !== APPLIED_STATUS) return null;
+  const versionId = candidate.appliedDomainPackVersionId;
+  return (
+    <div className={styles.approvedReplayCta} role="status">
+      {versionId ? (
+        <p>
+          초안 버전 #{versionId}에 반영했습니다. 같은 버전으로 검증 케이스를 리플레이해 회귀를
+          확인하세요.
+        </p>
+      ) : (
+        <p>승인을 처리했지만 적용 버전 응답을 기다리는 중입니다.</p>
+      )}
+      {versionId && onReplay ? (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => onReplay(versionId)}
+        >
+          <span>이 버전으로 검증 케이스 리플레이</span>
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
+export function StructuralPatchReview({
+  candidate,
+  confirmed,
+  onToggleConfirm,
+  legacyFallback,
+  onReplayAppliedVersion,
+}: Readonly<StructuralPatchReviewProps>) {
+  const model = buildStructuralPatchReview(candidate);
+
+  if (model.kind === "legacy") {
+    return <>{legacyFallback}</>;
+  }
+
+  if (model.kind === "missing") {
+    return (
+      <StructuralReviewShell candidate={candidate} model={model}>
+        <CandidateOverview candidate={candidate} model={model} />
+        <p className={styles.patchUnavailableMessage}>
+          {model.message ?? "draft patch 정보가 없습니다."}
+        </p>
+        <p className={styles.patchConfirmHint}>
+          패치 내용을 확인할 수 없어 승인할 수 없습니다. 후보 생성 데이터를 먼저 확인하세요.
+        </p>
+      </StructuralReviewShell>
+    );
+  }
+
+  if (model.kind === "invalid") {
+    return (
+      <StructuralReviewShell candidate={candidate} model={model}>
+        <CandidateOverview candidate={candidate} model={model} />
+        <p className={styles.patchUnavailableMessage}>
+          {model.message ?? "패치 검증에 실패했습니다."}
+        </p>
+        {model.errors.length > 0 ? (
+          <ul className={styles.validationErrorList} aria-label="검증 오류 목록">
+            {model.errors.map((error, index) => (
+              <li key={`${index}-${error}`}>{error}</li>
+            ))}
+          </ul>
+        ) : null}
+        <RawPatchDetails candidate={candidate} />
+        <p className={styles.patchConfirmHint}>검증 실패 상태에서는 승인할 수 없습니다.</p>
+      </StructuralReviewShell>
+    );
+  }
+
+  const guardrail = evaluateApprovalGuardrail(model, confirmed);
+  return (
+    <StructuralReviewShell candidate={candidate} model={model}>
+      <CandidateOverview candidate={candidate} model={model} />
+      <EvidencePanel candidate={candidate} />
+      <div className={styles.structuralDiffPanel} aria-label="구조 변경 상세">
+        {model.diffs.map((diff, index) => (
+          <StructuralDiffCard key={`${diff.operationType}-${index}`} diff={diff} />
+        ))}
+      </div>
+      <div className={styles.guardrailChecklist}>
+        <label>
+          <input type="checkbox" checked={confirmed} onChange={onToggleConfirm} />
+          <span>워크플로우 구조 변경을 검토했습니다</span>
+        </label>
+        {guardrail.disabledReasons.length > 0 ? (
+          <ul aria-label="승인 차단 사유">
+            {guardrail.disabledReasons.map((reason) => (
+              <li key={reason}>{reason}</li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+      <RawPatchDetails candidate={candidate} />
+      <ApprovedReplayCta candidate={candidate} onReplay={onReplayAppliedVersion} />
+    </StructuralReviewShell>
+  );
+}

--- a/frontend/src/pages/workspace/ui/simulation/structuralPatchReview.test.ts
+++ b/frontend/src/pages/workspace/ui/simulation/structuralPatchReview.test.ts
@@ -1,0 +1,349 @@
+import { describe, expect, it } from "vitest";
+import type {
+  SimulationImprovementCandidate,
+  SimulationPatchOperationView,
+} from "@/features/simulation";
+import {
+  buildOperationDiff,
+  buildStructuralPatchReview,
+  evaluateApprovalGuardrail,
+  isWorkflowStructureOperation,
+  operationTypeLabel,
+} from "./structuralPatchReview";
+
+// ---- 목 팩토리 ----
+
+function makeOp(overrides: Partial<SimulationPatchOperationView> = {}): SimulationPatchOperationView {
+  return {
+    operationType: "MARK_SLOT_REQUIRED",
+    kind: "ELEMENT",
+    targetCategory: null,
+    targetCode: null,
+    targetId: null,
+    value: null,
+    nodeId: null,
+    nodeType: null,
+    slotCode: null,
+    prompt: null,
+    from: null,
+    to: null,
+    condition: null,
+    reason: null,
+    targetComplete: true,
+    ...overrides,
+  };
+}
+
+function makeCandidate(
+  overrides: Partial<SimulationImprovementCandidate> = {},
+): SimulationImprovementCandidate {
+  return {
+    id: 1000,
+    workspaceId: 1,
+    domainPackVersionId: 101,
+    feedbackId: 900,
+    sessionId: 10,
+    chatMessageId: null,
+    candidateType: "SLOT_QUESTION",
+    targetElementType: "SLOT",
+    targetElementId: null,
+    targetElementKey: null,
+    beforeSummary: "before",
+    afterSummary: "after",
+    evidenceSummary: "evidence",
+    reviewSessionId: null,
+    reviewTaskId: null,
+    appliedDomainPackVersionId: null,
+    draftPatchJson: "{}",
+    decisionReason: null,
+    decidedBy: null,
+    decidedAt: null,
+    status: "DRAFT",
+    createdBy: 7,
+    createdAt: "2026-06-04T10:45:00Z",
+    updatedAt: "2026-06-04T10:45:00Z",
+    patchSchemaVersion: null,
+    patchSummary: null,
+    patchValidationStatus: "NONE",
+    patchValidationErrors: [],
+    operations: [],
+    ...overrides,
+  };
+}
+
+// ---- operationTypeLabel ----
+
+describe("operationTypeLabel", () => {
+  it("알려진 operationType에 대해 한국어 라벨을 반환한다", () => {
+    expect(operationTypeLabel("MARK_SLOT_REQUIRED")).toBe("슬롯 필수화");
+    expect(operationTypeLabel("ADD_WORKFLOW_NODE")).toBe("워크플로우 노드 추가");
+    expect(operationTypeLabel("UPDATE_TRANSITION")).toBe("전이 수정");
+  });
+
+  it("알 수 없는 operationType은 원문을 그대로 반환한다", () => {
+    expect(operationTypeLabel("FOO_BAR")).toBe("FOO_BAR");
+    expect(operationTypeLabel("")).toBe("");
+  });
+});
+
+// ---- isWorkflowStructureOperation ----
+
+describe("isWorkflowStructureOperation", () => {
+  it("WORKFLOW_NODE kind는 워크플로우 구조 변경으로 판단한다", () => {
+    expect(isWorkflowStructureOperation(makeOp({ kind: "WORKFLOW_NODE" }))).toBe(true);
+  });
+
+  it("WORKFLOW_TRANSITION kind는 워크플로우 구조 변경으로 판단한다", () => {
+    expect(isWorkflowStructureOperation(makeOp({ kind: "WORKFLOW_TRANSITION" }))).toBe(true);
+  });
+
+  it("ELEMENT kind는 워크플로우 구조 변경이 아니다", () => {
+    expect(isWorkflowStructureOperation(makeOp({ kind: "ELEMENT" }))).toBe(false);
+  });
+});
+
+// ---- buildOperationDiff ----
+
+describe("buildOperationDiff", () => {
+  it("MARK_SLOT_REQUIRED는 필수 여부 before/after 필드를 반환한다", () => {
+    const diff = buildOperationDiff(makeOp({ operationType: "MARK_SLOT_REQUIRED" }));
+    expect(diff.operationLabel).toBe("슬롯 필수화");
+    expect(diff.fields).toHaveLength(1);
+    expect(diff.fields[0].label).toBe("필수 여부");
+    expect(diff.fields[0].before).toContain("선택");
+    expect(diff.fields[0].after).toContain("필수");
+  });
+
+  it("ADD_WORKFLOW_NODE는 nodeId/nodeType/prompt 필드를 after에 반영하고 before는 '노드 없음'이다", () => {
+    const diff = buildOperationDiff(
+      makeOp({
+        operationType: "ADD_WORKFLOW_NODE",
+        kind: "WORKFLOW_NODE",
+        nodeId: "node-ask-phone",
+        nodeType: "ASK_SLOT",
+        prompt: "전화번호를 알려주세요.",
+      }),
+    );
+    expect(diff.operationLabel).toBe("워크플로우 노드 추가");
+    const nodeIdField = diff.fields.find((f) => f.label === "노드 ID");
+    expect(nodeIdField).toBeDefined();
+    expect(nodeIdField?.before).toBe("노드 없음");
+    expect(nodeIdField?.after).toBe("node-ask-phone");
+    const nodeTypeField = diff.fields.find((f) => f.label === "노드 타입");
+    expect(nodeTypeField?.after).toBe("ASK_SLOT");
+    const promptField = diff.fields.find((f) => f.label === "프롬프트");
+    expect(promptField?.after).toBe("전화번호를 알려주세요.");
+  });
+
+  it("UPDATE_TRANSITION은 from→to 전이 필드와 condition 필드를 포함한다", () => {
+    const diff = buildOperationDiff(
+      makeOp({
+        operationType: "UPDATE_TRANSITION",
+        kind: "WORKFLOW_TRANSITION",
+        from: "state_a",
+        to: "state_b",
+        condition: "slot.amount > 0",
+      }),
+    );
+    expect(diff.operationLabel).toBe("전이 수정");
+    const transitionField = diff.fields.find((f) => f.label === "전이");
+    expect(transitionField?.after).toBe("state_a → state_b");
+    const conditionField = diff.fields.find((f) => f.label === "조건");
+    expect(conditionField?.after).toBe("slot.amount > 0");
+  });
+
+  it("UPDATE_POLICY_CONDITION은 value를 after로 반영한다", () => {
+    const diff = buildOperationDiff(
+      makeOp({
+        operationType: "UPDATE_POLICY_CONDITION",
+        value: "amount >= 100",
+      }),
+    );
+    expect(diff.operationLabel).toBe("정책 조건 변경");
+    const field = diff.fields.find((f) => f.label === "정책 조건");
+    expect(field?.after).toBe("amount >= 100");
+  });
+
+  it("UPDATE_RESPONSE_COPY는 value를 after로 반영한다", () => {
+    const diff = buildOperationDiff(
+      makeOp({
+        operationType: "UPDATE_RESPONSE_COPY",
+        value: "주문을 확인했습니다.",
+      }),
+    );
+    expect(diff.operationLabel).toBe("응답 문구 변경");
+    const field = diff.fields.find((f) => f.label === "응답 문구");
+    expect(field?.after).toBe("주문을 확인했습니다.");
+  });
+
+  it("알 수 없는 operationType은 폴백 필드를 반환하고 라벨은 원문이다", () => {
+    const diff = buildOperationDiff(
+      makeOp({ operationType: "FOO_BAR", value: "someValue" }),
+    );
+    expect(diff.operationLabel).toBe("FOO_BAR");
+    expect(diff.fields.length).toBeGreaterThan(0);
+    const fallbackField = diff.fields[0];
+    expect(fallbackField.after).toBe("someValue");
+  });
+
+  it("targetComplete와 reason을 그대로 전달한다", () => {
+    const diff = buildOperationDiff(
+      makeOp({ targetComplete: false, reason: "근거 설명" }),
+    );
+    expect(diff.targetComplete).toBe(false);
+    expect(diff.reason).toBe("근거 설명");
+  });
+});
+
+// ---- buildStructuralPatchReview ----
+
+describe("buildStructuralPatchReview", () => {
+  describe('patchValidationStatus="VALID"', () => {
+    it("operations 2개를 diffs로 변환하고 kind=structural을 반환한다", () => {
+      const ops = [
+        makeOp({ operationType: "MARK_SLOT_REQUIRED", kind: "ELEMENT" }),
+        makeOp({ operationType: "UPDATE_RESPONSE_COPY", kind: "ELEMENT", value: "안녕하세요" }),
+      ];
+      const result = buildStructuralPatchReview(
+        makeCandidate({
+          patchValidationStatus: "VALID",
+          patchSummary: "슬롯 필수화 + 응답 수정",
+          operations: ops,
+        }),
+      );
+      expect(result.kind).toBe("structural");
+      expect(result.diffs).toHaveLength(2);
+      expect(result.summary).toBe("슬롯 필수화 + 응답 수정");
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it("WORKFLOW_NODE op 포함 시 hasWorkflowStructureChange=true다", () => {
+      const ops = [
+        makeOp({ operationType: "ADD_WORKFLOW_NODE", kind: "WORKFLOW_NODE" }),
+        makeOp({ operationType: "MARK_SLOT_REQUIRED", kind: "ELEMENT" }),
+      ];
+      const result = buildStructuralPatchReview(
+        makeCandidate({ patchValidationStatus: "VALID", operations: ops }),
+      );
+      expect(result.hasWorkflowStructureChange).toBe(true);
+    });
+
+    it("ELEMENT kind만 있을 때 hasWorkflowStructureChange=false다", () => {
+      const ops = [
+        makeOp({ operationType: "MARK_SLOT_REQUIRED", kind: "ELEMENT" }),
+        makeOp({ operationType: "UPDATE_RESPONSE_COPY", kind: "ELEMENT" }),
+      ];
+      const result = buildStructuralPatchReview(
+        makeCandidate({ patchValidationStatus: "VALID", operations: ops }),
+      );
+      expect(result.hasWorkflowStructureChange).toBe(false);
+    });
+  });
+
+  it('patchValidationStatus="LEGACY"는 kind=legacy, diffs 빈 배열을 반환한다', () => {
+    const result = buildStructuralPatchReview(
+      makeCandidate({
+        patchValidationStatus: "LEGACY",
+        operations: [makeOp()],
+      }),
+    );
+    expect(result.kind).toBe("legacy");
+    expect(result.diffs).toHaveLength(0);
+  });
+
+  it('patchValidationStatus="INVALID"는 kind=invalid, errors를 반환한다', () => {
+    const result = buildStructuralPatchReview(
+      makeCandidate({
+        patchValidationStatus: "INVALID",
+        patchValidationErrors: ["필드 A 누락", "필드 B 타입 오류"],
+        operations: [],
+      }),
+    );
+    expect(result.kind).toBe("invalid");
+    expect(result.errors).toEqual(["필드 A 누락", "필드 B 타입 오류"]);
+  });
+
+  it('patchValidationStatus="NONE"은 kind=missing을 반환한다', () => {
+    const result = buildStructuralPatchReview(
+      makeCandidate({ patchValidationStatus: "NONE" }),
+    );
+    expect(result.kind).toBe("missing");
+  });
+});
+
+// ---- evaluateApprovalGuardrail ----
+
+describe("evaluateApprovalGuardrail", () => {
+  function makeModel(
+    kind: "structural" | "legacy" | "invalid" | "missing",
+    overrides: {
+      diffs?: ReturnType<typeof buildOperationDiff>[];
+      errors?: string[];
+    } = {},
+  ) {
+    const diffs = overrides.diffs ?? [
+      buildOperationDiff(makeOp({ targetComplete: true })),
+    ];
+    return {
+      kind,
+      status: kind === "structural" ? ("VALID" as const) :
+              kind === "legacy" ? ("LEGACY" as const) :
+              kind === "invalid" ? ("INVALID" as const) :
+              ("NONE" as const),
+      summary: null,
+      hasWorkflowStructureChange: false,
+      diffs,
+      errors: overrides.errors ?? [],
+      message: null,
+    };
+  }
+
+  it("invalid 모델은 canApprove=false이고 disabledReasons이 비어있지 않다", () => {
+    const result = evaluateApprovalGuardrail(makeModel("invalid"), true);
+    expect(result.canApprove).toBe(false);
+    expect(result.disabledReasons.length).toBeGreaterThan(0);
+  });
+
+  it("missing 모델은 canApprove=false다", () => {
+    const result = evaluateApprovalGuardrail(makeModel("missing"), true);
+    expect(result.canApprove).toBe(false);
+    expect(result.disabledReasons.length).toBeGreaterThan(0);
+  });
+
+  it("structural + 모든 targetComplete=true + confirmed=false → canApprove=false, 구조 변경 검토 확인 사유", () => {
+    const result = evaluateApprovalGuardrail(makeModel("structural"), false);
+    expect(result.canApprove).toBe(false);
+    const reasons = result.disabledReasons.join(" ");
+    expect(reasons).toContain("구조 변경 검토 확인");
+  });
+
+  it("structural + 모든 targetComplete=true + confirmed=true → canApprove=true", () => {
+    const result = evaluateApprovalGuardrail(makeModel("structural"), true);
+    expect(result.canApprove).toBe(true);
+    expect(result.disabledReasons).toHaveLength(0);
+  });
+
+  it("structural + targetComplete=false인 op 포함 + confirmed=true → canApprove=false, 대상 확인 불가 사유", () => {
+    const diffs = [buildOperationDiff(makeOp({ targetComplete: false }))];
+    const result = evaluateApprovalGuardrail(makeModel("structural", { diffs }), true);
+    expect(result.canApprove).toBe(false);
+    const reasons = result.disabledReasons.join(" ");
+    expect(reasons).toContain("대상을 확인할 수 없는");
+  });
+
+  it("structural + operations 빈 배열 → canApprove=false", () => {
+    const result = evaluateApprovalGuardrail(makeModel("structural", { diffs: [] }), true);
+    expect(result.canApprove).toBe(false);
+  });
+
+  it("legacy + confirmed=true → canApprove=true", () => {
+    const result = evaluateApprovalGuardrail(makeModel("legacy"), true);
+    expect(result.canApprove).toBe(true);
+    expect(result.disabledReasons).toHaveLength(0);
+  });
+
+  it("legacy + confirmed=false → canApprove=false", () => {
+    const result = evaluateApprovalGuardrail(makeModel("legacy"), false);
+    expect(result.canApprove).toBe(false);
+  });
+});

--- a/frontend/src/pages/workspace/ui/simulation/structuralPatchReview.ts
+++ b/frontend/src/pages/workspace/ui/simulation/structuralPatchReview.ts
@@ -1,0 +1,239 @@
+import type {
+  SimulationImprovementCandidate,
+  SimulationPatchOperationView,
+  SimulationPatchValidationStatus,
+} from "@/features/simulation";
+
+const OPERATION_TYPE_LABELS: Readonly<Record<string, string>> = {
+  MARK_SLOT_REQUIRED: "슬롯 필수화",
+  ADD_WORKFLOW_NODE: "워크플로우 노드 추가",
+  UPDATE_WORKFLOW_NODE: "워크플로우 노드 수정",
+  ADD_TRANSITION: "전이 추가",
+  UPDATE_TRANSITION: "전이 수정",
+  REMOVE_TRANSITION: "전이 삭제",
+  UPDATE_POLICY_CONDITION: "정책 조건 변경",
+  UPDATE_RESPONSE_COPY: "응답 문구 변경",
+  UPDATE_INTENT_DESCRIPTION: "인텐트 설명 변경",
+  ADD_INTENT_EXAMPLE: "인텐트 예시 추가",
+  UPDATE_SLOT_DESCRIPTION: "슬롯 설명 변경",
+  UPDATE_SLOT_VALIDATION: "슬롯 검증 변경",
+  UPDATE_RISK_TRIGGER: "리스크 트리거 변경",
+};
+
+export function operationTypeLabel(operationType: string): string {
+  return OPERATION_TYPE_LABELS[operationType] ?? operationType;
+}
+
+export function isWorkflowStructureOperation(op: SimulationPatchOperationView): boolean {
+  return op.kind === "WORKFLOW_NODE" || op.kind === "WORKFLOW_TRANSITION";
+}
+
+export interface PatchDiffField {
+  readonly label: string;
+  readonly before: string;
+  readonly after: string;
+}
+
+export interface PatchOperationDiff {
+  readonly operationType: string;
+  readonly operationLabel: string;
+  readonly kind: SimulationPatchOperationView["kind"];
+  readonly targetLabel: string;
+  readonly fields: readonly PatchDiffField[];
+  readonly reason: string | null;
+  readonly targetComplete: boolean;
+}
+
+function buildTargetLabel(op: SimulationPatchOperationView): string {
+  const reference = op.targetCode ?? (op.targetId !== null ? `#${op.targetId}` : null) ?? op.nodeId;
+  if (op.targetCategory && reference) return `${op.targetCategory} · ${reference}`;
+  if (op.targetCategory) return op.targetCategory;
+  if (reference) return reference;
+  return "(대상 미상)";
+}
+
+function fallbackAfterValue(op: SimulationPatchOperationView): string {
+  return op.value ?? op.prompt ?? op.condition ?? "(상세 없음)";
+}
+
+function buildNodeFields(op: SimulationPatchOperationView, before: string): PatchDiffField[] {
+  const fields: PatchDiffField[] = [];
+  if (op.nodeId) fields.push({ label: "노드 ID", before, after: op.nodeId });
+  if (op.nodeType) fields.push({ label: "노드 타입", before, after: op.nodeType });
+  if (op.slotCode) fields.push({ label: "슬롯", before, after: op.slotCode });
+  if (op.prompt) fields.push({ label: "프롬프트", before, after: op.prompt });
+  if (fields.length === 0) {
+    fields.push({ label: "노드", before, after: fallbackAfterValue(op) });
+  }
+  return fields;
+}
+
+function buildTransitionFields(
+  op: SimulationPatchOperationView,
+  before: string,
+): PatchDiffField[] {
+  const transition = `${op.from ?? "(시작 미상)"} → ${op.to ?? "(종료 미상)"}`;
+  const fields: PatchDiffField[] = [{ label: "전이", before, after: transition }];
+  if (op.condition) {
+    fields.push({ label: "조건", before: "기존 조건", after: op.condition });
+  }
+  return fields;
+}
+
+function buildOperationFields(op: SimulationPatchOperationView): PatchDiffField[] {
+  switch (op.operationType) {
+    case "MARK_SLOT_REQUIRED":
+      return [{ label: "필수 여부", before: "선택 슬롯(필수 아님)", after: "필수 슬롯" }];
+    case "ADD_WORKFLOW_NODE":
+      return buildNodeFields(op, "노드 없음");
+    case "UPDATE_WORKFLOW_NODE":
+      return buildNodeFields(op, "기존 노드");
+    case "ADD_TRANSITION":
+      return buildTransitionFields(op, "전이 없음");
+    case "UPDATE_TRANSITION":
+      return buildTransitionFields(op, "기존 전이");
+    case "REMOVE_TRANSITION":
+      return buildTransitionFields(op, "기존 전이");
+    case "UPDATE_POLICY_CONDITION":
+      return [{ label: "정책 조건", before: "기존 조건", after: fallbackAfterValue(op) }];
+    case "UPDATE_RESPONSE_COPY":
+      return [{ label: "응답 문구", before: "기존 문구", after: fallbackAfterValue(op) }];
+    case "UPDATE_INTENT_DESCRIPTION":
+      return [{ label: "인텐트 설명", before: "현재 값", after: fallbackAfterValue(op) }];
+    case "ADD_INTENT_EXAMPLE":
+      return [{ label: "인텐트 예시", before: "현재 값", after: fallbackAfterValue(op) }];
+    case "UPDATE_SLOT_DESCRIPTION":
+      return [{ label: "슬롯 설명", before: "현재 값", after: fallbackAfterValue(op) }];
+    case "UPDATE_SLOT_VALIDATION":
+      return [{ label: "슬롯 검증", before: "현재 값", after: fallbackAfterValue(op) }];
+    case "UPDATE_RISK_TRIGGER":
+      return [{ label: "리스크 트리거", before: "현재 값", after: fallbackAfterValue(op) }];
+    default:
+      return [{ label: "변경", before: "현재 값", after: fallbackAfterValue(op) }];
+  }
+}
+
+export function buildOperationDiff(op: SimulationPatchOperationView): PatchOperationDiff {
+  return {
+    operationType: op.operationType,
+    operationLabel: operationTypeLabel(op.operationType),
+    kind: op.kind,
+    targetLabel: buildTargetLabel(op),
+    fields: buildOperationFields(op),
+    reason: op.reason,
+    targetComplete: op.targetComplete,
+  };
+}
+
+export type StructuralReviewKind = "structural" | "legacy" | "invalid" | "missing";
+
+export interface StructuralPatchReviewModel {
+  readonly kind: StructuralReviewKind;
+  readonly status: SimulationPatchValidationStatus;
+  readonly summary: string | null;
+  readonly hasWorkflowStructureChange: boolean;
+  readonly diffs: readonly PatchOperationDiff[];
+  readonly errors: readonly string[];
+  readonly message: string | null;
+}
+
+export function buildStructuralPatchReview(
+  candidate: SimulationImprovementCandidate,
+): StructuralPatchReviewModel {
+  const status = candidate.patchValidationStatus;
+  switch (status) {
+    case "VALID": {
+      const operations = candidate.operations;
+      return {
+        kind: "structural",
+        status,
+        summary: candidate.patchSummary,
+        hasWorkflowStructureChange: operations.some(isWorkflowStructureOperation),
+        diffs: operations.map(buildOperationDiff),
+        errors: [],
+        message: null,
+      };
+    }
+    case "LEGACY":
+      return {
+        kind: "legacy",
+        status,
+        summary: candidate.patchSummary,
+        hasWorkflowStructureChange: false,
+        diffs: [],
+        errors: [],
+        message: null,
+      };
+    case "INVALID":
+      return {
+        kind: "invalid",
+        status,
+        summary: candidate.patchSummary,
+        hasWorkflowStructureChange: false,
+        diffs: [],
+        errors: candidate.patchValidationErrors,
+        message: "패치 검증에 실패했습니다. 승인할 수 없습니다.",
+      };
+    case "NONE":
+    default:
+      return {
+        kind: "missing",
+        status,
+        summary: candidate.patchSummary,
+        hasWorkflowStructureChange: false,
+        diffs: [],
+        errors: [],
+        message: "draft patch 정보가 없습니다.",
+      };
+  }
+}
+
+export interface ApprovalGuardrail {
+  readonly canApprove: boolean;
+  readonly requiresStructuralConfirmation: boolean;
+  readonly disabledReasons: readonly string[];
+}
+
+export function evaluateApprovalGuardrail(
+  model: StructuralPatchReviewModel,
+  structuralConfirmed: boolean,
+): ApprovalGuardrail {
+  switch (model.kind) {
+    case "invalid":
+      return {
+        canApprove: false,
+        requiresStructuralConfirmation: false,
+        disabledReasons: ["패치 검증 실패"],
+      };
+    case "missing":
+      return {
+        canApprove: false,
+        requiresStructuralConfirmation: false,
+        disabledReasons: ["draft patch 없음"],
+      };
+    case "legacy":
+      return {
+        canApprove: structuralConfirmed,
+        requiresStructuralConfirmation: true,
+        disabledReasons: structuralConfirmed ? [] : ["변경 상세 확인이 필요합니다"],
+      };
+    case "structural":
+    default: {
+      const disabledReasons: string[] = [];
+      if (model.diffs.length === 0) {
+        disabledReasons.push("변경 작업이 없습니다");
+      }
+      if (model.diffs.some((diff) => !diff.targetComplete)) {
+        disabledReasons.push("대상을 확인할 수 없는 변경이 있습니다");
+      }
+      if (!structuralConfirmed) {
+        disabledReasons.push("구조 변경 검토 확인이 필요합니다");
+      }
+      return {
+        canApprove: disabledReasons.length === 0,
+        requiresStructuralConfirmation: true,
+        disabledReasons,
+      };
+    }
+  }
+}

--- a/frontend/src/pages/workspace/ui/simulation/workspace-simulation-page.module.css
+++ b/frontend/src/pages/workspace/ui/simulation/workspace-simulation-page.module.css
@@ -1112,6 +1112,199 @@
   line-height: 1.5;
 }
 
+.structuralBadgeGroup {
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.workflowStructureBadge {
+  border: 1px solid var(--ink);
+  border-radius: var(--r-pill);
+  background: var(--ink);
+  color: var(--paper);
+  font-size: 11px;
+  font-weight: 540;
+  line-height: 1;
+  padding: 5px 8px;
+  white-space: nowrap;
+}
+
+.evidencePanel {
+  display: grid;
+  gap: 4px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-2);
+  background: var(--paper);
+  padding: var(--s-2);
+}
+
+.evidencePanel > span {
+  color: var(--ink-3);
+  font-size: 10px;
+  font-weight: 540;
+  text-transform: uppercase;
+}
+
+.evidencePanel p {
+  margin: 0;
+  color: var(--ink-2);
+  font-size: 12px;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+
+.evidencePanel ul {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 10px;
+  margin: 2px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.evidencePanel li {
+  color: var(--ink-3);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.structuralDiffPanel {
+  display: grid;
+  gap: var(--s-2);
+}
+
+.diffOpCard {
+  display: grid;
+  gap: var(--s-2);
+  border: 1px solid var(--line);
+  border-radius: var(--r-2);
+  background: var(--paper);
+  padding: var(--s-2);
+}
+
+.diffOpHeader {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 4px 8px;
+}
+
+.diffOpHeader strong {
+  color: var(--ink);
+  font-size: 12px;
+  font-weight: 540;
+}
+
+.diffOpHeader span {
+  color: var(--ink-3);
+  font-size: 11px;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.diffTargetWarning {
+  margin: 0;
+  color: var(--ink);
+  font-size: 11px;
+  font-weight: 540;
+  line-height: 1.4;
+}
+
+.diffBeforeAfter {
+  display: grid;
+  gap: 4px;
+}
+
+.diffReason {
+  display: grid;
+  gap: 2px;
+  margin: 0;
+  color: var(--ink-2);
+  font-size: 11px;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+
+.diffReason span {
+  color: var(--ink-3);
+  font-size: 10px;
+  font-weight: 540;
+  text-transform: uppercase;
+}
+
+.guardrailChecklist {
+  display: grid;
+  gap: var(--s-2);
+  border: 1px solid var(--line);
+  border-radius: var(--r-2);
+  background: var(--paper-2);
+  padding: var(--s-2);
+}
+
+.guardrailChecklist label {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  color: var(--ink);
+  font-size: 12px;
+  font-weight: 540;
+  line-height: 1.4;
+  cursor: pointer;
+}
+
+.guardrailChecklist input {
+  margin-top: 2px;
+  flex: 0 0 auto;
+}
+
+.guardrailChecklist ul {
+  display: grid;
+  gap: 3px;
+  margin: 0;
+  padding-left: 16px;
+}
+
+.guardrailChecklist li {
+  color: var(--ink-3);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.validationErrorList {
+  display: grid;
+  gap: 3px;
+  margin: 0;
+  padding-left: 16px;
+}
+
+.validationErrorList li {
+  color: var(--ink);
+  font-size: 12px;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+
+.approvedReplayCta {
+  display: grid;
+  gap: var(--s-2);
+  border: 1px solid var(--ink);
+  border-radius: var(--r-2);
+  background: var(--paper);
+  padding: var(--s-2);
+}
+
+.approvedReplayCta p {
+  margin: 0;
+  color: var(--ink);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
 @media (max-width: 1180px) {
   .createPanel,
   .labGrid {


### PR DESCRIPTION
## 개요

Closes #882

운영자가 LLM이 제안한 `simulation-structural-patch.v1` 구조 패치를 원본 JSON이 아닌 **도메인 용어 diff**로 검토하고 안전하게 승인/반려할 수 있는 신뢰 계층 UI를 추가한다. #880(생성)·#881(적용) 위에 올라가는 검토 표면이며, 패치 생성·적용·그래프 편집기는 범위 밖이다.

## 백엔드 (read-side 정규화)

- 후보 응답에 `patchSchemaVersion` / `patchSummary` / `patchValidationStatus` / `patchValidationErrors` / `operations` 추가
- `SimulationCandidatePatchViewMapper`가 `draftPatchJson`을 분류하고(분류 순서: `NONE` → `LEGACY` → `VALID` → `INVALID`) operation을 정규화하며 op별 `targetComplete`를 계산. list·detail 동일 경로로 회귀 방지
- `approve` 경로에서 `INVALID` 구조 패치를 schema-integrity 게이트로 거부(stale/forged client 방어). DB target resolution·apply는 하지 않음

## 프론트엔드 (검토 UI)

- operation별 before/after diff: 슬롯 필수화·워크플로우 노드 추가·전이 변경·정책 조건 변경·응답 문구 변경 + 그 외 op 폴백
- 근거 패널, raw JSON은 `<details>` 보조 표면화
- 승인 가드레일: 검증 통과 + 모든 op 대상 확정 + 명시적 "구조 변경 검토 완료" 확인. 무효/모호 패치는 승인 비활성화 + 사유 표시
- "워크플로우 구조 변경" 뱃지, generated/review/approved/applied 상태 구분, 승인 전 미적용 문구
- 승인 후 적용된 draft 버전 id 표시 + 골든 케이스 리플레이 유도(미적용 시 "응답 대기" 구분)
- 레거시 설명형 패치는 기존 UI로 계속 가독

## 검증

- 백엔드: `./gradlew test --tests "*SimulationImprovementCandidate*" --tests "*SimulationCandidatePatchViewMapper*"` → BUILD SUCCESSFUL (mapper 25 + service 52)
- 프론트: `tsc -b --noEmit` 에러 0 · `vp test src/pages/workspace/ui` 10 files / 120 tests passed · `audit:api`·`audit:fsd` 통과

## 비고

- parser가 식별자 누락 op를 거부하므로 VALID 패치 op는 항상 `targetComplete=true` — `false` 차단 경로는 프론트 로직 단위 테스트로 검증
- 생성 실패 envelope(`simulation-structural-patch-generation.v1`)는 `INVALID`로 분류되어 승인 거부됨(의도된 안전 동작)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 구조적 도메인 패치 검토 UI 추가 — 검증 상태 배지, 연산별 Before/After diff, 워크플로우 구조 변경 뱃지, 원본 JSON 보조 노출, 적용 버전 리플레이 CTA
  * 승인 가드레일: 검증 통과 및 명시적 구조 변경 확인 필요, 무효/모호 패치는 승인 비활성화 및 사유 표시

* **개선**
  * 후보 응답에 패치 메타데이터·검증 결과·정규화된 연산 목록 포함
  * UI 스타일·테스트 보강으로 리뷰 신뢰성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->