### PR TITLE
chore(workspace-dashboard): #924 확인항목 수정 지표 로그 비율 기준으로 정정

### DIFF
--- a/backend/src/main/java/com/init/workspace/infrastructure/persistence/JdbcWorkspaceDashboardQueryAdapter.java
+++ b/backend/src/main/java/com/init/workspace/infrastructure/persistence/JdbcWorkspaceDashboardQueryAdapter.java
@@ -185,7 +185,9 @@ public class JdbcWorkspaceDashboardQueryAdapter implements WorkspaceDashboardQue
         """
         SELECT
           COUNT(dl.id) AS decision_log_count,
-          COALESCE(SUM(jsonb_array_length(dl.missing_slots_json)), 0) AS missing_slot_hit_count,
+          COUNT(dl.id) FILTER (
+            WHERE jsonb_array_length(dl.missing_slots_json) > 0
+          ) AS missing_slot_hit_count,
           COALESCE(SUM(jsonb_array_length(dl.risk_hits_json)), 0) AS risk_hit_count,
           COUNT(dl.id) FILTER (
             WHERE dl.confidence_score IS NOT NULL


### PR DESCRIPTION
## 문제
하나카드 계정 대시보드 추천 액션의 "확인항목 수정"(`MISSING_SLOT_HIGH`) 카드 수치가 비정상적으로 크게 표시됨 (#924).

## 원인
`missing_slot_hit_count` 집계가 `SUM(jsonb_array_length(missing_slots_json))`로, **누락 슬롯 항목 총 발생 수를 합산**하고 있었음.
반면 비율은 `missing_slot_hit_count / decision_log_count`(= 로그 수)로 계산해 **분자·분모 단위가 불일치**.
로그 하나에 누락 슬롯이 여러 개면 분자가 분모를 초과해 비율이 100%를 넘고, "건수"도 실제 로그 수보다 부풀려짐.

## 수정
`missing_slot_hit_count`를 **누락 슬롯이 1개 이상인 결정 로그 수**(`COUNT FILTER`)로 변경.

```sql
COUNT(dl.id) FILTER (
  WHERE jsonb_array_length(dl.missing_slots_json) > 0
) AS missing_slot_hit_count,
```

분자(누락 로그 수)와 분모(전체 결정 로그 수) 단위가 일치하여 비율이 0~100% 범위로 정상화됨.
`missing_slots_json`이 NULL인 로그는 `jsonb_array_length(NULL)`이 NULL이 되어 FILTER에서 제외 → "누락 없음"으로 올바르게 처리.

## 참고
- `risk_hit_count`에도 동일한 `SUM(jsonb_array_length(...))` 단위 불일치가 잠재되어 있으나, 본 이슈(#924) 범위 밖이라 별도 이슈/PR로 처리 예정.

Closes #924

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 누락된 슬롯 신호 계산 로직이 개선되었습니다. 누락된 슬롯이 존재하는 결정 기록의 카운트가 더욱 정확하게 집계됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->