### PR TITLE
docs(readme): #852 ML 파이프라인 개선 과정 문서 분리 및 피드백 루프 반영

### DIFF
--- a/.agent/docs/ml-pipeline-evolution.md
+++ b/.agent/docs/ml-pipeline-evolution.md
@@ -1,0 +1,123 @@
+# ML 파이프라인 개선 과정 기록
+
+## 1. 문서 목적
+
+이 문서는 intent discovery 파이프라인이 초기 설계에서 현재 구조에 이르기까지 **어떤 한계를 만나 무엇을 바꿨는지**를 기록한다. 결과물(8단계 파이프라인) 자체보다 그 결정의 근거를 남겨, 이후 같은 문제를 다시 논의할 때 출발점으로 쓰는 것이 목적이다.
+
+전체 시스템 아키텍처와 stage별 책임은 [`architecture.md`](architecture.md) 7장을 함께 참조한다. 본 문서는 "왜 이렇게 바뀌었는가"에 집중한다.
+
+---
+
+## 2. 출발점 — IntentGPT 기반 few-shot intent discovery
+
+초기 설계는 **IntentGPT: Few-Shot Intent Discovery with Large Language Models**의 접근에서 출발했다. 가져온 핵심 아이디어는 소량의 예시와 LLM의 의미 이해 능력으로 상담 발화 묶음에서 잠재 intent를 발견하고, 각 cluster를 대표하는 exemplar와 label 후보를 만드는 것이다.
+
+초기에는 이 구조만으로도 상담 로그의 반복 패턴을 어느 정도 추출할 수 있었다. 문제는 추출된 결과를 **그대로 운영 지식으로 쓸 수 없다**는 데서 드러났다.
+
+---
+
+## 3. 한계 — intent label만으로는 운영 지식이 되지 않는다
+
+few-shot LLM intent discovery를 실제 고객지원 운영 지식으로 쓰기에는 두 가지 한계가 분명했다.
+
+1. **label은 처리 절차를 담지 못한다.** intent label("카드 분실 신고")만으로는 상담사가 어떤 정보를 물어야 하는지(slot), 어떤 정책을 확인해야 하는지(policy), 어디서 사람에게 넘겨야 하는지(handoff)를 알 수 없다.
+2. **의미가 같아도 처리 흐름이 다르면 분리되어야 한다.** semantic similarity로는 한 덩어리로 묶이지만 실제 처리 절차가 다른 상담은, 서로 다른 workflow entry point로 나뉘어야 한다. label 기준 clustering은 이 경계를 만들지 못한다.
+
+이 두 한계가 이후 모든 설계 변경의 출발점이다.
+
+---
+
+## 4. 확장 — "절차"를 생성 기준에 넣은 8단계 파이프라인
+
+few-shot intent discovery를 끝단으로 두지 않고, 8개 stage로 확장했다. 각 stage는 독립 DAG 태스크이며 산출물(artifact)로 연결된다(구현: `ml/src/pipeline/stages/`).
+
+```
+ingestion → preprocessing → representation → intent_discovery
+  → flow_splitting → draft_generation → evaluation → publish_candidate
+```
+
+한계 3을 해소한 두 가지 핵심 설계 변경은 다음과 같다.
+
+**변경 A — `representation`/`flow_splitting`을 별도 stage로 분리.**
+3장의 한계 ②(같은 의미, 다른 절차)를 풀기 위한 결정이다.
+
+- `representation`(`stages/representation`, `preprocessing/flow_signature.py`)은 발화 텍스트만 보지 않고 상담자/고객 role과 대화 진행 순서를 반영한 semantic representation과 **flow signature**를 만든다.
+- `intent_discovery`(`stages/intent_discovery`)는 dense embedding + graph community detection으로 semantic 후보군을 만든다.
+- `flow_splitting`(`stages/flow_splitting`)은 그 후보군을 다시 **실제 처리 흐름 단위**로 나눈다.
+
+이 분리 덕분에 "무엇을 물었나"뿐 아니라 **"어떤 절차로 해결되나"**가 Domain Pack 생성의 1급 기준이 된다.
+
+**변경 B — `draft_generation`을 구조화 산출물로.**
+3장의 한계 ①(label≠운영 지식)을 풀기 위한 결정이다.
+
+`draft_generation`(`stages/draft_generation`)은 intent cluster를 단순 목록이 아니라 slot / policy / risk / **workflow graph** 초안으로 구조화한다(`knowledge_extraction.py`, `workflow_graph.py`). 예를 들어 "카드 분실 신고" cluster의 최종 산출물에는 본인 확인 slot, 분실/정지/해제 정책, 위험 신호, 그리고 START / ACTION / DECISION / HANDOFF / TERMINAL 노드로 이어지는 workflow가 함께 담긴다.
+
+마지막으로 `evaluation`이 품질을 게이팅하고(5장), `publish_candidate`(`stages/publish_candidate`)가 Spring Backend가 review 작업으로 이어받을 artifact 형태로 정리한다.
+
+---
+
+## 5. 평가 게이트 — 운영자에게 넘길 만한 초안인가
+
+`evaluation` stage(`stages/evaluation`)는 초안을 무조건 publish하지 않고, 세 지표로 "운영자가 검토할 만한 수준인지"를 판정한다. 임계값 미달 초안은 게이트에서 걸러지거나 review 우선순위가 낮게 제안된다(`gates.py`, `thresholds.py`, `metrics.py`).
+
+| 지표 | 의미 | 정의(요약) |
+| --- | --- | --- |
+| **mapping rate** | intent와 workflow가 정합하게 연결된 비율 | discovered intent code를 가진 workflow 수 / 전체 workflow 수 (`_mapping_rate`) |
+| **outlier rate** | 어떤 cluster에도 안정적으로 속하지 못한 발화 비율 | 낮을수록 군집 경계가 명확 |
+| **workflow separability** | 분리된 workflow들이 실제로 구분되는 정도 | 높을수록 `flow_splitting`의 경계가 유효 |
+
+추가로 `graph_validation.py`가 workflow graph의 구조 유효성(도달 불가 노드, 누락된 terminal 등)을 검증한다. 즉 평가는 단일 점수가 아니라 **품질 게이트 + review 우선순위 제안 + graph 구조 검증**의 묶음이다.
+
+---
+
+## 6. 가장 큰 품질 보정 축 — 검토 결과를 다시 학습으로 (구현된 피드백 루프)
+
+자동 clustering이나 prompt 조정만으로는 모든 경계를 안정적으로 잡기 어렵다. 상담 로그에는 암묵적 정책, 예외 처리, 조직별 표현 습관, 위험 상황의 handoff 기준이 섞여 있기 때문이다. 그래서 가장 큰 품질 상승분은 **human-in-the-loop**에서 나온다 — 다만 이것은 단순 QA가 아니라 **검토 결정을 다음 실행의 제약으로 되먹이는 closed-loop**로 구현돼 있다.
+
+```
+운영자 검토 결정 (review)
+   │  same_intent / separate / same_workflow / separate_workflow ...
+   ▼
+feedback_constraints  ──정규화──▶  must_link · cannot_link (intent)
+   │                                same_workflow · separate_workflow (workflow)
+   ▼
+intent_discovery clustering / flow_splitting 에 제약으로 재주입
+   │  (load_feedback_constraints_from_env → clustering(constraints=...))
+   ▼
+evaluation feedback_replay_diff  ──▶  피드백 반영 전후 품질 차이 측정
+   │
+   ▼
+feedback_candidate_generation  ──▶  경계가 모호한 지점을 골라
+                                    다음 검토 질문(INTENT_BOUNDARY /
+                                    WORKFLOW_BOUNDARY)으로 운영자에게 제시
+```
+
+구현 근거:
+
+- **검토 결정의 제약 변환** — `intent_discovery/feedback_constraints.py`가 backend가 emit한 review 결정을 `must_link`/`cannot_link`(intent), `same_workflow`/`separate_workflow`(workflow) constraint로 정규화한다.
+- **clustering에 재주입** — `intent_discovery/main.py`는 `load_feedback_constraints_from_env()`로 제약을 읽어 clustering에 `constraints=`로 전달하고, 적용 개수를 manifest(`feedbackConstraintCount`)에 남긴다. flow 경계 보정은 `flow_splitting/workflow_feedback.py`가 담당한다.
+- **효과 측정** — `evaluation/feedback_replay_diff.py`가 피드백 반영 전후의 결과 차이를 측정해, 검토가 실제로 품질을 바꿨는지 확인한다.
+- **능동적 질문 생성(active learning)** — `feedback_candidate_generation`은 경계가 모호한 후보를 골라 운영자에게 물을 boundary 질문(`INTENT_BOUNDARY`/`WORKFLOW_BOUNDARY`)을 자동 생성한다. 무작정 다 보여주지 않고, **결정이 가장 큰 영향을 주는 지점**에 검토 노력을 집중시킨다.
+
+핵심은 검토가 일회성 수정에서 끝나지 않고, **constraint로 정규화되어 다음 실행의 군집·분할 경계를 직접 바꾼다**는 점이다. intent 병합/분리, slot 필수 여부, policy 조건, workflow 전이 보정이 그대로 다음 파이프라인 실행의 입력이 된다.
+
+---
+
+## 7. 향후 — 검토 데이터 축적 후 fine-tuning
+
+6장의 closed-loop는 검토 결정을 **제약(constraint)**으로 되먹인다. 그 위에 쌓이는 검토 이력(반복 수정한 intent label, slot 정의, workflow 전이, 반려 사유)은 다음 단계의 학습 재료가 된다.
+
+같은 도메인의 검토 데이터가 충분히 축적되면 LLM **fine-tuning 또는 preference tuning**이 더 효과적인 경로가 될 수 있다. 다만 현재 구현은 처음부터 fine-tuning된 모델을 전제하지 않는다. 데이터가 적은 초기 단계에서는 "파이프라인이 후보를 만들고 → 사람이 검토로 품질을 끌어올리며 → 검토 결과가 제약으로 되먹여지고 → 그 이력이 다음 개선의 학습 재료가 되는" 구조가 더 현실적이라고 보았다. fine-tuning은 이 루프를 대체하는 것이 아니라, 데이터가 쌓인 뒤 루프 안의 후보 생성 품질을 끌어올리는 다음 단계다.
+
+---
+
+## 8. 결정 요약
+
+| 결정 | 한계/동기 | 변경 | 근거 모듈 |
+| --- | --- | --- | --- |
+| 절차를 생성 기준에 추가 | label은 처리 흐름을 못 담음 | `representation`·`flow_splitting` 분리, flow signature 도입 | `stages/representation`, `stages/flow_splitting` |
+| 구조화된 초안 생성 | label≠운영 지식 | slot/policy/risk/workflow graph로 구조화 | `stages/draft_generation` |
+| 게이트 기반 평가 | 모든 초안을 사람에게 넘길 수 없음 | mapping/outlier/separability + graph 검증 | `stages/evaluation` |
+| 검토를 제약으로 되먹임 | 자동화만으로 경계가 불안정 | must/cannot-link, same/separate-workflow 재주입 | `feedback_constraints.py`, `feedback_replay_diff.py` |
+| 능동적 검토 질문 | 검토 노력의 집중 필요 | boundary 질문 자동 생성 | `stages/feedback_candidate_generation` |
+| fine-tuning은 향후 | 초기 데이터 부족 | 루프로 데이터 축적 후 전환 | — (계획) |

--- a/README.md
+++ b/README.md
@@ -259,15 +259,15 @@ flowchart LR
 
 ### ML 파이프라인 개선 과정 기록
 
-초기 intent discovery 설계는 **IntentGPT: Few-Shot Intent Discovery with Large Language Models**의 접근에서 출발했다. 이 접근에서 가져온 핵심 아이디어는 소량의 예시와 LLM의 의미 이해 능력을 이용해 상담 발화 묶음에서 잠재 intent를 발견하고, 각 cluster를 대표하는 exemplar와 label 후보를 만드는 것이다. 초기에는 이 구조만으로도 상담 로그의 반복 패턴을 어느 정도 추출할 수 있었지만, 실제 고객지원 운영 지식으로 쓰기에는 두 가지 한계가 분명했다. 첫째, intent label만으로는 상담사가 어떤 정보를 물어야 하는지, 어떤 정책을 확인해야 하는지, 어디서 상담사에게 넘겨야 하는지 알 수 없다. 둘째, 같은 intent처럼 보이는 상담도 처리 절차가 다르면 다른 workflow entry point로 분리되어야 한다.
+intent discovery는 처음부터 8단계였던 것이 아니라, few-shot LLM 접근의 한계를 만나며 확장된 결과다. 핵심 결정만 요약하면 다음과 같다.
 
-그래서 현재 파이프라인은 few-shot LLM 기반 intent discovery를 그대로 끝단으로 두지 않고, `ingestion → preprocessing → representation → intent_discovery → flow_splitting → draft_generation → evaluation → publish_candidate` 흐름으로 확장했다. `representation` 단계에서는 발화 텍스트만 보지 않고 상담자/고객 role과 대화 진행 순서를 반영한 semantic representation, flow signature를 만든다. `intent_discovery` 단계는 semantic similarity 기반 후보군을 만들고, `flow_splitting` 단계는 이 후보군을 다시 실제 처리 흐름 단위로 나눈다. 이 변형 덕분에 "무엇을 물어봤는가"뿐 아니라 "어떤 절차로 해결되는가"가 Domain Pack 생성의 기준에 들어간다.
+- **출발점** — **IntentGPT: Few-Shot Intent Discovery with Large Language Models** 접근으로, 소량 예시 + LLM 의미 이해로 잠재 intent와 exemplar/label 후보를 발견했다.
+- **한계** — intent label만으로는 ① 상담사가 물어야 할 정보·정책·handoff 기준을 알 수 없고, ② 의미가 같아 보여도 처리 절차가 다르면 분리되지 않았다.
+- **확장** — `representation`(role·대화 순서 반영)과 `flow_splitting`(처리 흐름 단위 분할)을 더해 "무엇을 물었나"뿐 아니라 **"어떤 절차로 해결되나"**를 생성 기준에 넣었고, `draft_generation`에서 slot/policy/risk/workflow graph 초안으로 구조화했다.
+- **최대 품질 축** — **human-in-the-loop**, 그것도 단순 QA가 아닌 **closed-loop**. 운영자 검토 결정을 must/cannot-link·same/separate-workflow 제약으로 정규화해 다음 실행의 clustering·flow splitting에 재주입하고, 경계가 모호한 지점은 능동적으로 검토 질문을 생성한다.
+- **향후** — 검토 이력이 축적되면 fine-tuning/preference tuning으로 후보 생성 품질을 끌어올린다. 다만 루프를 대체하지 않고, 데이터가 쌓인 뒤의 다음 단계로 둔다.
 
-이후 `draft_generation`은 intent cluster를 단순 목록으로 저장하지 않고 slot / policy / risk / workflow graph 초안으로 구조화한다. 예를 들어 어떤 cluster가 "카드 분실 신고"로 묶였더라도, 최종 산출물에는 본인 확인에 필요한 slot, 분실/정지/해제 정책, 위험 신호, START / ACTION / DECISION / HANDOFF / TERMINAL 노드로 이어지는 workflow가 함께 포함되어야 한다. `evaluation`은 mapping rate, outlier rate, workflow separability를 기준으로 이 초안이 운영자가 검토할 만한 수준인지 판단하고, `publish_candidate`는 Spring Backend가 review 작업으로 이어받을 수 있는 artifact 형태로 정리한다.
-
-가장 중요한 품질 보정 축은 **human-in-the-loop**다. 파이프라인이 만든 초안은 곧바로 publish되지 않고 운영자 검토 화면에서 수정, 승인, 반려를 거친다. 이 단계는 단순한 QA가 아니라 자동 생성이 놓치기 쉬운 운영 맥락을 다시 주입하는 과정이다. 상담 로그에는 암묵적인 정책, 예외 처리, 조직별 표현 습관, 위험 상황에서의 handoff 기준이 섞여 있기 때문에, 자동 clustering이나 prompt 조정만으로 모든 경계를 안정적으로 잡기 어렵다. 실제 개선 관점에서도 사람이 Domain Pack 초안을 검토하며 intent 병합/분리, slot 필수 여부, policy 조건, workflow 전이를 보정하는 단계가 가장 큰 품질 상승분을 만든다는 판단을 반영했다.
-
-향후 같은 도메인의 검토 데이터가 충분히 축적된다면 LLM fine-tuning이 더 효과적인 경로가 될 수 있다. 특히 운영자가 반복적으로 수정한 intent label, slot 정의, workflow 전이, 반려 사유가 쌓이면 fine-tuning 또는 preference tuning 데이터로 전환할 수 있다. 다만 현재 구현은 처음부터 fine-tuning된 모델을 전제로 하지 않는다. 데이터가 적은 초기 단계에서는 파이프라인이 후보를 만들고, 사람이 검토로 품질을 끌어올리며, 그 검토 결과가 다시 다음 개선의 학습 재료가 되는 구조가 더 현실적이라고 보았다.
+> 한계 분석과 단계별 설계 근거의 전체 서술은 [`.agent/docs/ml-pipeline-evolution.md`](.agent/docs/ml-pipeline-evolution.md)를 참조한다.
 
 ### Workflow = 상태 기반 graph
 
@@ -301,7 +301,9 @@ workflow는 발화 트리가 아니라 **상태 기반 graph(state machine)**로
 ├── frontend/       # Vite + React FSD 웹 애플리케이션 (운영자 콘솔 · 채팅 데모)
 ├── ml/             # Python Pipeline (Airflow DAG 기반 도메인 팩 생성 계층)
 ├── infra/          # AWS 배포 인프라 (terraform · aws · postgres)
-└── .agent/docs/    # architecture · schema · deployment 문서
+├── .agent/specs/   # 기능별 SDD 스펙 문서 ({이슈번호}.md)
+├── .agent/rules/   # 기여·테스트·git 규칙
+└── .agent/docs/    # architecture · schema · deployment · ml-pipeline-evolution 문서
 ```
 
 | 모듈 | 설명 | README |
@@ -519,7 +521,7 @@ Backend는 `local` 프로필에서 springdoc 기반 OpenAPI 문서/Swagger UI를
   - `frontend`: `pnpm run deps:frontend && pnpm run ci:frontend`, mocked E2E는 별도 job에서 `pnpm run e2e:frontend`
   - `ml`: `pnpm run ci:ml`
 - **spec-check**: `feature/*`, `fix/*`, `spec/*` 브랜치는 `.agent/specs/{이슈번호}.md` 스펙 파일을 필수 검증한다.
-- **coverage baseline**: Backend line 90% / branch 70%, Frontend statements 80% / branches 70% / functions 75% / lines 80%, ML total 80%를 CI에서 강제한다. 장기 목표는 `.agent/rules/testing.md`의 70%+ 라인 커버리지와 새 코드 80% 기준이며, baseline은 coverage 개선 PR에서 점진적으로 상향한다. CI는 각 모듈의 coverage artifact를 업로드해 실패한 파일/영역을 확인할 수 있게 한다.
+- **coverage baseline**: 모듈별 현재 강제 기준은 Backend line 90% / branch 70%, Frontend statements 80% / branches 70% / functions 75% / lines 80%, ML total 80%다. `.agent/rules/testing.md`의 기준은 대상별로 다르다 — **전체 라인 70%+**, **도메인 로직 90%+**, **새 코드 80%+**(레거시 제외). 즉 모듈 baseline은 레거시 공백을 고려한 현재 강제선이고, coverage 개선 PR에서 위 대상별 목표를 향해 점진 상향한다. CI는 각 모듈의 coverage artifact를 업로드해 실패한 파일/영역을 확인할 수 있게 한다.
 - Backend의 빠른 로컬 테스트(`./gradlew test` 또는 `./gradlew testH2`)는 H2 인메모리(`jdbc:h2:mem:testdb`)를 사용하고 Liquibase를 비활성화한다.
 - Backend의 CI 재현 테스트(`./gradlew testPg`)는 PostgreSQL/pgvector DB에 연결하고 Liquibase를 활성화한 뒤 Hibernate `ddl-auto=validate`로 검증한다. 기본 로컬 연결값은 `jdbc:postgresql://localhost:5432/testdb`, `postgres/postgres`이며 `SPRING_DATASOURCE_URL`, `SPRING_DATASOURCE_USERNAME`, `SPRING_DATASOURCE_PASSWORD`로 덮어쓸 수 있다.
   CI basic에서는 checkstyle을 실행하지 않는다. checkstyle은 `pnpm run lint:backend`, frontend lint는 pre-commit과 `pnpm run lint:frontend`, ML ruff/mypy는 pre-commit과 `pnpm run quality:ml`에서 실행해 빠른 PR feedback과 포괄 검사를 분리한다.


### PR DESCRIPTION
## 개요

README의 "ML 파이프라인 개선 과정 기록"을 별도 문서 [`.agent/docs/ml-pipeline-evolution.md`](.agent/docs/ml-pipeline-evolution.md)로 분리하고, README 본문은 요약 불릿 + 링크로 압축한다. 분리한 문서는 실제 `ml/src/pipeline/stages/` 구현 및 평가 지표와 대조해 사실 정확성을 보강했다.

관련 이슈 맥락: #852

## 변경 사항

### 문서 분리
- 5문단 산문을 별도 문서로 이동, README는 5개 핵심 불릿 + 링크로 압축해 스캔 가능성 개선

### 분리 문서 보강 (코드 대조)
- **한계 ↔ 설계 변경 1:1 매핑** — label의 두 한계를 `representation`/`flow_splitting` 분리, `draft_generation` 구조화와 직접 연결
- **평가 게이트 지표 정의** — mapping / outlier / separability + `graph_validation` 구조 검증을 표로 명시 (`_mapping_rate` 실제 공식 반영)
- **피드백 closed-loop를 구현에 맞춰 서술** — 기존 문서는 "단순 검토 + 향후 fine-tuning"으로 과소 서술했으나, 실제로는 검토 결정을 `must_link`/`cannot_link`·`same_workflow`/`separate_workflow` 제약으로 정규화해 다음 실행의 clustering·flow splitting에 재주입하는 closed-loop가 구현돼 있어 이를 반영 (`feedback_constraints.py`, `feedback_replay_diff.py`, `feedback_candidate_generation`)
- **결정 요약 표** 추가 (결정 → 동기 → 변경 → 근거 모듈)

### 부수 변경 (README)
- coverage baseline 문구를 대상별 기준(전체 라인 70% / 도메인 로직 90% / 새 코드 80%)으로 명확화 — 기존 서술이 baseline 90%와 목표 70%를 혼동하게 읽히던 문제 해소
- Repository 구조 트리에 `.agent/specs`·`.agent/rules` 추가

## 검증
- 문서 내 모든 코드 근거(stage 모듈·지표·피드백 경로)는 실제 파일 존재 및 사용처를 확인
- README 참조 링크 41개 영향 없음, 신규 문서 링크 ↔ 파일 일치 확인
- 문서 전용 변경 (런타임 코드 무변경)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * Intent discovery 파이프라인의 진화 과정과 설계 원리를 다룬 상세 문서 추가
  * README 업데이트: 파이프라인 확장 근거, human-in-the-loop 피드백 메커니즘, 리포지토리 구조 설명 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->