### PR TITLE
fix(pipeline-review): #940 추천 도메인 중복 순위 오류 정정

### DIFF
--- a/frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.test.tsx
+++ b/frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.test.tsx
@@ -343,6 +343,52 @@ describe("PipelineReviewCheckpointCard", () => {
     ).toBeInTheDocument();
   });
 
+  it("ranks domain candidates by relative confidence so distinct scores never share a rank", () => {
+    mockedUseCheckpoint.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        pipelineJobId: 7,
+        pipelineStatus: "WAITING_DOMAIN_CONFIRMATION",
+        reviewKind: "DOMAIN_CONFIRMATION",
+        tasks: [
+          {
+            id: 101,
+            targetType: "DOMAIN_CANDIDATE",
+            status: "OPEN",
+            priority: "HIGH",
+            title: "카드 상담",
+            payload: { displayName: "카드 상담", confidence: 0.62 },
+          },
+          {
+            id: 102,
+            targetType: "DOMAIN_CANDIDATE",
+            status: "OPEN",
+            priority: "HIGH",
+            title: "대출 상담",
+            // 같은 임계 구간(0.5~0.8)이지만 confidence가 달라 순위가 갈려야 한다.
+            payload: { displayName: "대출 상담", confidence: 0.55 },
+          },
+          {
+            id: 103,
+            targetType: "DOMAIN_CANDIDATE",
+            status: "OPEN",
+            priority: "HIGH",
+            title: "보험 상담",
+            payload: { displayName: "보험 상담", confidence: 0.88 },
+          },
+        ],
+      },
+    } as never);
+
+    renderCard();
+
+    // 임계 구간이 아니라 상대 순위로 매겨지므로 세 후보가 1·2·3순위로 모두 구분된다.
+    expect(screen.getByText("1순위")).toBeInTheDocument();
+    expect(screen.getByText("2순위")).toBeInTheDocument();
+    expect(screen.getByText("3순위")).toBeInTheDocument();
+  });
+
   it("guides operators when the selected candidate has low confidence", () => {
     mockedUseCheckpoint.mockReturnValue({
       isLoading: false,

--- a/frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.tsx
+++ b/frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.tsx
@@ -89,6 +89,28 @@ export function PipelineReviewCheckpointCard({
     () => openTasks.map((task) => task.id),
     [openTasks],
   );
+  // confidence가 가까운 후보들이 같은 임계 구간에 묶여 같은 순위로 보이는 문제를 막기 위해
+  // 절대 임계값이 아니라 후보 간 상대 순위(높은 confidence가 1순위)로 순위를 매긴다.
+  // confidence가 동일한 후보만 같은 순위를 공유한다(dense ranking).
+  const domainRankByTaskId = useMemo(() => {
+    const ranked = openTasks
+      .filter((task) => typeof task.payload.confidence === "number")
+      .sort(
+        (a, b) => (b.payload.confidence ?? 0) - (a.payload.confidence ?? 0),
+      );
+    const rankByTaskId = new Map<string, number>();
+    let rank = 0;
+    let previousConfidence: number | undefined;
+    for (const task of ranked) {
+      const confidence = task.payload.confidence ?? 0;
+      if (previousConfidence === undefined || confidence !== previousConfidence) {
+        rank += 1;
+        previousConfidence = confidence;
+      }
+      rankByTaskId.set(task.id, rank);
+    }
+    return rankByTaskId;
+  }, [openTasks]);
   const domainSelectionKey =
     query.data?.reviewKind === "DOMAIN_CONFIRMATION"
       ? `${workspaceId}:${pipelineJobId}:${openTaskIds.join(",")}`
@@ -389,7 +411,7 @@ export function PipelineReviewCheckpointCard({
                   ) : (
                     task.payload.confidence !== undefined && (
                       <span className={styles.confidence}>
-                        {formatDomainConfidence(task.payload.confidence)}
+                        {formatDomainRank(domainRankByTaskId.get(task.id))}
                       </span>
                     )
                   )}
@@ -480,8 +502,8 @@ export function PipelineReviewCheckpointCard({
                 <div className={styles.termRow} aria-label="후보 신뢰도">
                   <span className={styles.term}>
                     후보 신뢰도{" "}
-                    {formatDomainConfidence(
-                      selectedDomainTask.payload.confidence,
+                    {formatDomainRank(
+                      domainRankByTaskId.get(selectedDomainTask.id),
                     )}
                   </span>
                 </div>
@@ -743,10 +765,9 @@ function questionScopeLabel(
   return `${decisionScope || "intent"} scope`;
 }
 
-function formatDomainConfidence(confidence: number): string {
-  if (confidence >= 0.8) return "1순위";
-  if (confidence >= 0.5) return "2순위";
-  return "3순위";
+function formatDomainRank(rank: number | undefined): string | null {
+  if (rank === undefined) return null;
+  return `${rank}순위`;
 }
 
 const LOW_CONFIDENCE_THRESHOLD = 0.5;


### PR DESCRIPTION
## 문제 (#940)
상담 도메인 확정 화면에서 추천 도메인 순위가 모두 달라야 하는데, 일부 후보가 같은 순위로 표시됨.
(순위 표시 이전, 정확도 퍼센티지로 보여줄 때는 전부 다른 값이었음)

## 원인
`formatDomainConfidence`가 confidence를 **고정 임계 구간**으로 순위를 매김:
- `>= 0.8` → 1순위
- `>= 0.5` → 2순위
- 그 외 → 3순위

→ confidence 값이 달라도 같은 구간에 들어가면(예: 0.62, 0.55) 같은 순위로 표시되어 중복 발생.

## 수정
- `domainRankByTaskId`(useMemo) 추가: 후보를 confidence 내림차순으로 정렬해 **상대 순위**를 부여. confidence가 정확히 같은 후보만 같은 순위를 공유하는 dense ranking → 값이 다르면 순위가 항상 갈림. (confidence 없는 fallback 후보는 순위에서 제외)
- `formatDomainConfidence` → `formatDomainRank(rank)`로 교체, 후보 카드 배지 / 선택된 후보 신뢰도 표시 두 곳을 순위 맵 기반으로 변경.

## 테스트
- 같은 임계 구간 안의 서로 다른 confidence(0.62 / 0.55 / 0.88) 후보 3개가 1·2·3순위로 모두 구분되는지 검증하는 회귀 테스트 추가.
- 기존 25개 테스트 전부 통과, tsc / ESLint 클린.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 도메인 후보 렌더링 순위 검증 테스트 추가

* **Bug Fixes**
  * 도메인 확인 화면에서 후보 표시를 신뢰도 값 기반에서 상대 순위 기반으로 변경하여 동일 신뢰도 구간에서도 순위가 명확하게 구분되도록 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->