### PR TITLE
chore(workspace-dashboard): #936 Risk hit 건수 지표 로그 수 기준으로 정정

### DIFF
--- a/backend/src/main/java/com/init/workspace/infrastructure/persistence/JdbcWorkspaceDashboardQueryAdapter.java
+++ b/backend/src/main/java/com/init/workspace/infrastructure/persistence/JdbcWorkspaceDashboardQueryAdapter.java
@@ -186,7 +186,9 @@ public class JdbcWorkspaceDashboardQueryAdapter implements WorkspaceDashboardQue
         SELECT
           COUNT(dl.id) AS decision_log_count,
           COALESCE(SUM(jsonb_array_length(dl.missing_slots_json)), 0) AS missing_slot_hit_count,
-          COALESCE(SUM(jsonb_array_length(dl.risk_hits_json)), 0) AS risk_hit_count,
+          COUNT(dl.id) FILTER (
+            WHERE jsonb_array_length(dl.risk_hits_json) > 0
+          ) AS risk_hit_count,
           COUNT(dl.id) FILTER (
             WHERE dl.confidence_score IS NOT NULL
               AND dl.confidence_score < :lowConfidenceThreshold


### PR DESCRIPTION
## 문제
대시보드 추천 액션 "주의 사항 검토"(`RISK_HIT_SURGE`) 카드의 "Risk hit: N건" 건수가 **risk hit가 발생한 로그 수가 아니라 risk hit 항목 총 발생 수**를 합산하고 있어, "건" 라벨과 의미가 불일치 (#936).

## 원인
`risk_hit_count` 집계가 `SUM(jsonb_array_length(risk_hits_json))`라, 로그 하나에 risk가 여러 개면 실제 로그 수보다 부풀려짐.
(증감률 `changeRate` 계산 자체는 분자·분모 동일 단위라 정상이나, 표시 "건수"의 의미가 어긋남.)

## 수정
`risk_hit_count`를 **risk hit가 1개 이상 발생한 결정 로그 수**(`COUNT FILTER`)로 변경.

```sql
COUNT(dl.id) FILTER (
  WHERE jsonb_array_length(dl.risk_hits_json) > 0
) AS risk_hit_count,
```

## 관련
- #924 / PR #935 (missing slot 동일 패턴 — 로그 수 기준 정정)

Closes #936

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **버그 수정**
  * 리스크 신호 대시보드의 리스크 히트 카운트 계산 로직을 개선하여 측정 정확도를 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->