### PR TITLE
chore(test): consultation 근거 로딩 E2E를 응답 게이트 방식으로 안정화

### DIFF
--- a/frontend/e2e/consultation.spec.ts
+++ b/frontend/e2e/consultation.spec.ts
@@ -7,17 +7,17 @@ import { installMockStomp } from "./support/mock-stomp";
 
 test.describe("Consultation screen", () => {
   let seen: string[];
-  let messageEvidenceDelayMs: number;
+  let messageEvidenceGate: Promise<void> | null;
   let shouldFailMessageEvidence: boolean;
 
   test.beforeEach(async ({ page }) => {
     seen = [];
-    messageEvidenceDelayMs = 0;
+    messageEvidenceGate = null;
     shouldFailMessageEvidence = false;
     await installAuth(page);
     await installMockStomp(page);
     await installConsultationApiMocks(page, seen, {
-      messageEvidenceDelayMs: () => messageEvidenceDelayMs,
+      messageEvidenceGate: () => messageEvidenceGate,
       shouldFailMessageEvidence: () => shouldFailMessageEvidence,
     });
   });
@@ -188,14 +188,21 @@ test.describe("Consultation screen", () => {
           },
         ] as const;
 
-        messageEvidenceDelayMs = 100;
+        // 응답을 게이트로 붙잡아 로딩 상태가 사라지기 전에 확인할 수 있게 한다.
+        let releaseMessageEvidence!: () => void;
+        messageEvidenceGate = new Promise((resolve) => {
+          releaseMessageEvidence = resolve;
+        });
 
-        for (const target of evidenceTargets) {
+        for (const [index, target] of evidenceTargets.entries()) {
           await openGeneratedConsultationMessage(page);
 
-          await expect(page.getByTestId("message-domain-loading")).toContainText(
-            "근거를 불러오는 중입니다",
-          );
+          if (index === 0) {
+            await expect(
+              page.getByTestId("message-domain-loading"),
+            ).toContainText("근거를 불러오는 중입니다");
+            releaseMessageEvidence();
+          }
           const evidencePanel = page.locator("aside").filter({ hasText: "확인 항목" });
           await expect(evidencePanel).toBeVisible();
           await expect(evidencePanel.getByText("응대 기준")).toBeVisible();

--- a/frontend/e2e/support/generated-api-mocks.ts
+++ b/frontend/e2e/support/generated-api-mocks.ts
@@ -209,7 +209,7 @@ export async function installDomainPackApiMocks(page: Page, seen: string[]) {
 }
 
 interface ConsultationApiMockOptions {
-  messageEvidenceDelayMs?: () => number;
+  messageEvidenceGate?: () => Promise<void> | null;
   shouldFailMessageEvidence?: () => boolean;
 }
 
@@ -369,9 +369,9 @@ export async function installConsultationApiMocks(
       method === "GET" &&
       path === "/consultation/sessions/601/messages/701/domain-pack-elements"
     ) {
-      const delayMs = options.messageEvidenceDelayMs?.() ?? 0;
-      if (delayMs > 0) {
-        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      const gate = options.messageEvidenceGate?.();
+      if (gate) {
+        await gate;
       }
 
       if (options.shouldFailMessageEvidence?.()) {


### PR DESCRIPTION
## 배경

main 푸시 CI([1a0ade7 run](https://github.com/ajou-2026-1-capstone-5/ostone/actions/runs/27256567429))에서 `frontend-e2e`가 실패했습니다.

- 실패 테스트: `e2e/consultation.spec.ts:167` — 도메인팩 근거 로딩 상태(`message-domain-loading`) 단언
- 머지된 커밋(#942)은 pipeline-review만 수정했고 consultation과 무관 → 테스트 자체의 타이밍 race

## 원인

mock 근거 응답을 `messageEvidenceDelayMs = 100`(100ms 타이머)으로 지연시킨 뒤 그 짧은 창 안에서 로딩 문구를 잡아야 했습니다. CI 러너 부하 시 로딩 창이 단언 전에 닫혀 3회 재시도 모두 동일하게 실패했습니다.

## 수정

- 타이머 지연(`messageEvidenceDelayMs`)을 Promise 게이트(`messageEvidenceGate`)로 교체
- 테스트가 로딩 상태를 확인한 뒤 게이트를 해제 → 로딩 창이 단언 완료까지 결정적으로 유지됨
- 로딩 단언은 첫 반복에서만 수행(이후 반복은 게이트가 이미 해제된 상태)

## 검증

- `pnpm e2e e2e/consultation.spec.ts` 8/8 통과
- 대상 테스트 `--repeat-each 3` 3/3 통과
- 변경 파일 eslint / tsc 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 상담 E2E 테스트의 메시지 도메인 근거 로딩 제어 메커니즘이 개선되었습니다. 더 정확한 비동기 흐름 제어를 통해 테스트 안정성이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->