### PR TITLE
fix(frontend): #901 로그인 시 기본 워크스페이스 대시보드로 리디렉션

### DIFF
--- a/.agent/specs/901.md
+++ b/.agent/specs/901.md
@@ -1,0 +1,63 @@
+# 901 · 로그인 시 대시보드로 리디렉션
+
+> Issue: 로그인시 대시보드로 리디렉션
+> Area: 프론트엔드 (FE). 인증 후 기본 목적지(post-login destination) 정렬 변경.
+
+---
+
+## Goal
+
+일반 사용자가 로그인에 성공하면 기본 워크스페이스의 **대시보드(`/workspaces/{id}/dashboard`)** 로 이동시킨다. 현재는 워크플로우 목록(`/workspaces/{id}/workflows`)으로 이동해, 워크스페이스 루트(`/workspaces`) 진입 시 대시보드로 가는 동작과 어긋난다.
+
+---
+
+## Problem
+
+- 직접 로그인 시 기본 목적지가 `/workspaces/{id}/workflows`로 계산된다 (`resolveDefaultWorkspaceDestination`).
+- 반면 워크스페이스 루트(`/workspaces`)는 이미 `/workspaces/{id}/dashboard`로 리디렉션한다 (`WorkspaceRootRedirect.tsx:45`).
+- 두 진입 경로의 착지점이 달라 사용자 경험이 일관되지 않다.
+
+---
+
+## Scope
+
+- 일반 사용자의 로그인 기본 목적지를 워크스페이스 대시보드로 변경한다.
+- `resolveAuthenticatedPostLoginDestination`이 기본 목적지를 산출하는 모든 경로(직접 로그인, 다른/이전 계정의 stale return-to 대체)에서 동일하게 대시보드로 향하도록 한다 — 둘 다 동일한 `resolveDefaultWorkspaceDestination`을 거치므로 한 곳 변경으로 정렬된다.
+
+## Non-goals
+
+- `return-to`(로그인 전 접근하려던 보호 페이지) 동작 변경. 본인 워크스페이스의 유효한 return-to는 그대로 유지한다.
+- SUPER_ADMIN(`/admin`) 및 워크스페이스 없음 fallback(`/workspaces`, `DEFAULT_POST_LOGIN_PATH`) 동작 변경.
+- 워크스페이스 마커 클릭 등 로그인 외 네비게이션(`WorkspaceMarker.tsx`) 동작 변경.
+- 대시보드 페이지 자체의 기능 변경.
+
+---
+
+## Affected modules (verified paths)
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `frontend/src/features/auth/model/resolveDefaultPostLoginDestination.ts` | edit | `resolveDefaultWorkspaceDestination`의 목적지 경로를 `/workflows` → `/dashboard`로 변경 |
+| `frontend/src/features/auth/model/resolveDefaultPostLoginDestination.test.ts` | edit | 기본 목적지/대체 목적지 기대값을 `/dashboard`로 갱신 |
+
+---
+
+## Requirements
+
+1. 기본 워크스페이스 id가 숫자이면 `resolveDefaultWorkspaceDestination`은 `/workspaces/{id}/dashboard`를 반환한다.
+2. id가 없거나 워크스페이스가 없으면 기존대로 `DEFAULT_POST_LOGIN_PATH`(`/workspaces`)를 반환한다.
+3. SUPER_ADMIN은 기존대로 `/admin`을 반환한다.
+4. 본인 워크스페이스의 유효한 return-to(`/workspaces/{id}/upload?...` 등)는 변경 없이 유지된다.
+5. 다른 계정/stale 워크스페이스 return-to는 현재 계정 기본 대시보드로 대체된다.
+
+---
+
+## Validation
+
+- `frontend` 디렉터리에서 `pnpm test`로 `resolveDefaultPostLoginDestination` 단위 테스트가 통과한다.
+- `pnpm build`(tsc 포함)로 타입 검사가 통과한다.
+- 수동: 일반 계정 로그인 후 `/workspaces/{id}/dashboard` 착지 확인, 워크스페이스 루트 진입과 동일한 착지점인지 확인.
+
+## Open questions
+
+- 없음. 기존 `WorkspaceRootRedirect`의 대시보드 정렬을 로그인 경로에도 적용하는 것으로 의도가 명확하다.

--- a/frontend/e2e/auth-login.spec.ts
+++ b/frontend/e2e/auth-login.spec.ts
@@ -64,6 +64,98 @@ async function fulfillJson(route: Route, body: unknown, status = 200) {
   });
 }
 
+function dashboardConsultationMetrics(workspaceId: number) {
+  return {
+    workspaceId,
+    periodStart: "2026-05-29T00:00:00+09:00",
+    periodEnd: "2026-06-04T09:00:00+09:00",
+    totalConsultationCount: 0,
+    completedConsultationCount: 0,
+    averageFirstResponseSeconds: null,
+    averageLlmFirstResponseSeconds: null,
+    averageHumanFirstResponseSeconds: null,
+    llmHandledCount: 0,
+    humanInterventionCount: 0,
+    unresolvedSessionCount: 0,
+    comparison: null,
+    coverage: {
+      workflowMatchedCount: 0,
+      workflowMatchRate: 0,
+      intentClassificationSuccessCount: 0,
+      intentClassificationSuccessRate: 0,
+      lowConfidenceCount: 0,
+      lowConfidenceRate: 0,
+      unmatchedSessionCount: 0,
+      autoCompletedWorkflowCount: 0,
+      humanHandoffRate: 0,
+      llmOnlyProcessingRate: 0,
+      measurementStatus: "INSUFFICIENT_DATA",
+      measurementMessage: "측정 데이터 없음",
+      trend: [],
+    },
+    handledTodayCount: 0,
+    llmHandledTodayCount: 0,
+    humanHandledTodayCount: 0,
+  };
+}
+
+function dashboardWorkflowRankings(workspaceId: number) {
+  return {
+    workspaceId,
+    periodStart: "2026-05-29T00:00:00+09:00",
+    periodEnd: "2026-06-04T09:00:00+09:00",
+    totalConsultationCount: 0,
+    rankings: [],
+    topRankings: [],
+  };
+}
+
+function dashboardActionRecommendations(workspaceId: number) {
+  return {
+    workspaceId,
+    periodStart: "2026-05-29T00:00:00+09:00",
+    periodEnd: "2026-06-04T09:00:00+09:00",
+    recommendations: [],
+  };
+}
+
+const dashboardKnowledgePackHealth = {
+  activeKnowledgePack: null,
+  lastLogUpload: null,
+  lastKnowledgePackGeneration: null,
+  pendingReviewCount: 0,
+  latestOpenReviewPipelineJobId: null,
+};
+
+async function fulfillDashboardMocks(
+  route: Route,
+  method: string,
+  path: string,
+  workspaceId: number,
+): Promise<boolean> {
+  if (method !== "GET") {
+    return false;
+  }
+  const prefix = `/workspaces/${workspaceId}`;
+  if (path === `${prefix}/consultation/metrics`) {
+    await fulfillJson(route, dashboardConsultationMetrics(workspaceId));
+    return true;
+  }
+  if (path === `${prefix}/dashboard/action-recommendations`) {
+    await fulfillJson(route, dashboardActionRecommendations(workspaceId));
+    return true;
+  }
+  if (path === `${prefix}/dashboard/workflow-rankings`) {
+    await fulfillJson(route, dashboardWorkflowRankings(workspaceId));
+    return true;
+  }
+  if (path === `${prefix}/dashboard/knowledge-pack-health`) {
+    await fulfillJson(route, dashboardKnowledgePackHealth);
+    return true;
+  }
+  return false;
+}
+
 async function installLoginApiMocks(
   page: Page,
   seen: string[],
@@ -114,6 +206,10 @@ async function installLoginApiMocks(
       return;
     }
 
+    if (await fulfillDashboardMocks(route, method, path, 1)) {
+      return;
+    }
+
     if (
       domainPackMode === "active" &&
       method === "GET" &&
@@ -156,9 +252,9 @@ test.describe("Login screen", () => {
         await page.getByLabel("비밀번호").fill("password123");
         await page.getByRole("button", { name: "시스템 로그인" }).click();
 
-        await expect(page).toHaveURL(/\/workspaces\/1\/workflows/);
+        await expect(page).toHaveURL(/\/workspaces\/1\/dashboard$/);
         await expect(
-          page.getByRole("heading", { name: "워크플로우", level: 1 }),
+          page.getByRole("heading", { name: "대시보드", exact: true }),
         ).toBeVisible();
         await expect
           .poll(() =>
@@ -171,12 +267,18 @@ test.describe("Login screen", () => {
         );
       });
 
-      test("Then an operator with an active domain pack lands on current workspace operations", async ({
+      test("Then an operator with an active domain pack lands on the workspace dashboard and can open operations", async ({
         page,
       }) => {
         const seen: string[] = [];
 
         await page.addInitScript(() => {
+          if (
+            window.sessionStorage.getItem("e2e-legacy-auth-seeded") === "true"
+          ) {
+            return;
+          }
+          window.sessionStorage.setItem("e2e-legacy-auth-seeded", "true");
           window.localStorage.setItem("accessToken", "legacy-access-token");
           window.localStorage.setItem("refreshToken", "legacy-refresh-token");
           window.localStorage.setItem(
@@ -196,10 +298,17 @@ test.describe("Login screen", () => {
         await page.getByLabel("비밀번호").fill("password123");
         await page.getByRole("button", { name: "시스템 로그인" }).click();
 
-        await expect(page).toHaveURL(/\/workspaces\/1\/workflows$/);
+        await expect(page).toHaveURL(/\/workspaces\/1\/dashboard$/);
         await expect(page.getByTestId("workspace-marker")).toContainText(
           "QA Workspace",
         );
+        await expect(
+          page.getByRole("heading", { name: "대시보드", exact: true }),
+        ).toBeVisible();
+
+        await page.goto("/workspaces/1/workflows");
+
+        await expect(page).toHaveURL(/\/workspaces\/1\/workflows$/);
         await expect(
           page.getByRole("heading", { name: "워크플로우", level: 1 }),
         ).toBeVisible();
@@ -331,17 +440,7 @@ test.describe("Login screen", () => {
             return;
           }
 
-          if (
-            method === "GET" &&
-            path === "/workspaces/42/dashboard/knowledge-pack-health"
-          ) {
-            await fulfillJson(route, {
-              activeKnowledgePack: null,
-              lastLogUpload: null,
-              lastKnowledgePackGeneration: null,
-              pendingReviewCount: 0,
-              latestOpenReviewPipelineJobId: null,
-            });
+          if (await fulfillDashboardMocks(route, method, path, 42)) {
             return;
           }
 
@@ -388,6 +487,16 @@ test.describe("Login screen", () => {
         await page.getByLabel("이메일 주소").fill("operator@example.com");
         await page.getByLabel("비밀번호").fill("password123");
         await page.getByRole("button", { name: "시스템 로그인" }).click();
+
+        await expect(page).toHaveURL(/\/workspaces\/42\/dashboard$/);
+        await expect(page.getByTestId("workspace-marker")).toContainText(
+          "신규 상담팀",
+        );
+        await expect(
+          page.getByRole("heading", { name: "대시보드", exact: true }),
+        ).toBeVisible();
+
+        await page.goto("/workspaces/42/workflows");
 
         await expect(page).toHaveURL(/\/workspaces\/42\/workflows$/);
         await expect(page.getByTestId("workspace-marker")).toContainText(
@@ -627,6 +736,10 @@ test.describe("Login screen", () => {
             return;
           }
 
+          if (await fulfillDashboardMocks(route, method, path, 1)) {
+            return;
+          }
+
           await route.fulfill({
             status: 500,
             contentType: "application/json",
@@ -641,8 +754,8 @@ test.describe("Login screen", () => {
         await page.getByLabel("비밀번호").fill("password123");
         await page.getByRole("button", { name: "시스템 로그인" }).click();
 
-        await expect(page).toHaveURL(/\/workspaces\/1\/workflows$/);
-        await expect(page.getByRole("heading", { name: "워크플로우", level: 1 })).toBeVisible();
+        await expect(page).toHaveURL(/\/workspaces\/1\/dashboard$/);
+        await expect(page.getByRole("heading", { name: "대시보드", exact: true })).toBeVisible();
         await expect(page.getByTestId("workspace-marker")).toContainText("Current Workspace");
         await expect(page.getByText("이전 상담사")).toHaveCount(0);
         await expect(page.getByText("Legacy Workspace")).toHaveCount(0);

--- a/frontend/e2e/navigation.spec.ts
+++ b/frontend/e2e/navigation.spec.ts
@@ -607,7 +607,7 @@ test.describe("Application navigation boundaries", () => {
       await page.getByLabel("비밀번호").fill("password123");
       await page.getByRole("button", { name: "시스템 로그인" }).click();
 
-      await expect(page).toHaveURL(/\/workspaces\/2\/workflows$/);
+      await expect(page).toHaveURL(/\/workspaces\/2\/dashboard$/);
       await expect(page.getByTestId("workspace-marker")).toContainText("Current Account Workspace");
 
       await page.goBack();
@@ -619,7 +619,7 @@ test.describe("Application navigation boundaries", () => {
       expect(seen).toContain("current GET /workspaces/1");
 
       await page.goForward();
-      await expect(page).toHaveURL(/\/workspaces\/2\/workflows$/);
+      await expect(page).toHaveURL(/\/workspaces\/2\/dashboard$/);
       await expect(page.getByTestId("workspace-marker")).toContainText("Current Account Workspace");
 
       await page.goBack();
@@ -658,7 +658,7 @@ test.describe("Application navigation boundaries", () => {
       await page.getByRole("button", { name: "시스템 로그인" }).click();
 
       try {
-        await expect(page).toHaveURL(/\/workspaces\/2\/workflows$/);
+        await expect(page).toHaveURL(/\/workspaces\/2\/dashboard$/);
         await expect(
           page.getByText("워크스페이스 정보를 불러오는 중입니다."),
         ).toBeVisible();
@@ -680,7 +680,7 @@ test.describe("Application navigation boundaries", () => {
         "Current Account Workspace",
       );
       await expect(
-        page.getByRole("heading", { name: "워크플로우", level: 1 }),
+        page.getByRole("heading", { name: "대시보드", exact: true }),
       ).toBeVisible();
       await expect(page.getByText("Previous Account Workspace")).toHaveCount(0);
       await expect(page.getByText("Previous Account Pack")).toHaveCount(0);

--- a/frontend/src/features/auth/model/resolveDefaultPostLoginDestination.test.ts
+++ b/frontend/src/features/auth/model/resolveDefaultPostLoginDestination.test.ts
@@ -31,7 +31,7 @@ describe("resolveDefaultPostLoginDestination", () => {
     expect(mockedListWorkspaces).not.toHaveBeenCalled();
   });
 
-  it("ACTIVE 워크스페이스의 workflows 경로를 반환한다", async () => {
+  it("ACTIVE 워크스페이스의 dashboard 경로를 반환한다", async () => {
     mockedListWorkspaces.mockResolvedValueOnce(
       listResponse([
         { id: 1, name: "Archived", status: "ARCHIVED" },
@@ -39,7 +39,7 @@ describe("resolveDefaultPostLoginDestination", () => {
       ]),
     );
 
-    await expect(resolveDefaultPostLoginDestination()).resolves.toBe("/workspaces/2/workflows");
+    await expect(resolveDefaultPostLoginDestination()).resolves.toBe("/workspaces/2/dashboard");
   });
 
   it("워크스페이스가 없으면 /workspaces fallback을 반환한다", async () => {
@@ -93,7 +93,7 @@ describe("resolveDefaultPostLoginDestination", () => {
       resolveAuthenticatedPostLoginDestination({
         from: { pathname: "/workspaces/4/upload" },
       }),
-    ).resolves.toBe("/workspaces/7/workflows");
+    ).resolves.toBe("/workspaces/7/dashboard");
   });
 
   it("이전 계정 domain pack return-to는 현재 계정 기본 workspace로 대체한다", async () => {
@@ -105,7 +105,7 @@ describe("resolveDefaultPostLoginDestination", () => {
       resolveAuthenticatedPostLoginDestination({
         from: { pathname: "/workspaces/99/domain-packs", search: "?versionId=1" },
       }),
-    ).resolves.toBe("/workspaces/7/workflows");
+    ).resolves.toBe("/workspaces/7/dashboard");
   });
 
   it("workspace 루트 return-to는 현재 계정 workspace 목록 확인 뒤 유지한다", async () => {

--- a/frontend/src/features/auth/model/resolveDefaultPostLoginDestination.ts
+++ b/frontend/src/features/auth/model/resolveDefaultPostLoginDestination.ts
@@ -24,7 +24,7 @@ function resolveDefaultWorkspaceDestination(workspaces: readonly WorkspaceRespon
   const workspace = selectDefaultWorkspace(workspaces);
 
   return typeof workspace?.id === "number"
-    ? `/workspaces/${workspace.id}/workflows`
+    ? `/workspaces/${workspace.id}/dashboard`
     : DEFAULT_POST_LOGIN_PATH;
 }
 

--- a/frontend/src/features/auth/ui/login-form/LoginForm.test.tsx
+++ b/frontend/src/features/auth/ui/login-form/LoginForm.test.tsx
@@ -70,7 +70,7 @@ describe("LoginForm", () => {
     });
   });
 
-  it("return-to가 없으면 기본 워크스페이스 workflows 화면으로 바로 이동한다", async () => {
+  it("return-to가 없으면 기본 워크스페이스 dashboard 화면으로 바로 이동한다", async () => {
     mockedListWorkspaces.mockResolvedValueOnce(
       listResponse([
         { id: 1, name: "Archived", status: "ARCHIVED" },
@@ -83,7 +83,7 @@ describe("LoginForm", () => {
     await submitLoginForm();
 
     await waitFor(() => {
-      expect(screen.getByTestId("location")).toHaveTextContent("/workspaces/7/workflows");
+      expect(screen.getByTestId("location")).toHaveTextContent("/workspaces/7/dashboard");
     });
     expect(mockedListWorkspaces).toHaveBeenCalledTimes(1);
     expect(localStorage.getItem("refreshToken")).toBeNull();
@@ -142,7 +142,7 @@ describe("LoginForm", () => {
     await submitLoginForm();
 
     await waitFor(() => {
-      expect(screen.getByTestId("location")).toHaveTextContent("/workspaces/7/workflows");
+      expect(screen.getByTestId("location")).toHaveTextContent("/workspaces/7/dashboard");
     });
     expect(mockedListWorkspaces).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
## Summary

- **#901**: 일반 사용자가 로그인하면 워크플로우 목록(`/workspaces/{id}/workflows`)이 아니라 기본 워크스페이스 **대시보드**(`/workspaces/{id}/dashboard`)로 이동한다.
- 워크스페이스 루트(`/workspaces`) 진입 시 이미 대시보드로 리디렉션하는 기존 동작(`WorkspaceRootRedirect`)과 로그인 직접 진입 시의 착지점을 일치시킨다.
- 변경은 기본 목적지 산출 함수 한 곳(`resolveDefaultWorkspaceDestination`)에서 이루어지며, 직접 로그인과 타 계정/stale return-to 대체 경로가 모두 동일하게 대시보드로 정렬된다.

비변경(non-goals): SUPER_ADMIN(`/admin`), 워크스페이스 없음 fallback(`/workspaces`), 본인 워크스페이스의 유효한 return-to, 워크스페이스 마커 클릭 등 로그인 외 네비게이션은 그대로 유지.

## Changed Files

| File | Change |
|---|---|
| `frontend/src/features/auth/model/resolveDefaultPostLoginDestination.ts` | 기본 목적지 경로 `/workflows` → `/dashboard` |
| `frontend/src/features/auth/model/resolveDefaultPostLoginDestination.test.ts` | 기본/대체 목적지 기대값을 대시보드로 갱신 |
| `frontend/src/features/auth/ui/login-form/LoginForm.test.tsx` | 로그인 착지 단정을 대시보드로 갱신 |
| `frontend/e2e/auth-login.spec.ts` | 로그인 착지 단정을 대시보드로 변경, 대시보드 엔드포인트 모킹 추가, 워크플로우 화면 검증은 명시 이동으로 보존 |
| `frontend/e2e/navigation.spec.ts` | 로그인 착지/히스토리 복원 단정을 대시보드로 갱신 |
| `.agent/specs/901.md` | 스펙 추가 |

## Verification

- 단위 테스트: 295 files, 2277 tests 통과 (`pnpm --dir frontend exec vp test`)
- e2e: 91 tests 통과 (`pnpm --dir frontend exec playwright test`)
- 빌드: 통과 (`tsc -b && vp build`)
- lint(eslint) / FSD·API audit: 통과
- 자체 코드 리뷰 3회(이슈 충실성 / 아키텍처·통합 / 리뷰어·CI 관점) 수행. 로그인과 무관한 마커 클릭·명시 네비게이션의 `/workflows` 단정은 의도적으로 변경하지 않음.

> 참고: 워크플로우 화면 자체의 동작은 `e2e/workspace-core.spec.ts`에서 독립적으로 커버됩니다.