### PR TITLE
docs(readme): #852 ML 파이프라인 개선 과정 기록

### DIFF
--- a/.agent/specs/852.md
+++ b/.agent/specs/852.md
@@ -1,0 +1,54 @@
+# README ML 파이프라인 개선 과정 기록
+
+## Goal
+
+루트 `README.md`의 기술 구현 하이라이트에 ML 파이프라인이 어떤 근거와 시행착오를 거쳐 현재 구조로 개선됐는지 남긴다. 독자가 현재 파이프라인을 단순 구현 목록이 아니라 연구 기반 설계, 변형된 stage 구성, human-in-the-loop 보정 흐름, 향후 fine-tuning 검토 여지를 함께 가진 결과물로 이해하게 하는 것이 목적이다.
+
+## Background
+
+GitHub Issue #852는 README에 ML 파이프라인 개선 과정을 기록하도록 요청했다. 이슈 코멘트의 요구사항은 다음 네 가지다.
+
+1. IntentGPT: Few-Shot Intent Discovery with Large Language Models 기반 구현
+2. 변형 파이프라인
+3. Human in the loop 구현
+4. LLM fine-tuning이 더 효과적이었을 수 있다는 회고, 특히 human-in-the-loop가 가장 큰 상승분을 만들었다는 관찰
+
+## Scope
+
+- `README.md`의 `기술 구현 하이라이트` 영역에 ML 파이프라인 개선 과정 기록을 추가한다.
+- 기존 `8단계 생성 파이프라인`, `Intent Discovery 알고리듬`, `Workflow = 상태 기반 graph`, `평가 지표` 설명과 충돌하지 않도록 배치한다.
+- 문서 내용은 현재 저장소에서 확인 가능한 설계 문서와 README 흐름을 기준으로 작성한다.
+
+## Non-goals
+
+- ML 파이프라인 코드, DAG, artifact schema, benchmark fixture 변경
+- Backend, Frontend, DB schema, OpenAPI 계약 변경
+- 실제 실험 수치, 성능 지표, 논문 인용 상세 추가
+- `ml/README.md` 개발 실행 가이드 구조 변경
+
+## Affected Modules
+
+- Root documentation: `README.md`
+- Reference docs checked:
+  - `.agent/docs/architecture.md`
+  - `.agent/specs/2-1-1.md`
+  - `ml/README.md`
+
+## Requirements
+
+1. README는 IntentGPT 기반 출발점을 설명하되, 현재 구현을 논문 원형 그대로라고 과장하지 않는다.
+2. README는 상담 로그 기반 Domain Pack 생성 요구에 맞춰 pipeline이 8단계 artifact-driven 구조로 변형됐음을 설명한다.
+3. README는 AI 초안을 운영자가 검토, 수정, 승인하는 human-in-the-loop가 품질 보정의 핵심 축임을 설명한다.
+4. README는 LLM fine-tuning 가능성을 향후 검토 대상으로 남기되, 현재 프로젝트 범위에서 이미 구현된 human-in-the-loop 효과와 대조해 회고 형태로 표현한다.
+5. README는 기존 핵심 기능과 기술 구현 하이라이트의 서술 톤을 유지하고, 새 코드나 실행 절차가 추가된 것처럼 보이지 않게 한다.
+
+## Validation
+
+- `README.md`에 이슈 코멘트의 네 항목이 모두 추적 가능해야 한다.
+- `.agent/specs/852.md` 파일명이 이슈 번호만 포함해야 한다.
+- 문서 링크와 경로는 실제 존재하는 경로만 사용해야 한다.
+- Markdown 목차 자동 생성이 없는 현재 README 구조를 고려해, 새 subsection 추가가 기존 앵커 링크를 깨지 않아야 한다.
+
+## Open Questions
+
+- 구체적인 실험 수치나 fine-tuning 비교 결과는 이슈에 포함되지 않았다. 따라서 이번 변경은 정량 결과가 아니라 설계 회고와 개선 방향 기록에 한정한다.

--- a/README.md
+++ b/README.md
@@ -257,6 +257,16 @@ flowchart LR
 
 산출물은 intent cluster candidate / exemplar set / outlier set이다.
 
+### ML 파이프라인 개선 과정 기록
+
+초기 intent discovery 설계는 **IntentGPT: Few-Shot Intent Discovery with Large Language Models**의 접근에서 출발했다. 다만 이 프로젝트의 목표는 intent label을 한 번에 생성하는 데서 끝나지 않고, 상담 로그를 실행 가능한 Domain Pack으로 전환하는 것이므로 연구 아이디어를 그대로 옮기기보다 운영 산출물 중심으로 변형했다.
+
+현재 파이프라인은 few-shot LLM 기반 의도 발견을 `ingestion → preprocessing → representation → intent_discovery → flow_splitting → draft_generation → evaluation → publish_candidate` 흐름으로 확장한다. semantic cluster는 workflow entry point 단위로 다시 나뉘고, 최종 결과는 intent뿐 아니라 slot / policy / risk / workflow 초안과 평가 artifact까지 포함한다.
+
+가장 중요한 품질 보정 축은 **human-in-the-loop**다. 파이프라인이 만든 초안은 곧바로 publish되지 않고 운영자 검토 화면에서 수정, 승인, 반려를 거친다. 실제 개선 관점에서도 자동 clustering이나 prompt 조정만으로 끝내기보다 사람이 domain pack 초안을 보정하는 단계가 가장 큰 품질 상승분을 만든다는 판단을 반영했다.
+
+향후 같은 데이터를 충분히 축적한다면 LLM fine-tuning이 더 효과적인 경로가 될 수 있다. 다만 현재 구현은 fine-tuning 전제 없이도 상담 로그에서 운영 지식을 추출하고, review feedback을 통해 품질을 끌어올릴 수 있는 구조를 우선한다.
+
 ### Workflow = 상태 기반 graph
 
 workflow는 발화 트리가 아니라 **상태 기반 graph(state machine)**로 본다. START / ACTION / DECISION / HANDOFF / TERMINAL 노드와 전이 edge로 처리 흐름을 표현하며, runtime은 publish된 domain pack을 읽어 현재 대화 상태를 해석하고 다음 action을 결정한다.


### PR DESCRIPTION
## 개요

Closes #852

README의 기술 구현 하이라이트에서 ML 파이프라인 개선 과정을 별도로 확인할 수 있게 합니다. 이슈 코멘트의 네 가지 포인트인 IntentGPT 기반 출발점, Domain Pack 생성 요구에 맞춘 변형 파이프라인, human-in-the-loop 보정, fine-tuning 가능성 회고를 README 흐름 안에 정리했습니다.

## 변경 내용

- `README.md`의 Intent Discovery 설명 뒤에 `ML 파이프라인 개선 과정 기록` subsection을 추가했습니다.
- `.agent/specs/852.md`에 문서 변경 범위, non-goals, 검증 기준을 기록했습니다.
- 실제 실험 수치나 fine-tuning 비교 결과는 이슈에 포함되지 않아 정량 주장 없이 설계 회고로 한정했습니다.

## 검증

- `git diff --check`
- `pnpm exec prettier --check .agent/specs/852.md`
- 경로 확인: `README.md`, `.agent/docs/architecture.md`, `.agent/specs/2-1-1.md`, `ml/README.md`

셀프 리뷰 3회 수행: 이슈 충실도, 저장소 규칙·경로 참조, 리뷰어/CI 관점에서 확인했고 잔여 발견 사항은 없습니다. README 전체 Prettier 적용은 기존 표 정렬이 대량 변경되어 되돌렸고, 이번 PR은 이슈 관련 문서 diff만 포함합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * ML 파이프라인 개선 과정 기록 문서 추가
  * 파이프라인 확장 및 품질 보정 절차에 대한 설명 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->