### PR TITLE
fix(dashboard): #922 자동화 커버리지 추이 막대를 workflow 매칭률 기준으로 표시

### DIFF
--- a/.agent/specs/922.md
+++ b/.agent/specs/922.md
@@ -1,0 +1,57 @@
+# #922 자동화 커버리지 추이 그래프와 수치 불일치 수정
+
+## 배경 / 문제
+
+워크스페이스 대시보드의 자동화 커버리지 패널(`AutomationCoveragePanel`) 하단
+"기간별 커버리지 추이" 그래프에서 막대 길이와 우측 수치가 서로 다른 지표를 표현함(이슈 #922).
+
+- 막대 너비: `point.totalConsultationCount / maxTrendTotal` — 기간 내 최대 상담 건수 대비 **상담 건수 비율**
+- 우측 수치: `point.workflowMatchRate` — **workflow 매칭률(%)**
+
+그 결과 첨부 스크린샷처럼 18.2%인 날의 막대가 50.0%인 날보다 길게 그려져,
+그래프가 수치를 표현하지 않는 것처럼 보인다. 또한 `workflowMatchRate`가 `null`인 날(수치 `--`)에도
+`Math.max(4, ...)` 최소 너비 때문에 막대 sliver가 항상 표시된다.
+
+## 원인 분석
+
+`frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx`의 `AutomationCoveragePanel`:
+
+```tsx
+const maxTrendTotal = Math.max(1, ...trend.map((point) => point.totalConsultationCount));
+// ...
+const width = `${Math.max(4, (point.totalConsultationCount / maxTrendTotal) * 100)}%`;
+// ...
+<strong>{formatPercent(point.workflowMatchRate, state)}</strong>
+```
+
+막대는 건수 기반, 라벨은 비율 기반으로 한 행에서 서로 다른 지표를 그린다.
+
+## 해결 방안
+
+이슈가 제시한 두 방안(그래프를 퍼센티지로 / 수치를 건수로) 중 **그래프가 퍼센티지를 나타내도록** 수정한다.
+패널 제목이 "기간별 커버리지 추이"이고 카드 지표들도 매칭률 중심이므로, 행의 단일 지표는
+`workflowMatchRate`가 의미상 맞다. 상담 건수 절대량은 상단 "총 상담" KPI 카드에서 이미 제공된다.
+
+- 막대 너비 = `workflowMatchRate`(0–100 스케일)를 그대로 % 너비로 사용
+- `workflowMatchRate`가 `null`이거나 `0`이면 막대를 그리지 않음(너비 0) — 수치 `--`/`0.0%`와 일치
+- 양수일 때는 시인성을 위해 기존 최소 너비 4%를 유지하고 100%로 클램프
+- `maxTrendTotal` 계산 제거
+
+## 변경 파일
+
+- `frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx`
+  - 추이 막대 너비를 `totalConsultationCount` 비율 → `workflowMatchRate` 기반으로 변경
+- `frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx`
+  - 막대 너비가 매칭률을 반영하는지, `null`/`0` 매칭률에서 막대가 비는지 회귀 테스트 추가
+
+## 검증 (Acceptance)
+
+- 추이 행의 막대 너비(%)가 같은 행의 `workflowMatchRate` 수치와 일치한다 (매칭률 65% → 너비 65%)
+- `workflowMatchRate`가 `null`인 날은 수치 `--` + 빈 막대로 표시된다
+- 추이 데이터가 없으면 기존 빈 상태 문구("기간별 커버리지 추이가 없습니다.")가 유지된다
+- `pnpm test` 내 `WorkspaceDashboardPage` 테스트 통과
+
+## Non-goals
+
+- 백엔드 coverage trend 집계 로직 변경 없음 (`ConsultationCoverageTrendPoint` 계약 유지)
+- 추이 그래프에 상담 건수 시리즈를 별도로 추가하는 시각화 확장 없음

--- a/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { toast } from "sonner";
@@ -325,6 +325,47 @@ describe("WorkspaceDashboardPage", () => {
         to: "2026-06-03",
       }),
     );
+  });
+
+  it("커버리지 추이 막대는 상담 건수가 아니라 workflow 매칭률을 반영한다", async () => {
+    mockedGetMetrics.mockResolvedValueOnce({
+      ...metricsResponse,
+      coverage: {
+        ...metricsResponse.coverage,
+        trend: [
+          {
+            date: "2026-06-01",
+            totalConsultationCount: 80,
+            workflowMatchedCount: 52,
+            workflowMatchRate: 65,
+          },
+          {
+            date: "2026-06-02",
+            totalConsultationCount: 40,
+            workflowMatchedCount: 0,
+            workflowMatchRate: null,
+          },
+          {
+            date: "2026-06-03",
+            totalConsultationCount: 20,
+            workflowMatchedCount: 10,
+            workflowMatchRate: 50,
+          },
+        ],
+      },
+    });
+
+    renderPage();
+
+    const firstBar = await screen.findByTestId("coverage-trend-bar-2026-06-01");
+    expect(firstBar).toHaveStyle({ width: "65%" });
+    expect(screen.getByTestId("coverage-trend-bar-2026-06-02")).toHaveStyle({ width: "0%" });
+    expect(screen.getByTestId("coverage-trend-bar-2026-06-03")).toHaveStyle({ width: "50%" });
+
+    const trendPanel = screen.getByLabelText("기간별 커버리지 추이");
+    expect(within(trendPanel).getByText("65.0%")).toBeInTheDocument();
+    expect(within(trendPanel).getByText("--")).toBeInTheDocument();
+    expect(within(trendPanel).getByText("50.0%")).toBeInTheDocument();
   });
 
   it("평균 계산이 불가능한 지표와 전 기간 비교는 --로 표시한다", async () => {

--- a/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx
@@ -156,6 +156,12 @@ function formatPercent(value: MetricValue, state: DashboardDataState): string {
   return `${value.toFixed(1)}%`;
 }
 
+function trendBarWidth(rate: MetricValue): string {
+  if (typeof rate !== "number" || !Number.isFinite(rate) || rate <= 0) return "0%";
+  // 0보다 큰 매칭률은 최소 4% 너비로 시인성을 보장한다
+  return `${Math.min(100, Math.max(4, rate))}%`;
+}
+
 function hasMetricData(metrics: ConsultationMetrics | null): boolean {
   if (!metrics) return false;
   return (
@@ -355,7 +361,6 @@ function AutomationCoveragePanel({
           ? "계측 확인"
           : "--";
   const trend = coverage?.trend ?? [];
-  const maxTrendTotal = Math.max(1, ...trend.map((point) => point.totalConsultationCount));
 
   return (
     <section className={styles.coveragePanel} aria-labelledby="automation-coverage-title">
@@ -420,18 +425,18 @@ function AutomationCoveragePanel({
 
       <div className={styles.trendPanel} aria-label="기간별 커버리지 추이">
         {trend.length > 0 ? (
-          trend.map((point) => {
-            const width = `${Math.max(4, (point.totalConsultationCount / maxTrendTotal) * 100)}%`;
-            return (
-              <div key={point.date} className={styles.trendRow}>
-                <span>{point.date}</span>
-                <div className={styles.trendTrack} aria-hidden="true">
-                  <span style={{ width }} />
-                </div>
-                <strong>{formatPercent(point.workflowMatchRate, state)}</strong>
+          trend.map((point) => (
+            <div key={point.date} className={styles.trendRow}>
+              <span>{point.date}</span>
+              <div className={styles.trendTrack} aria-hidden="true">
+                <span
+                  data-testid={`coverage-trend-bar-${point.date}`}
+                  style={{ width: trendBarWidth(point.workflowMatchRate) }}
+                />
               </div>
-            );
-          })
+              <strong>{formatPercent(point.workflowMatchRate, state)}</strong>
+            </div>
+          ))
         ) : (
           <p className={styles.trendEmpty}>기간별 커버리지 추이가 없습니다.</p>
         )}


### PR DESCRIPTION
## 개요

Closes #922

자동화 커버리지 패널의 "기간별 커버리지 추이" 그래프에서 막대 길이와 우측 수치가 서로 다른 지표를 표현해 불일치하던 문제를 해결합니다.

## 원인

`AutomationCoveragePanel`의 추이 행에서 두 지표가 한 행에 섞여 있었습니다.

- 막대 너비: `totalConsultationCount / maxTrendTotal` — 기간 내 최대 상담 건수 대비 **건수 비율**
- 우측 수치: `workflowMatchRate` — **workflow 매칭률(%)**

그 결과 매칭률 18.2%인 날의 막대가 50.0%인 날보다 길게 그려졌고, 매칭률이 `null`인 날(수치 `--`)에도 `Math.max(4, ...)` 최소 너비 때문에 막대 sliver가 항상 표시됐습니다.

## 해결

이슈가 제시한 두 방안 중 **그래프가 퍼센티지를 나타내도록** 수정했습니다. 패널 제목이 "기간별 커버리지 추이"이고 카드 지표도 매칭률 중심이며, 상담 건수 절대량은 상단 "총 상담" KPI에서 이미 제공되기 때문입니다.

- 막대 너비 = `workflowMatchRate`(0–100)를 그대로 % 너비로 사용 → 수치와 항상 일치
- 매칭률이 `null` 또는 `0`이면 빈 막대 → `--`/`0.0%` 수치와 일치
- 양수 매칭률은 시인성을 위해 최소 4% 너비 유지, 100% 클램프

## Changed Files

| File | Change |
|---|---|
| `frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx` | 추이 막대 너비를 건수 비율 → `workflowMatchRate` 기반(`trendBarWidth`)으로 변경 |
| `frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx` | 막대가 매칭률을 반영하고 null/0 매칭률에서 비는지 회귀 테스트 추가 |
| `.agent/specs/922.md` | 이슈 스펙 |

## Verification

- `vp test run src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx`: 8 passed (회귀 테스트는 기존 공식이면 너비 100%/50%가 되어 실패함을 확인)
- frontend 전체: 295 files, 2,278 tests all pass (audit:api / audit:fsd 포함)
- `eslint` 변경 파일 통과, `vp fmt --check` 통과

셀프 리뷰 3회(이슈 충실도 / 아키텍처·FSD 경계 / 리뷰어·CI 관점) 수행, 잔여 발견 사항 없음. 양수 매칭률의 최소 4% 너비는 1–4% 구간을 약간 과장하지만 시인성 트레이드오프로 의도적으로 유지했습니다(코드 주석에 명시).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 자동화 커버리지 패널의 기간별 커버리지 추이 그래프에서 발생하던 데이터 불일치가 해결되었습니다. 그래프의 막대 너비가 표시되는 워크플로우 일치율 수치와 정확하게 일치하도록 수정되었으며, 데이터가 없거나 0일 때는 빈 상태로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->