### PR TITLE
fix(workflow-runtime): #853 시스템 프롬프트 plain text 응답 규칙 고정

### DIFF
--- a/.agent/specs/853.md
+++ b/.agent/specs/853.md
@@ -1,0 +1,75 @@
+# [fix/853] 시스템 프롬프트 보정
+
+> **Issue**: #853
+> **Bounded Context**: `workflow-runtime`
+> **Template**: `_TEMPLATE_BE.md`
+> **Branch**: `fix/853-system-prompt`
+> **Frontend Scope**: 없음. 이번 스펙은 backend LLM assistant system prompt 보정과 회귀 방지만 다룬다.
+
+---
+
+## Goal
+
+사용자-facing AI 채팅 응답이 markdown 문법을 포함하지 않고 순수 텍스트로 제공되도록 `workflow-runtime`의 production system prompt 제약을 명확히 유지한다.
+
+---
+
+## Problem
+
+#853은 본문과 댓글 없이 "시스템 프롬프트 보정"만 제공한다. 저장소 이력상 동일 영역의 최근 변경은 `backend/src/main/resources/application.yml`의 `app.ai.chat.system-prompt`에 사용자 응답 markdown 금지 규칙을 추가한 것이다.
+
+현재 `app.ai.chat.system-prompt`는 workflow tool 사용 순서, 내부 데이터 유출 방지, 한국어 응답 기본값을 정의한다. 이 prompt에서 사용자-facing 출력 형식을 고정하지 않으면 assistant 응답에 `**굵게**`, `# 제목`, backtick, bullet, numbered list 같은 markdown 문법이 그대로 노출될 수 있다.
+
+---
+
+## Scope
+
+| Area | Change |
+| --- | --- |
+| Backend config | `app.ai.chat.system-prompt`가 사용자-facing 응답에서 markdown 문법을 쓰지 말고 plain text만 반환하도록 유지한다. |
+| Backend test | production `application.yml`의 system prompt에 no-markdown/plain-text 규칙이 남아 있는지 회귀 테스트로 고정한다. |
+
+---
+
+## Non-goals
+
+- LLM provider, model, timeout, fallback 정책을 변경하지 않는다.
+- Spring AI tool calling 흐름이나 `WorkflowAssistantTools` 계약을 변경하지 않는다.
+- Frontend message rendering 스타일을 변경하지 않는다.
+- test profile의 축약 prompt를 production prompt와 동일하게 만들지 않는다.
+
+---
+
+## Affected Files
+
+| Path | Purpose |
+| --- | --- |
+| `backend/src/main/resources/application.yml` | production `app.ai.chat.system-prompt` 설정 |
+| `backend/src/test/java/com/init/workflowruntime/config/AiConfigTest.java` | AI config 및 prompt 회귀 테스트 |
+
+위 경로는 작성 시점에 저장소에서 존재를 확인했다.
+
+---
+
+## Acceptance Criteria
+
+- Production system prompt는 사용자-facing 응답에서 markdown 문법 사용을 금지한다.
+- Production system prompt는 plain text only 응답 제약을 포함한다.
+- 회귀 테스트는 production `application.yml`을 직접 읽어 해당 prompt 제약이 빠지면 실패한다.
+- API, DB schema, OpenAPI/generated frontend client 변경은 없다.
+
+---
+
+## Validation Plan
+
+| Command | Purpose |
+| --- | --- |
+| `cd backend && ./gradlew test --tests com.init.workflowruntime.config.AiConfigTest` | AI config 및 system prompt 회귀 테스트 |
+| `cd backend && ./gradlew spotlessCheck` | 변경된 Java 테스트 포맷 검증 |
+| `git diff --check` | whitespace 안전성 확인 |
+
+---
+
+## Open Questions
+
+- #853 본문과 댓글이 비어 있어 markdown 금지 외의 추가 prompt 보정 요구사항은 확인되지 않았다. 추가 요구가 생기면 별도 이슈나 후속 PR에서 다룬다.

--- a/backend/src/test/java/com/init/workflowruntime/config/AiConfigTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/config/AiConfigTest.java
@@ -5,11 +5,16 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadPoolExecutor;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.FileSystemResource;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @DisplayName("AiConfig")
@@ -87,5 +92,29 @@ class AiConfigTest {
     assertThatThrownBy(() -> new AiConfig(" "))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("systemPrompt must not be null or blank");
+  }
+
+  @Test
+  @DisplayName("production system prompt는 사용자 응답 markdown 생성을 금지한다")
+  void should_keepPlainTextResponseRule_when_configuringProductionSystemPrompt()
+      throws IOException {
+    String systemPrompt = productionSystemPrompt();
+
+    assertThat(systemPrompt)
+        .contains("14. Do not use markdown syntax")
+        .contains("numbered lists, or any other markdown formatting")
+        .contains("Plain text only.");
+  }
+
+  private String productionSystemPrompt() throws IOException {
+    YamlPropertySourceLoader loader = new YamlPropertySourceLoader();
+    List<PropertySource<?>> propertySources =
+        loader.load("application", new FileSystemResource("src/main/resources/application.yml"));
+    return propertySources.stream()
+        .map(propertySource -> propertySource.getProperty("app.ai.chat.system-prompt"))
+        .filter(String.class::isInstance)
+        .map(String.class::cast)
+        .findFirst()
+        .orElseThrow();
   }
 }


### PR DESCRIPTION
## 개요

Closes #853

본문과 댓글이 비어 있는 #853의 확인 가능한 요구사항은 "시스템 프롬프트 보정"입니다. 현재 main에는 #904를 통해 사용자-facing 응답에서 markdown 문법을 쓰지 않도록 하는 system prompt 규칙이 이미 반영되어 있으므로, 이번 변경은 해당 동작이 이후 설정 변경으로 빠지지 않도록 스펙과 회귀 테스트로 고정합니다.

## 변경 내용

- `.agent/specs/853.md`에 backend `workflow-runtime` system prompt 보정 범위, non-goals, 수용 기준, 검증 계획을 기록했습니다.
- `AiConfigTest`가 production `app.ai.chat.system-prompt` property를 직접 읽어 no-markdown/plain-text 규칙이 포함되어 있는지 검증합니다.
- API, DB schema, OpenAPI/generated frontend client, LLM provider 설정은 변경하지 않습니다.

## 품질 근거

- 확인한 패턴: `backend/src/main/resources/application.yml`의 `app.ai.chat.system-prompt`, `AiConfig`의 `defaultSystem(systemPrompt)` 구성, 기존 `AiConfigTest`, 최근 #904 prompt 변경, root `ci:backend`가 `cd backend`에서 Gradle을 실행하는 방식.
- 위험 표면: prompt 규칙 누락 회귀, test profile prompt와 production prompt 혼동, 불필요한 runtime/API 변경.
- 테스트는 raw YAML 문자열 검색이 아니라 Spring Boot `YamlPropertySourceLoader`로 production property를 읽도록 구성했습니다.

## 검증

- `docker run --rm -u "$(id -u):$(id -g)" -v "$PWD":/workspace -w /workspace/backend -e GRADLE_USER_HOME=/workspace/.gradle eclipse-temurin:21-jdk ./gradlew test --tests com.init.workflowruntime.config.AiConfigTest` → BUILD SUCCESSFUL
- `docker run --rm -u "$(id -u):$(id -g)" -v "$PWD":/workspace -w /workspace/backend -e GRADLE_USER_HOME=/workspace/.gradle eclipse-temurin:21-jdk ./gradlew spotlessCheck` → BUILD SUCCESSFUL
- `git diff --check` → 통과

참고: 로컬 호스트에는 Java 21 toolchain이 없어 동일 Gradle 명령을 직접 실행하면 toolchain 탐색에서 중단되어, 저장소 기존 검증 패턴과 동일하게 `eclipse-temurin:21-jdk` 컨테이너에서 실행했습니다.

## 셀프 리뷰

- Round 1, 이슈 충실도: #853에 명시된 범위를 prompt 보정으로 한정하고, 추가 요구사항 부재를 open question으로 남겼습니다. 발견 사항 없음.
- Round 2, 아키텍처/통합: backend config/test 범위만 변경하며 runtime flow, tool contract, API/schema를 건드리지 않는지 확인했습니다. 검증 계획에 실제 format check를 추가했습니다.
- Round 3, 리뷰어/CI 관점: 의도치 않은 파일, 경로 존재, brittle raw text assertion, 검증 주장 누락을 확인했습니다. raw YAML 검색 대신 property loader 기반 테스트로 보강했고 잔여 발견 사항은 없습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AI 채팅 응답에서 마크다운 문법이 노출되지 않도록 시스템 프롬프트 규칙을 강화했습니다. 모든 응답이 순수 텍스트 형식으로만 표시되어 사용자 경험이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->