### PR TITLE
feat(simulation): #917 개선 후보 변경 전/후 표시를 피드백 출처와 세션 workflow 맥락이 드러나게 개선

### DIFF
--- a/.agent/specs/917.md
+++ b/.agent/specs/917.md
@@ -1,0 +1,68 @@
+# Spec: 시뮬레이션 피드백 → 개선 후보 "변경 전/변경 후" 출력 메시지 UX 개선 (#917)
+
+> Issue: https://github.com/ajou-2026-1-capstone-5/ostone/issues/917
+> Area: Frontend (workspace simulation page)
+
+---
+
+## Goal
+
+시뮬레이션 개선 후보 카드의 "변경 전/변경 후" 출력이 실제 데이터 출처(사용자가 입력한 피드백 설명·기대 응답/행동)와 세션 맥락(세션에 적용된 workflow 이름)을 명확히 구분해 표시하도록 개선해, 세션 workflow 이름이 "변경 전 값"으로 잘못 읽히는 혼동을 제거한다.
+
+## 문제 정의 (이슈 요약)
+
+- 이슈 #917은 "변경 전/변경 후 출력이 뒤바뀐 버그"로 의심되었으나, 조사 결과 **버그가 아님**이 확인됨.
+- 실제 동작: 후보 생성 시 프론트엔드가 `"{대상 라벨} 개선 후보 ({세션 workflow명} workflow 맥락): {피드백 설명}"` 형태의 문자열을 `beforeSummary`로 조립해 전송하고(`WorkspaceSimulationPage.tsx`의 `buildCandidateBeforeSummary`), 개선 후보 카드가 이를 `변경 전` 라벨로 그대로 출력한다.
+- 혼동 지점:
+  1. `변경 전` 항목 앞부분에 세션에 적용된 workflow 이름이 괄호로 붙어, 해당 workflow가 "변경 전 intent/값"인 것처럼 읽힘.
+  2. `변경 전`/`변경 후` 라벨 자체가 실제 내용(피드백 설명 / 기대 응답·행동 원문)과 어긋남 — 이슈 비고: "변경 전 후에 대한 내용이 단순히 우리가 입력했던 텍스트만 출력됨".
+- 사용자 지시: 해당 출력 메시지 부분의 UX 개선까지 포함해 진행.
+
+## Scope
+
+1. **후보 카드 라벨 정정** — 개선 후보 탭 카드의 `변경 전`/`변경 후` 라벨을 데이터 출처가 드러나는 라벨로 교체.
+   - `변경 전` → `현재 동작 (피드백 설명)`
+   - `변경 후` → `기대 동작 (기대 응답/행동)`
+2. **beforeSummary 생성 문구 재구성** — `buildCandidateBeforeSummary`가 만드는 문자열에서 모호한 `"{대상} 개선 후보 (... workflow 맥락):"` 접두어를 제거하고, 사용자 입력 설명을 본문으로, 세션 workflow 맥락을 명시적 문구로 뒤에 분리한다.
+   - workflow 맥락 있음: `"{description} (세션에 적용된 workflow: {workflowName})"`
+   - workflow 맥락 없음: `"{description}"`
+   - 대상 유형 정보는 이미 `targetElementType` 필드와 카드 헤더(`대상: ...`)에 표시되므로 문자열 접두어에서 중복 제거한다.
+3. **관련 테스트 갱신** — payload/라벨 기대값을 새 형식으로 갱신.
+
+## Non-Goals
+
+- 백엔드 변경 없음. `SimulationImprovementCandidateService.draftFrom`의 fallback(`beforeSummary` 미전달 시 `feedback.description`)은 새 형식과 의미적으로 일치하므로 그대로 둔다.
+- 이미 저장된 기존 후보의 `beforeSummary` 마이그레이션은 하지 않는다(표시 라벨 개선만 소급 적용됨).
+- Draft patch 검토 패널(`CandidatePatchReview`)의 필드 단위 Before/After 표시는 실제 patch 값 비교이므로 변경하지 않는다.
+- 피드백 작성 폼 자체(설명/기대 응답·행동 입력)는 변경하지 않는다.
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `frontend/src/pages/workspace/ui/WorkspaceSimulationPage.tsx` | edit | `buildCandidateBeforeSummary` 문구 재구성, 후보 카드 `변경 전/변경 후` dt 라벨 교체 |
+| `frontend/src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx` | edit | `beforeSummary` payload 기대값 갱신 (4곳 이상) |
+| `frontend/src/pages/workspace/ui/WorkspaceSimulationPage.candidates.test.tsx` | edit | `변경 전` 라벨 기대값을 새 라벨로 갱신 |
+
+## Data / API Impact
+
+- API 계약 변경 없음. `beforeSummary`/`afterSummary`는 기존과 동일하게 free-text(≤2000자)로 전송되며 생성 형식만 달라진다.
+- `CreateSimulationImprovementCandidateRequest` 2000자 제한: 새 형식은 기존 접두어보다 짧거나 비슷하므로 제한 위반 위험 없음.
+- review task payload(`payloadJson`)에 저장되는 `beforeSummary` 문자열 형식이 새 후보부터 달라진다. 소비처는 free-text로 표시만 하므로 호환 문제 없음.
+
+## Acceptance Criteria
+
+1. 개선 후보 카드에서 기존 `변경 전`/`변경 후` 라벨 대신 `현재 동작 (피드백 설명)`/`기대 동작 (기대 응답/행동)` 라벨이 표시된다.
+2. 새로 생성되는 후보의 `beforeSummary`는 피드백 설명 원문으로 시작하고, 세션 workflow 맥락이 있으면 `"(세션에 적용된 workflow: {이름})"` 문구가 뒤에 붙는다 — workflow 이름이 변경 전 값처럼 읽히는 접두어 형태가 아니어야 한다.
+3. workflow 맥락이 없는 세션에서는 `beforeSummary`가 피드백 설명 원문과 동일하다.
+4. `afterSummary`는 기존대로 기대 응답/행동 원문이다.
+5. 갱신된 vitest 스위트(WorkspaceSimulationPage 관련)가 통과한다.
+
+## Validation Plan
+
+- `cd frontend && pnpm vitest run src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx src/pages/workspace/ui/WorkspaceSimulationPage.candidates.test.tsx src/pages/workspace/ui/WorkspaceSimulationPage.qa-fixes.test.tsx`
+- `pnpm run lint:frontend` 또는 staged 파일 lint, `pnpm run format:frontend` 준수
+
+## Open Questions
+
+- 없음. 라벨 문구는 피드백 작성 폼의 기존 필드명("설명", "기대 응답/행동")과 정합하도록 선정했다.

--- a/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.candidates.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.candidates.test.tsx
@@ -126,7 +126,12 @@ describe("WorkspaceSimulationPage improvement candidates", () => {
     expect(screen.getAllByText("기타")).toHaveLength(1);
     expect(screen.getByText("CUSTOM")).toBeInTheDocument();
     expect(screen.getAllByText("초안").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("변경 전").length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText("현재 동작 (피드백 설명)").length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText("기대 동작 (기대 응답/행동)").length,
+    ).toBeGreaterThan(0);
     expect(screen.getAllByText("근거").length).toBeGreaterThan(0);
   });
 

--- a/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx
@@ -311,7 +311,7 @@ describe("WorkspaceSimulationPage", () => {
         expect.objectContaining({
           targetElementType: "SLOT",
           beforeSummary:
-            "Slot 개선 후보 (환불 처리 workflow 맥락): 주문번호를 묻지 않았습니다.",
+            "주문번호를 묻지 않았습니다. (세션에 적용된 workflow: 환불 처리)",
           afterSummary: "주문번호를 먼저 요청합니다.",
         }),
       );
@@ -402,7 +402,7 @@ describe("WorkspaceSimulationPage", () => {
         expect.objectContaining({
           targetElementType: "SLOT",
           beforeSummary:
-            "Slot 개선 후보 (환불 처리 workflow 맥락): 주문번호를 묻지 않았습니다.",
+            "주문번호를 묻지 않았습니다. (세션에 적용된 workflow: 환불 처리)",
           afterSummary: "주문번호를 먼저 요청합니다.",
         }),
       );
@@ -443,7 +443,7 @@ describe("WorkspaceSimulationPage", () => {
           targetElementId: 100,
           targetElementKey: "refund_workflow",
           beforeSummary:
-            "Workflow 개선 후보 (환불 처리 workflow 맥락): 주문번호를 묻지 않았습니다.",
+            "주문번호를 묻지 않았습니다. (세션에 적용된 workflow: 환불 처리)",
           afterSummary: "주문번호를 먼저 요청합니다.",
         }),
       );
@@ -471,7 +471,7 @@ describe("WorkspaceSimulationPage", () => {
         expect.objectContaining({
           targetElementType: "POLICY",
           beforeSummary:
-            "Policy 개선 후보 (환불 처리 workflow 맥락): 주문번호를 묻지 않았습니다.",
+            "주문번호를 묻지 않았습니다. (세션에 적용된 workflow: 환불 처리)",
         }),
       );
     });
@@ -560,7 +560,7 @@ describe("WorkspaceSimulationPage", () => {
         905,
         expect.objectContaining({
           targetElementType: "WORKFLOW",
-          beforeSummary: "Workflow 개선 후보: 주문번호를 묻지 않았습니다.",
+          beforeSummary: "주문번호를 묻지 않았습니다.",
         }),
       );
     });
@@ -571,6 +571,38 @@ describe("WorkspaceSimulationPage", () => {
         targetElementId: expect.any(Number),
       }),
     );
+  });
+
+  it("workflow 맥락 문구를 붙이면 2000자를 넘는 설명은 원문만 beforeSummary로 보낸다", async () => {
+    const longDescription = "가".repeat(2000);
+    mockedSimulationApi.listFeedback.mockResolvedValue({
+      content: [
+        {
+          ...feedbackWithType(908, "MISSING_SLOT_QUESTION"),
+          description: longDescription,
+        },
+      ],
+      page: 0,
+      size: 20,
+      totalElements: 1,
+      totalPages: 1,
+    });
+    renderPage();
+
+    await openFeedbackTab();
+    fireEvent.click(await screen.findByRole("button", { name: "후보" }));
+
+    await waitFor(() => {
+      expect(
+        mockedSimulationApi.createImprovementCandidate,
+      ).toHaveBeenCalledWith(
+        1,
+        908,
+        expect.objectContaining({
+          beforeSummary: longDescription,
+        }),
+      );
+    });
   });
 
   it("개선 후보 생성 후 목록 새로고침 실패는 생성 실패로 처리하지 않는다", async () => {

--- a/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.tsx
@@ -44,6 +44,7 @@ import type {
 import { parseRouteId } from "@/shared/lib/parseRouteId";
 import { ApiRequestError, selectApiList } from "@/shared/api";
 import { useListIntents } from "@/shared/api/generated/endpoints/intent-definition-controller/intent-definition-controller";
+import { createSimulationImprovementCandidateRequestBeforeSummaryMax } from "@/shared/api/generated/zod";
 import type { IntentDefinitionSummary } from "@/shared/api/generated/zod";
 import type { ShellContext } from "@/shared/ui/ostone/chrome";
 import { Button } from "@/shared/ui/button";
@@ -476,16 +477,20 @@ function candidateTargetElementLabel(
   return "세부 element 미선택";
 }
 
+const BEFORE_SUMMARY_MAX_LENGTH =
+  createSimulationImprovementCandidateRequestBeforeSummaryMax;
+
 function buildCandidateBeforeSummary(
   feedback: SimulationFeedback,
-  targetType: SimulationImprovementCandidateTargetType,
   workflowTarget: CandidateWorkflowTarget | null,
 ): string {
-  const targetLabel = candidateTargetTypeLabel(targetType);
-  const workflowLabel = workflowTarget
-    ? ` (${workflowTarget.workflowName} workflow 맥락)`
-    : "";
-  return `${targetLabel} 개선 후보${workflowLabel}: ${feedback.description}`;
+  if (!workflowTarget) {
+    return feedback.description;
+  }
+  const summary = `${feedback.description} (세션에 적용된 workflow: ${workflowTarget.workflowName})`;
+  return summary.length <= BEFORE_SUMMARY_MAX_LENGTH
+    ? summary
+    : feedback.description;
 }
 
 function buildCandidateTargetPayload(
@@ -496,11 +501,7 @@ function buildCandidateTargetPayload(
 ): CreateSimulationImprovementCandidatePayload {
   const payload: CreateSimulationImprovementCandidatePayload = {
     targetElementType: targetType,
-    beforeSummary: buildCandidateBeforeSummary(
-      feedback,
-      targetType,
-      workflowTarget,
-    ),
+    beforeSummary: buildCandidateBeforeSummary(feedback, workflowTarget),
     afterSummary: feedback.expectedBehavior,
   };
 
@@ -2496,11 +2497,11 @@ export function WorkspaceSimulationPage() {
                         </div>
                         <dl className={styles.candidateSummary}>
                           <div>
-                            <dt>변경 전</dt>
+                            <dt>현재 동작 (피드백 설명)</dt>
                             <dd>{candidate.beforeSummary}</dd>
                           </div>
                           <div>
-                            <dt>변경 후</dt>
+                            <dt>기대 동작 (기대 응답/행동)</dt>
                             <dd>{candidate.afterSummary}</dd>
                           </div>
                           <div>


### PR DESCRIPTION
## 개요

Closes #917

시뮬레이션 개선 후보 카드의 "변경 전 / 변경 후" 출력이 데이터 출처를 드러내지 않아 생기던 혼동을 해소합니다.

이슈에서 확인된 것처럼 출력 순서가 뒤바뀐 버그는 아니었고, 두 가지 UX 문제가 원인이었습니다.

- `변경 전` 텍스트가 `"{대상} 개선 후보 ({세션 workflow명} workflow 맥락): {피드백 설명}"` 형태로 조립되어, 세션에 적용된 workflow 이름이 "변경 전 intent/값"처럼 읽혔습니다.
- `변경 전`/`변경 후` 라벨이 실제 내용(사용자가 입력한 피드백 설명·기대 응답/행동 원문)과 어긋났습니다.

## 해결

- 후보 카드 라벨을 데이터 출처가 드러나게 교체: `변경 전` → `현재 동작 (피드백 설명)`, `변경 후` → `기대 동작 (기대 응답/행동)`. 피드백 작성 폼의 필드명("설명", "기대 응답/행동")과 일치합니다.
- `buildCandidateBeforeSummary`가 만드는 문자열을 재구성: 피드백 설명 원문을 본문으로 두고, 세션 workflow 맥락은 `"(세션에 적용된 workflow: {이름})"` 문구로 뒤에 분리. 대상 유형 접두어는 카드 헤더(`대상: ...`)·`targetElementType`과 중복이라 제거했습니다.
- 맥락 문구를 붙여 backend `beforeSummary` 2000자 제한(`@Size`)을 넘는 경우 설명 원문만 전송하도록 가드 추가 — 제한값은 생성된 zod 상수(`createSimulationImprovementCandidateRequestBeforeSummaryMax`)를 재사용합니다.

백엔드는 변경하지 않습니다. `beforeSummary` 미전달 시 백엔드 fallback이 이미 `feedback.description`이라 새 형식과 의미가 일치합니다. 기존에 저장된 후보의 문자열은 마이그레이션하지 않습니다(라벨 개선만 소급 적용).

## Changed Files

| File | Change |
|---|---|
| `frontend/src/pages/workspace/ui/WorkspaceSimulationPage.tsx` | `buildCandidateBeforeSummary` 문구 재구성 + 2000자 가드, 후보 카드 라벨 교체 |
| `frontend/src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx` | `beforeSummary` payload 기대값 갱신(5곳), 2000자 가드 회귀 테스트 추가 |
| `frontend/src/pages/workspace/ui/WorkspaceSimulationPage.candidates.test.tsx` | 새 라벨 표시 검증으로 갱신 |
| `.agent/specs/917.md` | 이슈 스펙 |

## Verification

- `vp test run src/pages/workspace/ui/`: 8 files, 88 tests pass
- frontend 전체 `vp test run`: 295 files, 2,279 tests pass
- `eslint` 변경 파일 통과, `audit:api` / `audit:fsd` 통과, `tsc -b` 통과
- `vp fmt`은 로컬 환경에서 vite.config.ts 로드 실패(ERR_UNKNOWN_FILE_EXTENSION)로 실행 불가 — main 체크아웃에서도 동일하게 재현되는 기존 환경 문제라, 변경 라인은 주변 코드 스타일(80컬럼 prettier 스타일)에 수동으로 맞췄습니다.

셀프 리뷰 3회(이슈 충실도 / 아키텍처·FSD 경계·계약 / 리뷰어·CI 관점) 수행. 라운드 2에서 2000자 매직 넘버를 생성된 zod 상수 재사용으로 교체했고, 잔여 발견 사항 없음. Intent revision diff 패널의 "변경 전/후"는 실제 전후 값 비교라 의도적으로 유지했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 개선 후보의 라벨 표시가 "변경 전/변경 후"에서 "현재 동작 (피드백 설명) / 기대 동작 (기대 응답/행동)"으로 업데이트되었습니다.
  * 개선 후보 설명에 세션의 workflow 맥락 정보가 추가되었습니다.

* **문서**
  * 개선 후보 UX 변경 사항에 대한 사양 문서가 추가되었습니다.

* **테스트**
  * 업데이트된 라벨과 workflow 맥락을 반영한 테스트 검증이 추가 및 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->